### PR TITLE
fix examples links

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -2,7 +2,7 @@
 
 How to run the examples:
 
-The [src](./src) directory provides a few examples, each being a directory, such as [recompute](./src/recompute) and [migration](./src/migration).
+The [src](./src) directory provides a few examples, each being a directory, such as [recompute](./src/examples/recompute) and [migration](./src/examples/migration).
 
 Set `EXAMPLE` environment variable to the name of the example you want to run.
 


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic

Fixed broken links in examples/README.md: the recompute and migration examples now point to src/examples/recompute and src/examples/migration, so the docs navigate correctly.

<!-- End of auto-generated description by cubic. -->