### PR TITLE
metaxy metadata drop CLI

### DIFF
--- a/src/metaxy/cli/graph.py
+++ b/src/metaxy/cli/graph.py
@@ -1,7 +1,5 @@
 """Graph management commands for Metaxy CLI."""
 
-from __future__ import annotations
-
 from typing import Annotated
 
 import cyclopts

--- a/src/metaxy/metadata_store/base.py
+++ b/src/metaxy/metadata_store/base.py
@@ -1,7 +1,5 @@
 """Abstract base class for metadata storage backends."""
 
-from __future__ import annotations
-
 import json
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
@@ -175,7 +173,7 @@ class MetadataStore(ABC):
         *,
         hash_algorithm: HashAlgorithm | None = None,
         prefer_native: bool = True,
-        fallback_stores: list[MetadataStore] | None = None,
+        fallback_stores: list["MetadataStore"] | None = None,
     ):
         """
         Initialize metadata store.
@@ -943,7 +941,7 @@ class MetadataStore(ABC):
 
     def copy_metadata(
         self,
-        from_store: MetadataStore,
+        from_store: "MetadataStore",
         features: list[FeatureKey | type[Feature] | FilteredFeature] | None = None,
         *,
         from_snapshot: str | None = None,
@@ -1031,7 +1029,7 @@ class MetadataStore(ABC):
 
     def _copy_metadata_impl(
         self,
-        from_store: MetadataStore,
+        from_store: "MetadataStore",
         features: list[FeatureKey | type[Feature] | FilteredFeature] | None,
         from_snapshot: str | None,
         filters: list[nw.Expr] | None,

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -33,9 +33,8 @@ def cli_graph():
     )
 
     temp_module.write_features({"TestFeature": test_feature_spec})
-    graph = temp_module.get_graph()
 
-    yield graph
+    yield temp_module.graph
 
     temp_module.cleanup()
 

--- a/tests/cli/test_cli_graph.py
+++ b/tests/cli/test_cli_graph.py
@@ -2,8 +2,10 @@
 
 import re
 
+from metaxy._testing import TempMetaxyProject
 
-def test_graph_push_first_time(metaxy_project):
+
+def test_graph_push_first_time(metaxy_project: TempMetaxyProject):
     """Test graph push records snapshot on first run."""
 
     def features():
@@ -27,7 +29,7 @@ def test_graph_push_first_time(metaxy_project):
         assert "Snapshot ID:" in result.stdout
 
 
-def test_graph_push_already_recorded(metaxy_project):
+def test_graph_push_already_recorded(metaxy_project: TempMetaxyProject):
     """Test graph push shows 'already recorded' on second run."""
 
     def features():
@@ -54,7 +56,7 @@ def test_graph_push_already_recorded(metaxy_project):
         assert "Snapshot ID:" in result2.stdout
 
 
-def test_graph_history_empty(metaxy_project):
+def test_graph_history_empty(metaxy_project: TempMetaxyProject):
     """Test graph history with no snapshots recorded."""
 
     def features():
@@ -77,7 +79,7 @@ def test_graph_history_empty(metaxy_project):
         assert "No graph snapshots recorded yet" in result.stdout
 
 
-def test_graph_history_with_snapshots(metaxy_project):
+def test_graph_history_with_snapshots(metaxy_project: TempMetaxyProject):
     """Test graph history displays recorded snapshots."""
 
     def features():
@@ -108,7 +110,7 @@ def test_graph_history_with_snapshots(metaxy_project):
         assert "1" in result.stdout  # 1 feature
 
 
-def test_graph_history_with_limit(metaxy_project):
+def test_graph_history_with_limit(metaxy_project: TempMetaxyProject):
     """Test graph history with --limit flag."""
 
     def features():
@@ -135,7 +137,7 @@ def test_graph_history_with_limit(metaxy_project):
         assert "Total snapshots: 1" in result.stdout
 
 
-def test_graph_describe_current(metaxy_project):
+def test_graph_describe_current(metaxy_project: TempMetaxyProject):
     """Test graph describe shows current graph metrics."""
 
     def features():
@@ -164,7 +166,7 @@ def test_graph_describe_current(metaxy_project):
         assert "video__files" in result.stdout
 
 
-def test_graph_describe_with_dependencies(metaxy_project):
+def test_graph_describe_with_dependencies(metaxy_project: TempMetaxyProject):
     """Test graph describe with dependent features shows correct depth."""
 
     def root_features():
@@ -227,7 +229,7 @@ def test_graph_describe_with_dependencies(metaxy_project):
             assert "video__files" in result.stdout
 
 
-def test_graph_describe_historical_snapshot(metaxy_project):
+def test_graph_describe_historical_snapshot(metaxy_project: TempMetaxyProject):
     """Test graph describe with specific snapshot ID."""
 
     def features():
@@ -263,7 +265,7 @@ def test_graph_describe_historical_snapshot(metaxy_project):
         assert "Feature Count" in result.stdout
 
 
-def test_graph_commands_with_store_flag(metaxy_project):
+def test_graph_commands_with_store_flag(metaxy_project: TempMetaxyProject):
     """Test graph commands work with --store flag."""
 
     def features():
@@ -287,7 +289,7 @@ def test_graph_commands_with_store_flag(metaxy_project):
         assert "Snapshot" in result.stdout
 
 
-def test_graph_workflow_integration(metaxy_project):
+def test_graph_workflow_integration(metaxy_project: TempMetaxyProject):
     """Test complete workflow: push -> history -> describe."""
 
     def features():

--- a/tests/cli/test_cli_metadata.py
+++ b/tests/cli/test_cli_metadata.py
@@ -1,0 +1,332 @@
+"""Tests for metadata CLI commands."""
+
+import polars as pl
+
+from metaxy._testing import TempMetaxyProject
+
+
+def _write_sample_metadata(metaxy_project: TempMetaxyProject, feature_key_str: str):
+    """Helper to write sample metadata for a feature."""
+    from metaxy.models.types import FeatureKey
+
+    # Parse feature key
+    feature_key = FeatureKey(feature_key_str.split("__"))
+
+    # Get feature class from graph
+    feature_cls = metaxy_project.graph.features_by_key[feature_key]
+
+    # Create sample data with data_version column
+    sample_data = pl.DataFrame(
+        {
+            "id": [1, 2, 3],
+            "value": ["a", "b", "c"],
+            "data_version": [
+                {"default": "hash1"},
+                {"default": "hash2"},
+                {"default": "hash3"},
+            ],
+        }
+    )
+
+    # Write metadata directly to store
+    store = metaxy_project.stores["dev"]
+    with store:
+        store.write_metadata(feature_cls, sample_data)
+
+
+def test_metadata_drop_requires_feature_or_all(metaxy_project: TempMetaxyProject):
+    """Test that drop requires either --feature or --all-features."""
+
+    def features():
+        from metaxy import Feature, FeatureKey, FeatureSpec, FieldKey, FieldSpec
+
+        class VideoFiles(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["video", "files"]),
+                deps=None,
+                fields=[FieldSpec(key=FieldKey(["default"]), code_version=1)],
+            ),
+        ):
+            pass
+
+    with metaxy_project.with_features(features):
+        # Write actual metadata for the feature
+        _write_sample_metadata(metaxy_project, "video__files")
+
+        # Try to drop without specifying features
+        result = metaxy_project.run_cli("metadata", "drop", "--confirm", check=False)
+
+        assert result.returncode == 1
+        assert "Must specify either --all-features or --feature" in result.stdout
+
+
+def test_metadata_drop_requires_confirm(metaxy_project: TempMetaxyProject):
+    """Test that drop requires --confirm flag."""
+
+    def features():
+        from metaxy import Feature, FeatureKey, FeatureSpec, FieldKey, FieldSpec
+
+        class VideoFiles(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["video", "files"]),
+                deps=None,
+                fields=[FieldSpec(key=FieldKey(["default"]), code_version=1)],
+            ),
+        ):
+            pass
+
+    with metaxy_project.with_features(features):
+        # Write actual metadata for the feature
+        _write_sample_metadata(metaxy_project, "video__files")
+
+        # Try to drop without --confirm
+        result = metaxy_project.run_cli(
+            "metadata", "drop", "--feature", "video__files", check=False
+        )
+
+        assert result.returncode == 1
+        assert "Must specify --confirm flag" in result.stdout
+
+
+def test_metadata_drop_single_feature(metaxy_project: TempMetaxyProject):
+    """Test dropping metadata for a single feature."""
+
+    def features():
+        from metaxy import Feature, FeatureKey, FeatureSpec, FieldKey, FieldSpec
+
+        class VideoFiles(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["video", "files"]),
+                deps=None,
+                fields=[FieldSpec(key=FieldKey(["default"]), code_version=1)],
+            ),
+        ):
+            pass
+
+        class AudioFiles(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["audio", "files"]),
+                deps=None,
+                fields=[FieldSpec(key=FieldKey(["default"]), code_version=1)],
+            ),
+        ):
+            pass
+
+    with metaxy_project.with_features(features):
+        # Write actual metadata for both features
+        _write_sample_metadata(metaxy_project, "video__files")
+        _write_sample_metadata(metaxy_project, "audio__files")
+
+        # Drop one feature
+        result = metaxy_project.run_cli(
+            "metadata", "drop", "--feature", "video__files", "--confirm"
+        )
+
+        assert result.returncode == 0
+        assert "Dropped: video__files" in result.stdout
+        assert "Drop complete: 1 feature(s) dropped" in result.stdout
+
+
+def test_metadata_drop_multiple_features(metaxy_project: TempMetaxyProject):
+    """Test dropping metadata for multiple features."""
+
+    def features():
+        from metaxy import Feature, FeatureKey, FeatureSpec, FieldKey, FieldSpec
+
+        class VideoFiles(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["video", "files"]),
+                deps=None,
+                fields=[FieldSpec(key=FieldKey(["default"]), code_version=1)],
+            ),
+        ):
+            pass
+
+        class AudioFiles(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["audio", "files"]),
+                deps=None,
+                fields=[FieldSpec(key=FieldKey(["default"]), code_version=1)],
+            ),
+        ):
+            pass
+
+        class TextFiles(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["text", "files"]),
+                deps=None,
+                fields=[FieldSpec(key=FieldKey(["default"]), code_version=1)],
+            ),
+        ):
+            pass
+
+    with metaxy_project.with_features(features):
+        # Write actual metadata for all features
+        _write_sample_metadata(metaxy_project, "video__files")
+        _write_sample_metadata(metaxy_project, "audio__files")
+        _write_sample_metadata(metaxy_project, "text__files")
+
+        # Drop multiple features
+        result = metaxy_project.run_cli(
+            "metadata",
+            "drop",
+            "--feature",
+            "video__files",
+            "--feature",
+            "audio__files",
+            "--confirm",
+        )
+
+        assert result.returncode == 0
+        assert "Dropped: video__files" in result.stdout
+        assert "Dropped: audio__files" in result.stdout
+        assert "Drop complete: 2 feature(s) dropped" in result.stdout
+
+
+def test_metadata_drop_all_features(metaxy_project: TempMetaxyProject):
+    """Test dropping metadata for all features."""
+
+    def features():
+        from metaxy import Feature, FeatureKey, FeatureSpec, FieldKey, FieldSpec
+
+        class VideoFiles(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["video", "files"]),
+                deps=None,
+                fields=[FieldSpec(key=FieldKey(["default"]), code_version=1)],
+            ),
+        ):
+            pass
+
+        class AudioFiles(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["audio", "files"]),
+                deps=None,
+                fields=[FieldSpec(key=FieldKey(["default"]), code_version=1)],
+            ),
+        ):
+            pass
+
+    with metaxy_project.with_features(features):
+        # Write actual metadata for both features
+        _write_sample_metadata(metaxy_project, "video__files")
+        _write_sample_metadata(metaxy_project, "audio__files")
+
+        # Drop all features
+        result = metaxy_project.run_cli(
+            "metadata", "drop", "--all-features", "--confirm"
+        )
+
+        assert result.returncode == 0
+        assert "Dropping metadata for 2 feature(s)" in result.stdout
+        assert (
+            "Dropped: video__files" in result.stdout
+            or "Dropped: audio__files" in result.stdout
+        )
+        assert "Drop complete: 2 feature(s) dropped" in result.stdout
+
+
+def test_metadata_drop_empty_store(metaxy_project: TempMetaxyProject):
+    """Test dropping from an empty store is a no-op."""
+
+    def features():
+        from metaxy import Feature, FeatureKey, FeatureSpec, FieldKey, FieldSpec
+
+        class VideoFiles(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["video", "files"]),
+                deps=None,
+                fields=[FieldSpec(key=FieldKey(["default"]), code_version=1)],
+            ),
+        ):
+            pass
+
+    with metaxy_project.with_features(features):
+        # Don't write any metadata - store is empty
+
+        # Drop all features from empty store - should be a no-op
+        result = metaxy_project.run_cli(
+            "metadata", "drop", "--all-features", "--confirm"
+        )
+
+        # Should succeed with 0 features dropped
+        assert result.returncode == 0
+        assert "Dropping metadata for 0 feature(s)" in result.stdout
+        assert "Drop complete: 0 feature(s) dropped" in result.stdout
+
+
+def test_metadata_drop_cannot_specify_both_flags(metaxy_project: TempMetaxyProject):
+    """Test that cannot specify both --feature and --all-features."""
+
+    def features():
+        from metaxy import Feature, FeatureKey, FeatureSpec, FieldKey, FieldSpec
+
+        class VideoFiles(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["video", "files"]),
+                deps=None,
+                fields=[FieldSpec(key=FieldKey(["default"]), code_version=1)],
+            ),
+        ):
+            pass
+
+    with metaxy_project.with_features(features):
+        # Try to specify both flags
+        result = metaxy_project.run_cli(
+            "metadata",
+            "drop",
+            "--feature",
+            "video__files",
+            "--all-features",
+            "--confirm",
+            check=False,
+        )
+
+        assert result.returncode == 1
+        assert "Cannot specify both --all-features and --feature" in result.stdout
+
+
+def test_metadata_drop_with_store_flag(metaxy_project: TempMetaxyProject):
+    """Test dropping metadata with explicit --store flag."""
+
+    def features():
+        from metaxy import Feature, FeatureKey, FeatureSpec, FieldKey, FieldSpec
+
+        class VideoFiles(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["video", "files"]),
+                deps=None,
+                fields=[FieldSpec(key=FieldKey(["default"]), code_version=1)],
+            ),
+        ):
+            pass
+
+    with metaxy_project.with_features(features):
+        # Write actual metadata for the feature
+        _write_sample_metadata(metaxy_project, "video__files")
+
+        # Drop with explicit store
+        result = metaxy_project.run_cli(
+            "metadata",
+            "drop",
+            "--store",
+            "dev",
+            "--feature",
+            "video__files",
+            "--confirm",
+        )
+
+        assert result.returncode == 0
+        assert "Dropped: video__files" in result.stdout

--- a/tests/metadata_stores/conftest.py
+++ b/tests/metadata_stores/conftest.py
@@ -258,7 +258,7 @@ def test_graph():
     )
 
     # Get graph from module
-    graph = temp_module.get_graph()
+    graph = temp_module.graph
 
     # Create features dict for easy access
     features = {

--- a/tests/metadata_stores/test_copy_metadata.py
+++ b/tests/metadata_stores/test_copy_metadata.py
@@ -1,7 +1,5 @@
 """Tests for metadata store copy functionality."""
 
-from __future__ import annotations
-
 from collections.abc import Iterator
 
 import narwhals as nw

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -135,9 +135,7 @@ def graph_v1():
     )
 
     # Get graph from module
-    graph = temp_module.get_graph()
-
-    yield graph
+    yield temp_module.graph
 
     # Cleanup after test completes
     temp_module.cleanup()
@@ -183,9 +181,7 @@ def graph_v2():
     )
 
     # Get graph from module
-    graph = temp_module.get_graph()
-
-    yield graph
+    yield temp_module.graph
 
     # Cleanup after test completes
     temp_module.cleanup()
@@ -1492,7 +1488,7 @@ def test_migration_ignores_new_features(
         }
     )
 
-    graph_with_new = temp_module.get_graph()
+    graph_with_new = temp_module.graph
 
     # Create store with only v1 upstream data (no new_feature data)
     store = InMemoryMetadataStore()
@@ -1581,7 +1577,7 @@ def test_migration_with_dependency_change() -> None:
         }
     )
 
-    graph_v1 = temp_v1.get_graph()
+    graph_v1 = temp_v1.graph
 
     # Create v2: Downstream now depends on UpstreamB instead
     temp_v2 = TempFeatureModule("test_dep_change_v2")
@@ -1611,7 +1607,7 @@ def test_migration_with_dependency_change() -> None:
         }
     )
 
-    graph_v2 = temp_v2.get_graph()
+    graph_v2 = temp_v2.graph
 
     # Get feature classes
     down_v1 = graph_v1.features_by_key[FeatureKey(["test", "downstream"])]
@@ -1713,7 +1709,7 @@ def test_migration_with_field_dependency_change() -> None:
         }
     )
 
-    graph_v1 = temp_v1.get_graph()
+    graph_v1 = temp_v1.graph
 
     # Create v2: Downstream now only depends on frames field
     temp_v2 = TempFeatureModule("test_field_dep_v2")
@@ -1742,7 +1738,7 @@ def test_migration_with_field_dependency_change() -> None:
         }
     )
 
-    graph_v2 = temp_v2.get_graph()
+    graph_v2 = temp_v2.graph
 
     # Get feature classes
     down_v1 = graph_v1.features_by_key[FeatureKey(["test", "downstream"])]
@@ -1811,7 +1807,7 @@ def test_sequential_migration_application():
         fields=[FieldSpec(key=FieldKey(["default"]), code_version=1)],
     )
     temp_module.write_features({"TestFeature": spec})
-    graph = temp_module.get_graph()
+    graph = temp_module.graph
 
     # Create store and record snapshot
     store = InMemoryMetadataStore()
@@ -1919,7 +1915,7 @@ def test_multiple_migration_heads_detection():
         fields=[FieldSpec(key=FieldKey(["default"]), code_version=1)],
     )
     temp_module.write_features({"TestFeature": spec})
-    graph = temp_module.get_graph()
+    graph = temp_module.graph
 
     store = InMemoryMetadataStore()
     test_feature = graph.features_by_key[FeatureKey(["test", "feature"])]

--- a/tests/test_snapshot_id_stability.py
+++ b/tests/test_snapshot_id_stability.py
@@ -42,7 +42,7 @@ def test_snapshot_id_stability_with_module():
 
     try:
         # Get the graph with features
-        graph1 = temp_module.get_graph()
+        graph1 = temp_module.graph
 
         # Get original snapshot_id
         original_snapshot_id = graph1.snapshot_id


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a new CLI command to safely drop feature metadata from a store, and streamline test utilities and typing. This helps clean up obsolete data and simplifies test setup.

- **New Features**
  - Add metaxy metadata drop with:
    - --feature <key> (repeatable; supports namespace__feature)
    - --all-features
    - --store <name>
    - --confirm (required to run)
  - Uses store.list_features when --all-features is set and calls drop_feature_metadata per feature.
  - Detailed per-feature results and a final summary.
  - Comprehensive tests covering validation, single/multi-feature, all-features, empty store, and --store usage.

- **Refactors**
  - TempMetaxyProject: replace get_graph() with graph property; add entrypoints, cached config, and stores access. Tests updated to use temp_module.graph.
  - MetadataStore typing: use forward references and remove unnecessary __future__ imports.

<!-- End of auto-generated description by cubic. -->

