### PR TITLE
metaxy graph CLI

### DIFF
--- a/src/metaxy/cli/app.py
+++ b/src/metaxy/cli/app.py
@@ -23,41 +23,6 @@ app = cyclopts.App(
 )
 
 
-def push():
-    """Record all feature versions (push graph snapshot).
-
-    This should be called during CD (Continuous Deployment) to record what
-    feature versions are being deployed. Call this before the deployment goes live.
-
-    Records a snapshot of the entire feature graph state based on code definitions.
-    """
-    from metaxy.cli.context import get_store
-    from metaxy.models.feature import FeatureGraph
-
-    # Get store from context
-    metadata_store = get_store()
-
-    with metadata_store:
-        # Get the active graph
-        graph = FeatureGraph.get_active()
-
-        # Record all feature versions
-        snapshot_id, was_already_recorded = (
-            metadata_store.record_feature_graph_snapshot()
-        )
-        feature_count = len(graph.features_by_key)
-
-        if was_already_recorded:
-            app.console.print(
-                f"[blue]ℹ[/blue] Snapshot already recorded (skipped): [bold]{snapshot_id}[/bold]"
-            )
-        else:
-            app.console.print(
-                f"[green]✓[/green] Recorded graph snapshot: [bold]{snapshot_id}[/bold]"
-            )
-        app.console.print(f"  {feature_count} features")
-
-
 @app.command
 def shell():
     """Start interactive shell."""
