### PR TITLE
autouse graph fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,12 +28,12 @@ def pytest_runtest_setup(item):
         del sys.modules[name]
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def graph():
     """Create a clean FeatureGraph for testing.
 
     This will set up a fresh FeatureGraph for each test.
-    Features defined in such tests will be bound to the graph.
+    Features defined in tests will be bound to this graph unless they specify their own graph.
     """
     with FeatureGraph().use() as graph:
         yield graph


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make the tests use a clean FeatureGraph automatically by setting the graph fixture to autouse. This removes boilerplate in tests and ensures each test runs with its own isolated graph.

<!-- End of auto-generated description by cubic. -->

