### PR TITLE
metaxy metadata copy CLI

### DIFF
--- a/src/metaxy/cli/app.py
+++ b/src/metaxy/cli/app.py
@@ -98,6 +98,7 @@ def launcher(
 app.command("metaxy.cli.migrations:app", name="migrations")
 app.command("metaxy.cli.push:push", name="push")
 app.command("metaxy.cli.list:app", name="list")
+app.command("metaxy.cli.metadata:app", name="metadata")
 
 
 def main():

--- a/src/metaxy/cli/metadata.py
+++ b/src/metaxy/cli/metadata.py
@@ -1,0 +1,142 @@
+"""Metadata management commands for Metaxy CLI."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Annotated
+
+import cyclopts
+from rich.console import Console
+
+from metaxy.models.types import FeatureKey
+
+if TYPE_CHECKING:
+    from metaxy.metadata_store import FilteredFeature
+    from metaxy.models.feature import Feature
+
+# Rich console for formatted output
+console = Console()
+
+# Metadata subcommand app
+app = cyclopts.App(
+    name="metadata",  # pyrefly: ignore[unexpected-keyword]
+    help="Manage Metaxy metadata",  # pyrefly: ignore[unexpected-keyword]
+    console=console,  # pyrefly: ignore[unexpected-keyword]
+)
+
+
+@app.command()
+def copy(
+    from_store: Annotated[
+        str,
+        cyclopts.Parameter(
+            name=["--from", "FROM"],
+            help="Source store name (must be configured in metaxy.toml)",
+        ),
+    ],
+    to_store: Annotated[
+        str,
+        cyclopts.Parameter(
+            name=["--to", "TO"],
+            help="Destination store name (must be configured in metaxy.toml)",
+        ),
+    ],
+    features: Annotated[
+        list[str] | None,
+        cyclopts.Parameter(
+            name=["--feature"],
+            help="Feature key to copy (e.g., 'my_feature' or 'namespace__my_feature'). Can be repeated multiple times. If not specified, uses --all-features.",
+        ),
+    ] = None,
+    all_features: Annotated[
+        bool,
+        cyclopts.Parameter(
+            name=["--all-features"],
+            help="Copy all features from source store",
+        ),
+    ] = False,
+    from_snapshot: Annotated[
+        str | None,
+        cyclopts.Parameter(
+            name=["--snapshot"],
+            help="Snapshot ID to copy (defaults to latest in source store). The snapshot_id is preserved in the destination.",
+        ),
+    ] = None,
+):
+    """Copy metadata between stores.
+
+    Copies metadata for specified features from one store to another,
+    optionally using a historical version. Useful for:
+    - Migrating data between environments
+    - Backfilling metadata
+    - Copying specific feature versions
+
+    Examples:
+        # Copy all features from latest snapshot in dev to staging
+        $ metaxy metadata copy --from dev --to staging --all-features
+
+        # Copy specific features (repeatable flag)
+        $ metaxy metadata copy --from dev --to staging --feature user_features --feature customer_features
+
+        # Copy specific snapshot
+        $ metaxy metadata copy --from prod --to staging --all-features --snapshot abc123
+    """
+    import logging
+
+    from metaxy.cli.context import get_config
+
+    # Enable logging to show progress
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    config = get_config()
+
+    # Validate arguments
+    if not all_features and not features:
+        console.print(
+            "[red]Error:[/red] Must specify either --all-features or --feature"
+        )
+        raise SystemExit(1)
+
+    if all_features and features:
+        console.print(
+            "[red]Error:[/red] Cannot specify both --all-features and --feature"
+        )
+        raise SystemExit(1)
+
+    # Parse feature keys
+    feature_keys: list[FeatureKey | type[Feature] | FilteredFeature] | None = None
+    if features:
+        feature_keys = []
+        for feature_str in features:
+            # Parse feature key (supports both "feature" and "namespace__feature" formats)
+            if "__" in feature_str:
+                namespace_parts = feature_str.split("__")
+                feature_keys.append(FeatureKey(namespace_parts))
+            else:
+                # Single-part key
+                feature_keys.append(FeatureKey([feature_str]))
+
+    # Get stores
+    console.print(f"[cyan]Source store:[/cyan] {from_store}")
+    console.print(f"[cyan]Destination store:[/cyan] {to_store}")
+
+    source_store = config.get_store(from_store)
+    dest_store = config.get_store(to_store)
+
+    # Open both stores and copy
+    with source_store, dest_store:
+        console.print("\n[bold]Starting copy operation...[/bold]\n")
+
+        try:
+            stats = dest_store.copy_metadata(
+                from_store=source_store,
+                features=feature_keys,
+                from_snapshot=from_snapshot,
+            )
+
+            console.print(
+                f"\n[green]✓[/green] Copy complete: {stats['features_copied']} features, {stats['rows_copied']} rows"
+            )
+
+        except Exception as e:
+            console.print(f"\n[red]✗[/red] Copy failed:\n{e}")
+            raise SystemExit(1)

--- a/src/metaxy/metadata_store/__init__.py
+++ b/src/metaxy/metadata_store/__init__.py
@@ -3,6 +3,7 @@
 from metaxy.metadata_store.base import (
     FEATURE_VERSIONS_KEY,
     MIGRATION_HISTORY_KEY,
+    FilteredFeature,
     MetadataStore,
     allow_feature_version_override,
 )
@@ -20,6 +21,7 @@ from metaxy.metadata_store.memory import InMemoryMetadataStore
 __all__ = [
     "MetadataStore",
     "InMemoryMetadataStore",
+    "FilteredFeature",
     "MetadataStoreError",
     "FeatureNotFoundError",
     "FieldNotFoundError",

--- a/tests/metadata_stores/test_copy_metadata.py
+++ b/tests/metadata_stores/test_copy_metadata.py
@@ -1,0 +1,741 @@
+"""Tests for metadata store copy functionality."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import narwhals as nw
+import polars as pl
+import pytest
+
+from metaxy import Feature, FeatureKey, FeatureSpec, FieldKey, FieldSpec
+from metaxy.metadata_store import FilteredFeature, InMemoryMetadataStore
+from metaxy.metadata_store.base import allow_feature_version_override
+from metaxy.models.feature import FeatureGraph
+
+
+@pytest.fixture
+def sample_features() -> Iterator[tuple[type[Feature], type[Feature]]]:
+    """Create sample features for testing."""
+    # Use a dedicated graph for these tests
+    graph = FeatureGraph()
+
+    with graph.use():
+
+        class FeatureA(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["test", "feature_a"]),
+                deps=None,
+                fields=[FieldSpec(key=FieldKey("field_a"), code_version=1)],
+            ),
+        ):
+            """First test feature."""
+
+            pass
+
+        class FeatureB(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["test", "feature_b"]),
+                deps=None,
+                fields=[FieldSpec(key=FieldKey("field_b"), code_version=1)],
+            ),
+        ):
+            """Second test feature."""
+
+            pass
+
+        yield FeatureA, FeatureB
+
+
+def test_copy_metadata_all_features(
+    sample_features: tuple[type[Feature], type[Feature]],
+) -> None:
+    """Test copying all features from one store to another."""
+    FeatureA, FeatureB = sample_features
+
+    # Create source and destination stores
+    source_store = InMemoryMetadataStore()
+    dest_store = InMemoryMetadataStore()
+
+    # Write to source store
+    with source_store:
+        # Write metadata to source store
+        source_data_a = pl.DataFrame(
+            {
+                "sample_id": ["s1", "s2", "s3"],
+                "field_a": [1, 2, 3],
+                "data_version": [
+                    {"field_a": "hash1"},
+                    {"field_a": "hash2"},
+                    {"field_a": "hash3"},
+                ],
+            }
+        )
+        source_store.write_metadata(FeatureA, source_data_a)
+
+        source_data_b = pl.DataFrame(
+            {
+                "sample_id": ["s1", "s2"],
+                "field_b": [10, 20],
+                "data_version": [{"field_b": "hash10"}, {"field_b": "hash20"}],
+            }
+        )
+        source_store.write_metadata(FeatureB, source_data_b)
+
+        # Get the snapshot_id that was written
+        written_data = (
+            source_store.read_metadata(FeatureA, current_only=False)
+            .collect()
+            .to_polars()
+        )
+        snapshot_id = written_data["snapshot_id"][0]
+
+    # Copy with destination store (source will be opened automatically)
+    with dest_store:
+        stats = dest_store.copy_metadata(
+            from_store=source_store,
+            features=None,  # Copy all
+            from_snapshot=snapshot_id,
+        )
+
+        # Verify stats
+        assert stats["features_copied"] == 2
+        assert stats["rows_copied"] == 5  # 3 + 2
+
+        # Verify data in destination has same snapshot_id
+        dest_data_a = (
+            dest_store.read_metadata(FeatureA, current_only=False).collect().to_polars()
+        )
+        assert dest_data_a.height == 3
+        assert dest_data_a["sample_id"].to_list() == ["s1", "s2", "s3"]
+        assert all(sid == snapshot_id for sid in dest_data_a["snapshot_id"])
+
+        dest_data_b = (
+            dest_store.read_metadata(FeatureB, current_only=False).collect().to_polars()
+        )
+        assert dest_data_b.height == 2
+        assert dest_data_b["sample_id"].to_list() == ["s1", "s2"]
+        assert all(sid == snapshot_id for sid in dest_data_b["snapshot_id"])
+
+
+def test_copy_metadata_specific_features(
+    sample_features: tuple[type[Feature], type[Feature]],
+) -> None:
+    """Test copying specific features."""
+    FeatureA, FeatureB = sample_features
+
+    source_store = InMemoryMetadataStore()
+    dest_store = InMemoryMetadataStore()
+
+    # Write to source
+    with source_store:
+        source_data_a = pl.DataFrame(
+            {
+                "sample_id": ["s1"],
+                "field_a": [1],
+                "data_version": [{"field_a": "hash1"}],
+            }
+        )
+        source_store.write_metadata(FeatureA, source_data_a)
+
+        source_data_b = pl.DataFrame(
+            {
+                "sample_id": ["s1"],
+                "field_b": [10],
+                "data_version": [{"field_b": "hash10"}],
+            }
+        )
+        source_store.write_metadata(FeatureB, source_data_b)
+
+        # Get the snapshot_id that was written
+        written_data = (
+            source_store.read_metadata(FeatureA, current_only=False)
+            .collect()
+            .to_polars()
+        )
+        snapshot_id = written_data["snapshot_id"][0]
+
+    # Copy only FeatureA
+    with dest_store:
+        stats = dest_store.copy_metadata(
+            from_store=source_store,
+            features=[FeatureA.spec.key],
+            from_snapshot=snapshot_id,
+        )
+
+        # Verify stats
+        assert stats["features_copied"] == 1
+        assert stats["rows_copied"] == 1
+
+        # Verify FeatureA exists in destination
+        dest_data_a = (
+            dest_store.read_metadata(FeatureA, current_only=False).collect().to_polars()
+        )
+        assert dest_data_a.height == 1
+
+        # Verify FeatureB does not exist in destination
+        assert not dest_store.has_feature(FeatureB)
+
+
+def test_copy_metadata_with_snapshot_filter(
+    sample_features: tuple[type[Feature], type[Feature]],
+) -> None:
+    """Test copying metadata filtered by snapshot ID."""
+    FeatureA, FeatureB = sample_features
+
+    source_store = InMemoryMetadataStore()
+    dest_store = InMemoryMetadataStore()
+
+    # Write data with different snapshot IDs to source
+    with source_store:
+        snapshot_1 = "snapshot_123"
+        snapshot_2 = "snapshot_456"
+
+        # Write metadata with different snapshot IDs
+        with allow_feature_version_override():
+            # Data with snapshot 1
+            data_snapshot_1 = pl.DataFrame(
+                {
+                    "sample_id": ["s1", "s2"],
+                    "field_a": [1, 2],
+                    "data_version": [{"field_a": "hash1"}, {"field_a": "hash2"}],
+                    "feature_version": [FeatureA.feature_version()] * 2,
+                    "snapshot_id": [snapshot_1] * 2,
+                }
+            )
+            source_store.write_metadata(FeatureA, data_snapshot_1)
+
+            # Data with snapshot 2
+            data_snapshot_2 = pl.DataFrame(
+                {
+                    "sample_id": ["s3", "s4", "s5"],
+                    "field_a": [3, 4, 5],
+                    "data_version": [
+                        {"field_a": "hash3"},
+                        {"field_a": "hash4"},
+                        {"field_a": "hash5"},
+                    ],
+                    "feature_version": [FeatureA.feature_version()] * 3,
+                    "snapshot_id": [snapshot_2] * 3,
+                }
+            )
+            source_store.write_metadata(FeatureA, data_snapshot_2)
+
+        # Verify source has both snapshots
+        all_source_data = (
+            source_store.read_metadata(FeatureA, current_only=False)
+            .collect()
+            .to_polars()
+        )
+        assert all_source_data.height == 5
+
+    # Copy only snapshot 2
+    with dest_store:
+        stats = dest_store.copy_metadata(
+            from_store=source_store,
+            features=[FeatureA.spec.key],
+            from_snapshot=snapshot_2,
+        )
+
+        # Verify only snapshot 2 data was copied with same snapshot_id
+        assert stats["features_copied"] == 1
+        assert stats["rows_copied"] == 3
+
+        # Verify destination has only the copied data with preserved snapshot_id
+        dest_data = (
+            dest_store.read_metadata(FeatureA, current_only=False).collect().to_polars()
+        )
+        assert dest_data.height == 3
+        assert dest_data["sample_id"].to_list() == ["s3", "s4", "s5"]
+        assert all(sid == snapshot_2 for sid in dest_data["snapshot_id"])
+
+
+def test_copy_metadata_empty_source() -> None:
+    """Test copying from store with no features."""
+    source_store = InMemoryMetadataStore()
+    dest_store = InMemoryMetadataStore()
+
+    with dest_store:
+        stats = dest_store.copy_metadata(
+            from_store=source_store,
+            features=None,
+        )
+
+        assert stats["features_copied"] == 0
+        assert stats["rows_copied"] == 0
+
+
+def test_copy_metadata_missing_feature(
+    sample_features: tuple[type[Feature], type[Feature]],
+) -> None:
+    """Test copying a feature that doesn't exist in source."""
+    FeatureA, FeatureB = sample_features
+
+    source_store = InMemoryMetadataStore()
+    dest_store = InMemoryMetadataStore()
+
+    # Write only FeatureA to source
+    with source_store:
+        source_data_a = pl.DataFrame(
+            {
+                "sample_id": ["s1"],
+                "field_a": [1],
+                "data_version": [{"field_a": "hash1"}],
+            }
+        )
+        source_store.write_metadata(FeatureA, source_data_a)
+
+        # Get the snapshot_id that was written
+        written_data = (
+            source_store.read_metadata(FeatureA, current_only=False)
+            .collect()
+            .to_polars()
+        )
+        snapshot_id = written_data["snapshot_id"][0]
+
+    # Try to copy both features (FeatureB doesn't exist)
+    with dest_store:
+        stats = dest_store.copy_metadata(
+            from_store=source_store,
+            features=[FeatureA.spec.key, FeatureB.spec.key],
+            from_snapshot=snapshot_id,
+        )
+
+        # Should copy only FeatureA and skip FeatureB with warning
+        assert stats["features_copied"] == 1
+        assert stats["rows_copied"] == 1
+
+
+def test_copy_metadata_preserves_feature_version(
+    sample_features: tuple[type[Feature], type[Feature]],
+) -> None:
+    """Test that feature_version is preserved during copy."""
+    FeatureA, _ = sample_features
+
+    source_store = InMemoryMetadataStore()
+    dest_store = InMemoryMetadataStore()
+
+    # Write data to source
+    with source_store:
+        original_version = FeatureA.feature_version()
+        source_data = pl.DataFrame(
+            {
+                "sample_id": ["s1"],
+                "field_a": [1],
+                "data_version": [{"field_a": "hash1"}],
+            }
+        )
+        source_store.write_metadata(FeatureA, source_data)
+
+        # Get the snapshot_id that was written
+        written_data = (
+            source_store.read_metadata(FeatureA, current_only=False)
+            .collect()
+            .to_polars()
+        )
+        snapshot_id = written_data["snapshot_id"][0]
+
+    # Copy to destination
+    with dest_store:
+        dest_store.copy_metadata(
+            from_store=source_store,
+            features=[FeatureA.spec.key],
+            from_snapshot=snapshot_id,
+        )
+
+        # Verify feature_version is preserved
+        dest_data = (
+            dest_store.read_metadata(FeatureA, current_only=False).collect().to_polars()
+        )
+        assert dest_data["feature_version"][0] == original_version
+
+
+def test_copy_metadata_store_not_open() -> None:
+    """Test that copy fails if stores are not opened."""
+    source_store = InMemoryMetadataStore()
+    dest_store = InMemoryMetadataStore()
+
+    # Don't use context managers - stores not opened
+    with pytest.raises(ValueError, match="must be opened"):
+        dest_store.copy_metadata(from_store=source_store)
+
+
+def test_copy_metadata_preserves_snapshot_id(
+    sample_features: tuple[type[Feature], type[Feature]],
+) -> None:
+    """Test that snapshot_id is preserved during copy."""
+    FeatureA, _ = sample_features
+
+    source_store = InMemoryMetadataStore()
+    dest_store = InMemoryMetadataStore()
+
+    # Write data to source
+    with source_store:
+        source_data = pl.DataFrame(
+            {
+                "sample_id": ["s1"],
+                "field_a": [1],
+                "data_version": [{"field_a": "hash1"}],
+            }
+        )
+        source_store.write_metadata(FeatureA, source_data)
+
+        # Get the snapshot_id that was written
+        written_data = (
+            source_store.read_metadata(FeatureA, current_only=False)
+            .collect()
+            .to_polars()
+        )
+        original_snapshot = written_data["snapshot_id"][0]
+
+    # Copy - snapshot_id should be preserved
+    with dest_store:
+        dest_store.copy_metadata(
+            from_store=source_store,
+            features=[FeatureA.spec.key],
+            from_snapshot=original_snapshot,
+        )
+
+        # Verify snapshot_id was preserved
+        dest_data = (
+            dest_store.read_metadata(FeatureA, current_only=False).collect().to_polars()
+        )
+        assert dest_data["snapshot_id"][0] == original_snapshot
+
+
+def test_copy_metadata_no_rows_for_snapshot(
+    sample_features: tuple[type[Feature], type[Feature]],
+) -> None:
+    """Test copying when no rows match the specified snapshot."""
+    FeatureA, _ = sample_features
+
+    source_store = InMemoryMetadataStore()
+    dest_store = InMemoryMetadataStore()
+
+    # Write data to source
+    with source_store:
+        source_data = pl.DataFrame(
+            {
+                "sample_id": ["s1"],
+                "field_a": [1],
+                "data_version": [{"field_a": "hash1"}],
+            }
+        )
+        source_store.write_metadata(FeatureA, source_data)
+
+    # Try to copy with non-existent snapshot
+    with dest_store:
+        stats = dest_store.copy_metadata(
+            from_store=source_store,
+            features=[FeatureA.spec.key],
+            from_snapshot="nonexistent_snapshot",
+        )
+
+        # Should skip feature with warning
+        assert stats["features_copied"] == 0
+        assert stats["rows_copied"] == 0
+
+
+def test_copy_metadata_with_global_filters(
+    sample_features: tuple[type[Feature], type[Feature]],
+) -> None:
+    """Test copying with global filters applied to all features."""
+    FeatureA, FeatureB = sample_features
+
+    source_store = InMemoryMetadataStore()
+    dest_store = InMemoryMetadataStore()
+
+    # Write metadata with different sample_ids
+    with source_store:
+        source_data_a = pl.DataFrame(
+            {
+                "sample_id": ["s1", "s2", "s3"],
+                "field_a": [1, 2, 3],
+                "data_version": [
+                    {"field_a": "hash1"},
+                    {"field_a": "hash2"},
+                    {"field_a": "hash3"},
+                ],
+            }
+        )
+        source_store.write_metadata(FeatureA, source_data_a)
+
+        source_data_b = pl.DataFrame(
+            {
+                "sample_id": ["s1", "s2", "s3", "s4"],
+                "field_b": [10, 20, 30, 40],
+                "data_version": [
+                    {"field_b": "hash10"},
+                    {"field_b": "hash20"},
+                    {"field_b": "hash30"},
+                    {"field_b": "hash40"},
+                ],
+            }
+        )
+        source_store.write_metadata(FeatureB, source_data_b)
+
+        # Get snapshot
+        written_data = (
+            source_store.read_metadata(FeatureA, current_only=False)
+            .collect()
+            .to_polars()
+        )
+        snapshot_id = written_data["snapshot_id"][0]
+
+    # Copy with global filter - only s1 and s2
+    with dest_store:
+        stats = dest_store.copy_metadata(
+            from_store=source_store,
+            features=None,  # All features
+            from_snapshot=snapshot_id,
+            filters=[nw.col("sample_id").is_in(["s1", "s2"])],
+        )
+
+        # Verify both features were copied but filtered
+        assert stats["features_copied"] == 2
+        assert stats["rows_copied"] == 4  # 2 rows from A, 2 from B
+
+        # Verify FeatureA has only s1, s2
+        dest_data_a = (
+            dest_store.read_metadata(FeatureA, current_only=False).collect().to_polars()
+        )
+        assert set(dest_data_a["sample_id"]) == {"s1", "s2"}
+
+        # Verify FeatureB has only s1, s2
+        dest_data_b = (
+            dest_store.read_metadata(FeatureB, current_only=False).collect().to_polars()
+        )
+        assert set(dest_data_b["sample_id"]) == {"s1", "s2"}
+
+
+def test_copy_metadata_with_per_feature_filters(
+    sample_features: tuple[type[Feature], type[Feature]],
+) -> None:
+    """Test copying with per-feature filters using FilteredFeature."""
+    FeatureA, FeatureB = sample_features
+
+    source_store = InMemoryMetadataStore()
+    dest_store = InMemoryMetadataStore()
+
+    # Write metadata
+    with source_store:
+        source_data_a = pl.DataFrame(
+            {
+                "sample_id": ["s1", "s2", "s3"],
+                "field_a": [1, 2, 3],
+                "data_version": [
+                    {"field_a": "hash1"},
+                    {"field_a": "hash2"},
+                    {"field_a": "hash3"},
+                ],
+            }
+        )
+        source_store.write_metadata(FeatureA, source_data_a)
+
+        source_data_b = pl.DataFrame(
+            {
+                "sample_id": ["s1", "s2", "s3"],
+                "field_b": [10, 20, 30],
+                "data_version": [
+                    {"field_b": "hash10"},
+                    {"field_b": "hash20"},
+                    {"field_b": "hash30"},
+                ],
+            }
+        )
+        source_store.write_metadata(FeatureB, source_data_b)
+
+        # Get snapshot
+        written_data = (
+            source_store.read_metadata(FeatureA, current_only=False)
+            .collect()
+            .to_polars()
+        )
+        snapshot_id = written_data["snapshot_id"][0]
+
+    # Copy with per-feature filters
+    with dest_store:
+        stats = dest_store.copy_metadata(
+            from_store=source_store,
+            features=[
+                FilteredFeature(
+                    feature=FeatureA.spec.key,
+                    filters=[nw.col("field_a") > 1],  # Only rows where field_a > 1
+                ),
+                FilteredFeature(
+                    feature=FeatureB.spec.key,
+                    filters=[nw.col("field_b") < 30],  # Only rows where field_b < 30
+                ),
+            ],
+            from_snapshot=snapshot_id,
+        )
+
+        # Verify both features copied with their specific filters
+        assert stats["features_copied"] == 2
+        assert stats["rows_copied"] == 4  # 2 from A (s2, s3), 2 from B (s1, s2)
+
+        # Verify FeatureA has only s2, s3 (field_a > 1)
+        dest_data_a = (
+            dest_store.read_metadata(FeatureA, current_only=False).collect().to_polars()
+        )
+        assert set(dest_data_a["sample_id"]) == {"s2", "s3"}
+        assert all(dest_data_a["field_a"] > 1)
+
+        # Verify FeatureB has only s1, s2 (field_b < 30)
+        dest_data_b = (
+            dest_store.read_metadata(FeatureB, current_only=False).collect().to_polars()
+        )
+        assert set(dest_data_b["sample_id"]) == {"s1", "s2"}
+        assert all(dest_data_b["field_b"] < 30)
+
+
+def test_copy_metadata_with_mixed_filters(
+    sample_features: tuple[type[Feature], type[Feature]],
+) -> None:
+    """Test copying with both global and per-feature filters combined."""
+    FeatureA, FeatureB = sample_features
+
+    source_store = InMemoryMetadataStore()
+    dest_store = InMemoryMetadataStore()
+
+    # Write metadata
+    with source_store:
+        source_data_a = pl.DataFrame(
+            {
+                "sample_id": ["s1", "s2", "s3", "s4"],
+                "field_a": [1, 2, 3, 4],
+                "data_version": [
+                    {"field_a": "hash1"},
+                    {"field_a": "hash2"},
+                    {"field_a": "hash3"},
+                    {"field_a": "hash4"},
+                ],
+            }
+        )
+        source_store.write_metadata(FeatureA, source_data_a)
+
+        source_data_b = pl.DataFrame(
+            {
+                "sample_id": ["s1", "s2", "s3", "s4"],
+                "field_b": [10, 20, 30, 40],
+                "data_version": [
+                    {"field_b": "hash10"},
+                    {"field_b": "hash20"},
+                    {"field_b": "hash30"},
+                    {"field_b": "hash40"},
+                ],
+            }
+        )
+        source_store.write_metadata(FeatureB, source_data_b)
+
+        # Get snapshot
+        written_data = (
+            source_store.read_metadata(FeatureA, current_only=False)
+            .collect()
+            .to_polars()
+        )
+        snapshot_id = written_data["snapshot_id"][0]
+
+    # Copy with both global and per-feature filters
+    with dest_store:
+        stats = dest_store.copy_metadata(
+            from_store=source_store,
+            features=[
+                FilteredFeature(
+                    feature=FeatureA.spec.key,
+                    filters=[nw.col("field_a") <= 3],  # Only field_a <= 3
+                ),
+                FeatureB.spec.key,  # No per-feature filter, only global applies
+            ],
+            from_snapshot=snapshot_id,
+            filters=[nw.col("sample_id").is_in(["s1", "s2", "s3"])],  # Global filter
+        )
+
+        # Verify results
+        assert stats["features_copied"] == 2
+
+        # FeatureA: global filter (s1,s2,s3) AND per-feature filter (field_a <= 3)
+        # Result: s1, s2, s3
+        dest_data_a = (
+            dest_store.read_metadata(FeatureA, current_only=False).collect().to_polars()
+        )
+        assert set(dest_data_a["sample_id"]) == {"s1", "s2", "s3"}
+        assert all(dest_data_a["field_a"] <= 3)
+
+        # FeatureB: only global filter (s1,s2,s3)
+        # Result: s1, s2, s3
+        dest_data_b = (
+            dest_store.read_metadata(FeatureB, current_only=False).collect().to_polars()
+        )
+        assert set(dest_data_b["sample_id"]) == {"s1", "s2", "s3"}
+
+
+def test_copy_metadata_with_mixed_feature_types(
+    sample_features: tuple[type[Feature], type[Feature]],
+) -> None:
+    """Test that we can mix FeatureKey and FilteredFeature in the features list."""
+    FeatureA, FeatureB = sample_features
+
+    source_store = InMemoryMetadataStore()
+    dest_store = InMemoryMetadataStore()
+
+    # Write metadata
+    with source_store:
+        source_data_a = pl.DataFrame(
+            {
+                "sample_id": ["s1", "s2"],
+                "field_a": [1, 2],
+                "data_version": [{"field_a": "hash1"}, {"field_a": "hash2"}],
+            }
+        )
+        source_store.write_metadata(FeatureA, source_data_a)
+
+        source_data_b = pl.DataFrame(
+            {
+                "sample_id": ["s1", "s2"],
+                "field_b": [10, 20],
+                "data_version": [{"field_b": "hash10"}, {"field_b": "hash20"}],
+            }
+        )
+        source_store.write_metadata(FeatureB, source_data_b)
+
+        # Get snapshot
+        written_data = (
+            source_store.read_metadata(FeatureA, current_only=False)
+            .collect()
+            .to_polars()
+        )
+        snapshot_id = written_data["snapshot_id"][0]
+
+    # Mix FeatureKey and FilteredFeature
+    with dest_store:
+        stats = dest_store.copy_metadata(
+            from_store=source_store,
+            features=[
+                FilteredFeature(
+                    feature=FeatureA.spec.key,
+                    filters=[nw.col("field_a") > 1],
+                ),
+                FeatureB.spec.key,  # Plain FeatureKey
+            ],
+            from_snapshot=snapshot_id,
+        )
+
+        # Verify results
+        assert stats["features_copied"] == 2
+        assert stats["rows_copied"] == 3  # 1 from A, 2 from B
+
+        # FeatureA filtered
+        dest_data_a = (
+            dest_store.read_metadata(FeatureA, current_only=False).collect().to_polars()
+        )
+        assert dest_data_a.height == 1
+        assert dest_data_a["sample_id"][0] == "s2"
+
+        # FeatureB not filtered
+        dest_data_b = (
+            dest_store.read_metadata(FeatureB, current_only=False).collect().to_polars()
+        )
+        assert dest_data_b.height == 2


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a metadata copy CLI and backend API to copy feature metadata between stores with snapshot-aware filtering. Preserves snapshot_id and feature_version, and supports fine-grained filters.

- **New Features**
  - New CLI: metaxy metadata copy with --from, --to, --feature (repeatable), --all-features, and --snapshot flags.
  - MetadataStore.copy_metadata: copies all or selected features; uses latest or explicit snapshot; supports global and per-feature filters via FilteredFeature; auto-opens the source store; returns copy stats.
  - Helper APIs: read_graph_snapshots and read_features for querying snapshots and feature versions; FilteredFeature exported from metaxy.metadata_store.
  - Tests: comprehensive coverage for snapshots, filters, mixed feature inputs, and edge cases.

<!-- End of auto-generated description by cubic. -->

