### PR TITLE
incremental copy CLI

### DIFF
--- a/src/metaxy/_testing.py
+++ b/src/metaxy/_testing.py
@@ -247,14 +247,21 @@ class TempMetaxyProject:
 
     def _write_config(self):
         """Write basic metaxy.toml with DuckDB store configuration."""
-        db_path = self.project_dir / "metadata.duckdb"
+        dev_db_path = self.project_dir / "metadata.duckdb"
+        staging_db_path = self.project_dir / "metadata_staging.duckdb"
         config_content = f'''store = "dev"
 
 [stores.dev]
 type = "metaxy.metadata_store.duckdb.DuckDBMetadataStore"
 
 [stores.dev.config]
-database = "{db_path}"
+database = "{dev_db_path}"
+
+[stores.staging]
+type = "metaxy.metadata_store.duckdb.DuckDBMetadataStore"
+
+[stores.staging.config]
+database = "{staging_db_path}"
 '''
         (self.project_dir / "metaxy.toml").write_text(config_content)
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added incremental copy to the metadata CLI to skip rows that already exist in the destination for the same snapshot. Enabled by default; use --no-incremental to do a full copy when the destination is empty or dedupes later.

- **New Features**
  - CLI: Added --incremental (default true) to metadata copy; includes usage examples and help text.
  - Store: copy_metadata now supports incremental anti-join on sample_id within snapshot_id, with graceful fallback to full copy if the destination feature is missing or the check fails.
  - Tests: Added a staging store to test config and coverage for incremental skip, non-incremental duplicates, and empty-destination behavior.

<!-- End of auto-generated description by cubic. -->