@@ -96,7 +61,7 @@ def launcher(
 
 # Register subcommands (lazy loading via import strings)
 app.command("metaxy.cli.migrations:app", name="migrations")
-app.command("metaxy.cli.push:push", name="push")
+app.command("metaxy.cli.graph:app", name="graph")
 app.command("metaxy.cli.list:app", name="list")
 app.command("metaxy.cli.metadata:app", name="metadata")
 

--- a/src/metaxy/cli/graph.py
+++ b/src/metaxy/cli/graph.py
@@ -1,0 +1,273 @@
+"""Graph management commands for Metaxy CLI."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+import cyclopts
+from rich.console import Console
+from rich.table import Table
+
+# Rich console for formatted output
+console = Console()
+
+# Graph subcommand app
+app = cyclopts.App(
+    name="graph",  # pyrefly: ignore[unexpected-keyword]
+    help="Manage feature graphs",  # pyrefly: ignore[unexpected-keyword]
+    console=console,  # pyrefly: ignore[unexpected-keyword]
+)
+
+
+@app.command()
+def push(
+    store: Annotated[
+        str | None,
+        cyclopts.Parameter(
+            name=["--store"],
+            help="Metadata store to use (defaults to configured default store)",
+        ),
+    ] = None,
+):
+    """Record all feature versions (push graph snapshot).
+
+    Records all features in the active graph to the metadata store
+    with a deterministic snapshot ID. This should be run after deploying
+    new feature definitions.
+
+    Example:
+        $ metaxy graph push
+
+        ✓ Recorded feature graph
+          Snapshot ID: abc123def456...
+
+        # Or if already recorded:
+        ℹ Snapshot already recorded (skipped)
+          Snapshot ID: abc123def456...
+    """
+    from metaxy.cli.context import get_store
+    from metaxy.entrypoints import load_features
+
+    # Load features from entrypoints
+    load_features()
+
+    metadata_store = get_store(store)
+
+    with metadata_store:
+        snapshot_id, was_already_recorded = (
+            metadata_store.record_feature_graph_snapshot()
+        )
+
+        if was_already_recorded:
+            console.print("[blue]ℹ[/blue] Snapshot already recorded (skipped)")
+            console.print(f"  Snapshot ID: {snapshot_id}")
+        else:
+            console.print("[green]✓[/green] Recorded feature graph")
+            console.print(f"  Snapshot ID: {snapshot_id}")
+
+
+@app.command()
+def history(
+    store: Annotated[
+        str | None,
+        cyclopts.Parameter(
+            name=["--store"],
+            help="Metadata store to use (defaults to configured default store)",
+        ),
+    ] = None,
+    limit: Annotated[
+        int | None,
+        cyclopts.Parameter(
+            name=["--limit"],
+            help="Limit number of snapshots to show (defaults to all)",
+        ),
+    ] = None,
+):
+    """Show history of recorded graph snapshots.
+
+    Displays all recorded graph snapshots from the metadata store,
+    showing snapshot IDs, when they were recorded, and feature counts.
+
+    Example:
+        $ metaxy graph history
+
+        Graph Snapshot History
+        ┌──────────────┬─────────────────────┬───────────────┐
+        │ Snapshot ID  │ Recorded At         │ Feature Count │
+        ├──────────────┼─────────────────────┼───────────────┤
+        │ abc123...    │ 2025-01-15 10:30:00 │ 42            │
+        │ def456...    │ 2025-01-14 09:15:00 │ 40            │
+        └──────────────┴─────────────────────┴───────────────┘
+    """
+    from metaxy.cli.context import get_store
+    from metaxy.entrypoints import load_features
+
+    # Load features from entrypoints
+    load_features()
+
+    metadata_store = get_store(store)
+
+    with metadata_store:
+        # Read snapshot history
+        snapshots_df = metadata_store.read_graph_snapshots()
+
+        if snapshots_df.height == 0:
+            console.print("[yellow]No graph snapshots recorded yet[/yellow]")
+            return
+
+        # Limit results if requested
+        if limit is not None:
+            snapshots_df = snapshots_df.head(limit)
+
+        # Create table
+        table = Table(title="Graph Snapshot History")
+        table.add_column("Snapshot ID", style="cyan", no_wrap=False, overflow="fold")
+        table.add_column("Recorded At", style="green", no_wrap=False)
+        table.add_column(
+            "Feature Count", style="yellow", justify="right", no_wrap=False
+        )
+
+        # Add rows
+        for row in snapshots_df.iter_rows(named=True):
+            snapshot_id = row["snapshot_id"]
+            recorded_at = row["recorded_at"].strftime("%Y-%m-%d %H:%M:%S")
+            feature_count = str(row["feature_count"])
+
+            table.add_row(snapshot_id, recorded_at, feature_count)
+
+        console.print(table)
+        console.print(f"\nTotal snapshots: {snapshots_df.height}")
+
+
+@app.command()
+def describe(
+    snapshot: Annotated[
+        str | None,
+        cyclopts.Parameter(
+            name=["--snapshot"],
+            help="Snapshot ID to describe (defaults to current graph from code)",
+        ),
+    ] = None,
+    store: Annotated[
+        str | None,
+        cyclopts.Parameter(
+            name=["--store"],
+            help="Metadata store to use (defaults to configured default store)",
+        ),
+    ] = None,
+):
+    """Describe a graph snapshot.
+
+    Shows detailed information about a graph snapshot including:
+    - Feature count
+    - Graph depth (longest dependency chain)
+    - Root features (features with no dependencies)
+
+    Example:
+        $ metaxy graph describe
+
+        Graph Snapshot: abc123def456...
+        ┌─────────────────────┬────────┐
+        │ Metric              │ Value  │
+        ├─────────────────────┼────────┤
+        │ Feature Count       │ 42     │
+        │ Graph Depth         │ 5      │
+        │ Root Features       │ 8      │
+        └─────────────────────┴────────┘
+
+        Root Features:
+        • user__profile
+        • transaction__history
+        ...
+    """
+    from metaxy.cli.context import get_store
+    from metaxy.entrypoints import load_features
+    from metaxy.models.feature import FeatureGraph
+
+    # Load features from entrypoints
+    load_features()
+
+    metadata_store = get_store(store)
+
+    with metadata_store:
+        # Determine which snapshot to describe
+        if snapshot is None:
+            # Use current graph from code
+            graph = FeatureGraph.get_active()
+            snapshot_id = graph.snapshot_id
+            console.print("[cyan]Describing current graph from code[/cyan]")
+        else:
+            # Use specified snapshot
+            snapshot_id = snapshot
+            console.print(f"[cyan]Describing snapshot: {snapshot_id}[/cyan]")
+
+            # Load graph from snapshot
+            features_df = metadata_store.read_features(
+                current=False, snapshot_id=snapshot_id
+            )
+
+            if features_df.height == 0:
+                console.print(
+                    f"[red]✗[/red] No features found for snapshot {snapshot_id}"
+                )
+                return
+
+            # For historical snapshots, we'll use the current graph structure
+            # but report on the features that were in that snapshot
+            graph = FeatureGraph.get_active()
+
+        # Get graph metrics
+        feature_count = len(graph.features_by_key)
+
+        # Calculate graph depth (longest dependency chain)
+        def get_feature_depth(feature_key, visited=None):
+            if visited is None:
+                visited = set()
+
+            if feature_key in visited:
+                return 0  # Avoid cycles
+
+            visited.add(feature_key)
+
+            feature_cls = graph.features_by_key.get(feature_key)
+            if feature_cls is None or not feature_cls.spec.deps:
+                return 1
+
+            max_dep_depth = 0
+            for dep in feature_cls.spec.deps:
+                dep_depth = get_feature_depth(dep.key, visited.copy())
+                max_dep_depth = max(max_dep_depth, dep_depth)
+
+            return max_dep_depth + 1
+
+        max_depth = 0
+        for feature_key in graph.features_by_key:
+            depth = get_feature_depth(feature_key)
+            max_depth = max(max_depth, depth)
+
+        # Find root features (no dependencies)
+        root_features = [
+            feature_key
+            for feature_key, feature_cls in graph.features_by_key.items()
+            if not feature_cls.spec.deps
+        ]
+
+        # Display summary table
+        console.print()
+        summary_table = Table(title=f"Graph Snapshot: {snapshot_id}")
+        summary_table.add_column("Metric", style="cyan", no_wrap=False)
+        summary_table.add_column(
+            "Value", style="yellow", justify="right", no_wrap=False
+        )
+
+        summary_table.add_row("Feature Count", str(feature_count))
+        summary_table.add_row("Graph Depth", str(max_depth))
+        summary_table.add_row("Root Features", str(len(root_features)))
+
+        console.print(summary_table)
+
+        # Display root features
+        if root_features:
+            console.print("\n[bold]Root Features:[/bold]")
+            for feature_key in sorted(root_features, key=lambda k: k.to_string()):
+                console.print(f"  • {feature_key.to_string()}")

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -76,49 +76,6 @@ def test_migrations_generate_help():
     # Should not raise
 
 
-def test_push_command(
-    cli_config_file: Path,
-    cli_graph: FeatureGraph,
-    capsys,
-    snapshot: SnapshotAssertion,
-):
-    """Test push command records feature versions during CD."""
-    from metaxy.cli.app import push
-    from metaxy.config import MetaxyConfig
-
-    # Load config and create store
-    config = MetaxyConfig.load(cli_config_file)
-
-    # Use test graph context
-    with cli_graph.use():
-        store = config.get_store("test")
-
-        # Simulate CD workflow: push records feature versions before deployment
-        with store:
-            set_config(config)
-            push()
-
-            # Later, in application code, users write metadata
-            TestFeature = cli_graph.features_by_key[FeatureKey(["test_cli", "feature"])]
-            data = pl.DataFrame(
-                {
-                    "sample_id": [1, 2],
-                    "data_version": [{"default": "h1"}, {"default": "h2"}],
-                }
-            )
-            store.write_metadata(TestFeature, data)
-
-    # Check output
-    captured = capsys.readouterr()
-    output_lines = [
-        line.strip() for line in captured.out.strip().split("\n") if line.strip()
-    ]
-
-    # Snapshot the output
-    assert len(output_lines) >= 1
-    assert "Recorded" in captured.out or "features" in captured.out
-
-
 def test_migrations_generate_no_changes(
     tmp_path: Path,
     cli_graph: FeatureGraph,
@@ -126,7 +83,6 @@ def test_migrations_generate_no_changes(
     snapshot: SnapshotAssertion,
 ):
     """Test generate command when no changes detected."""
-    pytest.importorskip("duckdb")
 
     from metaxy.cli.migrations import generate
     from metaxy.config import MetaxyConfig
@@ -175,7 +131,6 @@ def test_migrations_apply_dry_run(
     tmp_path: Path, cli_graph: FeatureGraph, capsys, snapshot: SnapshotAssertion
 ):
     """Test apply command in dry-run mode."""
-    pytest.importorskip("duckdb")
 
     from metaxy.cli.migrations import apply
     from metaxy.config import MetaxyConfig

--- a/tests/cli/test_cli_e2e.py
+++ b/tests/cli/test_cli_e2e.py
@@ -91,7 +91,6 @@ def test_cli_e2e_duckdb_workflow(e2e_project: Path, snapshot: SnapshotAssertion)
     6. Apply migration
     7. Verify results
     """
-    pytest.importorskip("duckdb")
 
     # Change to project directory
     import os
@@ -335,7 +334,6 @@ class VideoProcessing(Feature, spec=FeatureSpec(
 
 def test_cli_migration_status_command(e2e_project: Path):
     """Test migrations status command shows correct info."""
-    pytest.importorskip("duckdb")
 
     import os
 

--- a/tests/cli/test_cli_graph.py
+++ b/tests/cli/test_cli_graph.py
@@ -1,0 +1,342 @@
+"""Tests for graph CLI commands."""
+
+import re
+
+
+def test_graph_push_first_time(metaxy_project):
+    """Test graph push records snapshot on first run."""
+
+    def features():
+        from metaxy import Feature, FeatureKey, FeatureSpec, FieldKey, FieldSpec
+
+        class VideoFiles(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["video", "files"]),
+                deps=None,
+                fields=[FieldSpec(key=FieldKey(["default"]), code_version=1)],
+            ),
+        ):
+            pass
+
+    with metaxy_project.with_features(features):
+        result = metaxy_project.run_cli("graph", "push")
+
+        assert result.returncode == 0
+        assert "Recorded feature graph" in result.stdout
+        assert "Snapshot ID:" in result.stdout
+
+
+def test_graph_push_already_recorded(metaxy_project):
+    """Test graph push shows 'already recorded' on second run."""
+
+    def features():
+        from metaxy import Feature, FeatureKey, FeatureSpec, FieldKey, FieldSpec
+
+        class VideoFiles(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["video", "files"]),
+                deps=None,
+                fields=[FieldSpec(key=FieldKey(["default"]), code_version=1)],
+            ),
+        ):
+            pass
+
+    with metaxy_project.with_features(features):
+        # First push
+        result1 = metaxy_project.run_cli("graph", "push")
+        assert "Recorded feature graph" in result1.stdout
+
+        # Second push - should skip
+        result2 = metaxy_project.run_cli("graph", "push")
+        assert "already recorded" in result2.stdout
+        assert "Snapshot ID:" in result2.stdout
+
+
+def test_graph_history_empty(metaxy_project):
+    """Test graph history with no snapshots recorded."""
+
+    def features():
+        from metaxy import Feature, FeatureKey, FeatureSpec, FieldKey, FieldSpec
+
+        class VideoFiles(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["video", "files"]),
+                deps=None,
+                fields=[FieldSpec(key=FieldKey(["default"]), code_version=1)],
+            ),
+        ):
+            pass
+
+    with metaxy_project.with_features(features):
+        result = metaxy_project.run_cli("graph", "history")
+
+        assert result.returncode == 0
+        assert "No graph snapshots recorded yet" in result.stdout
+
+
+def test_graph_history_with_snapshots(metaxy_project):
+    """Test graph history displays recorded snapshots."""
+
+    def features():
+        from metaxy import Feature, FeatureKey, FeatureSpec, FieldKey, FieldSpec
+
+        class VideoFiles(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["video", "files"]),
+                deps=None,
+                fields=[FieldSpec(key=FieldKey(["default"]), code_version=1)],
+            ),
+        ):
+            pass
+
+    with metaxy_project.with_features(features):
+        # Push to create snapshot
+        metaxy_project.run_cli("graph", "push")
+
+        # Check history
+        result = metaxy_project.run_cli("graph", "history")
+
+        assert result.returncode == 0
+        assert "Graph Snapshot History" in result.stdout
+        assert "Snapshot ID" in result.stdout
+        assert "Recorded At" in result.stdout
+        assert "Feature Count" in result.stdout
+        assert "1" in result.stdout  # 1 feature
+
+
+def test_graph_history_with_limit(metaxy_project):
+    """Test graph history with --limit flag."""
+
+    def features():
+        from metaxy import Feature, FeatureKey, FeatureSpec, FieldKey, FieldSpec
+
+        class VideoFiles(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["video", "files"]),
+                deps=None,
+                fields=[FieldSpec(key=FieldKey(["default"]), code_version=1)],
+            ),
+        ):
+            pass
+
+    with metaxy_project.with_features(features):
+        # Push once
+        metaxy_project.run_cli("graph", "push")
+
+        # Check history with limit
+        result = metaxy_project.run_cli("graph", "history", "--limit", "1")
+
+        assert result.returncode == 0
+        assert "Total snapshots: 1" in result.stdout
+
+
+def test_graph_describe_current(metaxy_project):
+    """Test graph describe shows current graph metrics."""
+
+    def features():
+        from metaxy import Feature, FeatureKey, FeatureSpec, FieldKey, FieldSpec
+
+        class VideoFiles(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["video", "files"]),
+                deps=None,
+                fields=[FieldSpec(key=FieldKey(["default"]), code_version=1)],
+            ),
+        ):
+            pass
+
+    with metaxy_project.with_features(features):
+        result = metaxy_project.run_cli("graph", "describe")
+
+        assert result.returncode == 0
+        assert "Describing current graph from code" in result.stdout
+        assert "Graph Snapshot:" in result.stdout
+        assert "Feature Count" in result.stdout
+        assert "Graph Depth" in result.stdout
+        assert "Root Features" in result.stdout
+        assert "1" in result.stdout  # 1 feature
+        assert "video__files" in result.stdout
+
+
+def test_graph_describe_with_dependencies(metaxy_project):
+    """Test graph describe with dependent features shows correct depth."""
+
+    def root_features():
+        from metaxy import Feature, FeatureKey, FeatureSpec, FieldKey, FieldSpec
+
+        class VideoFiles(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["video", "files"]),
+                deps=None,
+                fields=[FieldSpec(key=FieldKey(["default"]), code_version=1)],
+            ),
+        ):
+            pass
+
+    def dependent_features():
+        from metaxy import (
+            Feature,
+            FeatureDep,
+            FeatureKey,
+            FeatureSpec,
+            FieldDep,
+            FieldKey,
+            FieldSpec,
+        )
+
+        class VideoProcessing(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["video", "processing"]),
+                deps=[FeatureDep(key=FeatureKey(["video", "files"]))],
+                fields=[
+                    FieldSpec(
+                        key=FieldKey(["frames"]),
+                        code_version=1,
+                        deps=[
+                            FieldDep(
+                                feature_key=FeatureKey(["video", "files"]),
+                                fields=[FieldKey(["default"])],
+                            )
+                        ],
+                    )
+                ],
+            ),
+        ):
+            pass
+
+    # Load both feature modules
+    with metaxy_project.with_features(root_features):
+        with metaxy_project.with_features(dependent_features):
+            result = metaxy_project.run_cli("graph", "describe")
+
+            assert result.returncode == 0
+            assert "Feature Count" in result.stdout
+            assert "2" in result.stdout  # 2 features
+            assert "Graph Depth" in result.stdout
+            # Depth should be 2 (root -> dependent)
+            assert "Root Features" in result.stdout
+            assert "1" in result.stdout  # 1 root feature
+            assert "video__files" in result.stdout
+
+
+def test_graph_describe_historical_snapshot(metaxy_project):
+    """Test graph describe with specific snapshot ID."""
+
+    def features():
+        from metaxy import Feature, FeatureKey, FeatureSpec, FieldKey, FieldSpec
+
+        class VideoFiles(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["video", "files"]),
+                deps=None,
+                fields=[FieldSpec(key=FieldKey(["default"]), code_version=1)],
+            ),
+        ):
+            pass
+
+    with metaxy_project.with_features(features):
+        # Push to create snapshot
+        push_result = metaxy_project.run_cli("graph", "push")
+
+        # Extract snapshot ID from output
+        match = re.search(r"Snapshot ID: ([a-f0-9]+)", push_result.stdout)
+        assert match, "Could not find snapshot ID in push output"
+        snapshot_id = match.group(1)
+
+        # Describe specific snapshot
+        result = metaxy_project.run_cli("graph", "describe", "--snapshot", snapshot_id)
+
+        assert result.returncode == 0
+        # Check that output contains "Describing snapshot" and the snapshot_id (may have newlines between them)
+        assert "Describing snapshot" in result.stdout
+        assert snapshot_id in result.stdout
+        assert "Graph Snapshot:" in result.stdout
+        assert "Feature Count" in result.stdout
+
+
+def test_graph_commands_with_store_flag(metaxy_project):
+    """Test graph commands work with --store flag."""
+
+    def features():
+        from metaxy import Feature, FeatureKey, FeatureSpec, FieldKey, FieldSpec
+
+        class VideoFiles(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["video", "files"]),
+                deps=None,
+                fields=[FieldSpec(key=FieldKey(["default"]), code_version=1)],
+            ),
+        ):
+            pass
+
+    with metaxy_project.with_features(features):
+        # Push with explicit store (uses default "dev" store)
+        result = metaxy_project.run_cli("graph", "push", "--store", "dev")
+
+        assert result.returncode == 0
+        assert "Snapshot" in result.stdout
+
+
+def test_graph_workflow_integration(metaxy_project):
+    """Test complete workflow: push -> history -> describe."""
+
+    def features():
+        from metaxy import Feature, FeatureKey, FeatureSpec, FieldKey, FieldSpec
+
+        class VideoFiles(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["video", "files"]),
+                deps=None,
+                fields=[FieldSpec(key=FieldKey(["default"]), code_version=1)],
+            ),
+        ):
+            pass
+
+        class AudioFiles(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["audio", "files"]),
+                deps=None,
+                fields=[FieldSpec(key=FieldKey(["default"]), code_version=1)],
+            ),
+        ):
+            pass
+
+    with metaxy_project.with_features(features):
+        # Step 1: Push
+        push_result = metaxy_project.run_cli("graph", "push")
+        assert "Recorded feature graph" in push_result.stdout
+
+        # Extract snapshot ID
+        match = re.search(r"Snapshot ID: ([a-f0-9]+)", push_result.stdout)
+        assert match is not None
+        snapshot_id = match.group(1)
+
+        # Step 2: History should show the snapshot
+        history_result = metaxy_project.run_cli("graph", "history")
+        assert snapshot_id[:13] in history_result.stdout
+        assert "2" in history_result.stdout  # 2 features
+
+        # Step 3: Describe should show current graph
+        describe_result = metaxy_project.run_cli("graph", "describe")
+        assert "Feature Count" in describe_result.stdout
+        assert "2" in describe_result.stdout
+
+        # Step 4: Describe historical snapshot
+        describe_historical = metaxy_project.run_cli(
+            "graph", "describe", "--snapshot", snapshot_id
+        )
+        # Check that output contains "Describing snapshot" and the snapshot_id (may have newlines between them)
+        assert "Describing snapshot" in describe_historical.stdout
+        assert snapshot_id in describe_historical.stdout

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,3 +37,31 @@ def graph():
     """
     with FeatureGraph().use() as graph:
         yield graph
+
+
+@pytest.fixture
+def metaxy_project(tmp_path):
+    """Create a temporary Metaxy project for testing.
+
+    Provides TempMetaxyProject instance with context manager API for
+    dynamically creating feature modules and running CLI commands.
+
+    Example:
+        def test_example(metaxy_project):
+            def features():
+                from metaxy import Feature, FeatureSpec, FeatureKey, FieldSpec, FieldKey
+
+                class MyFeature(Feature, spec=FeatureSpec(
+                    key=FeatureKey(["my_feature"]),
+                    deps=None,
+                    fields=[FieldSpec(key=FieldKey(["default"]), code_version=1)]
+                )):
+                    pass
+
+            with metaxy_project.with_features(features):
+                result = metaxy_project.run_cli("graph", "push")
+                assert result.returncode == 0
+    """
+    from metaxy._testing import TempMetaxyProject
+
+    return TempMetaxyProject(tmp_path)

--- a/tests/metadata_stores/test_duckdb.py
+++ b/tests/metadata_stores/test_duckdb.py
@@ -6,7 +6,7 @@ import polars as pl
 import pytest
 
 # Skip all tests in this module if DuckDB not available
-pytest.importorskip("duckdb")
+
 pytest.importorskip("pyarrow")
 
 from metaxy._utils import collect_to_polars


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a dedicated "graph" CLI to manage feature graphs: push snapshots, view history, and describe graph metrics. Replaces the top-level push command and improves test setup with a temporary project helper.

- **New Features**
  - metaxy graph push: records a deterministic snapshot and skips if already recorded.
  - metaxy graph history: lists snapshots with ID, time, and feature count; supports --limit.
  - metaxy graph describe: shows feature count, depth, and root features; supports --snapshot.
  - All graph commands accept --store to select the metadata store.

- **Migration**
  - Run metaxy graph push instead of metaxy push.

<!-- End of auto-generated description by cubic. -->

