### PR TITLE
metaxy graph render CLI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,8 @@ uv run pytest tests/test_migrations.py::test_migration_generation
 uv run pytest tests/metadata_stores/test_duckdb.py
 ```
 
+Always keep tests up-to-date and maintainable. Add or update tests as features are added or modified.
+
 ### Linting and Formatting
 ```bash
 # Run ruff linter

--- a/examples/src/examples/migration/README.md
+++ b/examples/src/examples/migration/README.md
@@ -1,0 +1,13 @@
+# Migration Example
+
+```mermaid
+---
+title: Feature Graph (snapshot: 4bd49031)
+---
+flowchart TB
+        examples_parent["<b>examples/parent</b><br/><small>(v: befcdcdd)</small><br/>---<br/>•
+embeddings <small>(v: eb57f1d2)</small>"]
+        examples_child["<b>examples/child</b><br/><small>(v: 6148c18f)</small><br/>---<br/>•
+predictions <small>(v: bebfc10d)</small>"]
+        examples_parent --> examples_child
+```

--- a/examples/src/examples/recompute/README.md
+++ b/examples/src/examples/recompute/README.md
@@ -1,0 +1,14 @@
+# Recompute Example
+
+
+```mermaid
+---
+title: Feature Graph (snapshot: 4bd49031)
+---
+flowchart TB
+        examples_parent["<b>examples/parent</b><br/><small>(v: befcdcdd)</small><br/>---<br/>•
+embeddings <small>(v: eb57f1d2)</small>"]
+        examples_child["<b>examples/child</b><br/><small>(v: 6148c18f)</small><br/>---<br/>•
+predictions <small>(v: bebfc10d)</small>"]
+        examples_parent --> examples_child
+```

--- a/flake.nix
+++ b/flake.nix
@@ -17,12 +17,14 @@
           pkgs.stdenv.cc.cc.lib
           pkgs.gcc-unwrapped.lib
           pkgs.glibc
+          pkgs.graphviz
         ];
         packages = with pkgs; [
           stdenv.cc
           uv
           python
           clickhouse
+          graphviz
         ];
         LD_LIBRARY_PATH = lib.makeLibraryPath [
           pkgs.stdenv.cc.cc.lib
@@ -31,6 +33,7 @@
           pkgs.glib
           pkgs.python310
           pkgs.clickhouse
+          pkgs.graphviz
         ];
         # UV_PYTHON = "${python}/bin/python";
         shellHook = ''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,13 @@ ibis = [
     "pyarrow>=18.0.0",
     "ibis-framework>=11.0.0",
 ]
+rendering = [
+    "mermaid-py>=0.8.0",
+    "rich>=13.0.0",
+]
+graphviz = [
+    "pygraphviz>=1.14",
+]
 
 [project.scripts]
 metaxy = "metaxy.cli.app:main"

--- a/src/metaxy/cli/graph.py
+++ b/src/metaxy/cli/graph.py
@@ -1,10 +1,12 @@
 """Graph management commands for Metaxy CLI."""
 
-from typing import Annotated
+from typing import Annotated, Literal
 
 import cyclopts
 from rich.console import Console
 from rich.table import Table
+
+from metaxy.graph import RenderConfig
 
 # Rich console for formatted output
 console = Console()
@@ -269,3 +271,304 @@ def describe(
             console.print("\n[bold]Root Features:[/bold]")
             for feature_key in sorted(root_features, key=lambda k: k.to_string()):
                 console.print(f"  • {feature_key.to_string()}")
+
+
+@app.command()
+def render(
+    config: Annotated[
+        RenderConfig | None, cyclopts.Parameter(name="*", help="Render configuration")
+    ] = None,
+    format: Annotated[
+        str,
+        cyclopts.Parameter(
+            name=["--format", "-f"],
+            help="Output format: terminal, mermaid, or graphviz",
+        ),
+    ] = "terminal",
+    type: Annotated[
+        Literal["graph", "cards"],
+        cyclopts.Parameter(
+            name=["--type", "-t"],
+            help="Terminal rendering type: graph or cards (only for --format terminal)",
+        ),
+    ] = "graph",
+    output: Annotated[
+        str | None,
+        cyclopts.Parameter(
+            name=["--output", "-o"],
+            help="Output file path (default: stdout)",
+        ),
+    ] = None,
+    snapshot: Annotated[
+        str | None,
+        cyclopts.Parameter(
+            name=["--snapshot"],
+            help="Snapshot ID to render (default: current graph from code)",
+        ),
+    ] = None,
+    store: Annotated[
+        str | None,
+        cyclopts.Parameter(
+            name=["--store"],
+            help="Metadata store to use (for loading historical snapshots)",
+        ),
+    ] = None,
+    # Preset modes
+    minimal: Annotated[
+        bool,
+        cyclopts.Parameter(
+            name=["--minimal"],
+            help="Minimal output: only feature keys and dependencies",
+        ),
+    ] = False,
+    verbose: Annotated[
+        bool,
+        cyclopts.Parameter(
+            name=["--verbose"],
+            help="Verbose output: show all available information",
+        ),
+    ] = False,
+):
+    """Render feature graph visualization.
+
+    Visualize the feature graph in different formats:
+    - terminal: Terminal rendering with two types:
+      - graph (default): Hierarchical tree view
+      - cards: Panel/card-based view with dependency edges
+    - mermaid: Mermaid flowchart markup
+    - graphviz: Graphviz DOT format
+
+    Examples:
+        # Render to terminal (default graph view)
+        $ metaxy graph render
+
+        # Render as cards with dependency edges
+        $ metaxy graph render --type cards
+
+        # Minimal view
+        $ metaxy graph render --minimal
+
+        # Everything
+        $ metaxy graph render --verbose
+
+        # Save Mermaid diagram to file
+        $ metaxy graph render --format mermaid --output graph.mmd
+
+        # Graphviz DOT format (pipe to dot command)
+        $ metaxy graph render --format graphviz | dot -Tpng -o graph.png
+
+        # Custom: show only structure with short hashes
+        $ metaxy graph render --no-show-fields --hash-length 6
+
+        # Focus on a specific feature and its dependencies
+        $ metaxy graph render --feature video/processing --up 2
+
+        # Show a feature and its downstream dependents
+        $ metaxy graph render --feature video/files --down 1
+
+        # Render historical snapshot
+        $ metaxy graph render --snapshot abc123... --store prod
+    """
+    from metaxy.cli.context import get_store
+    from metaxy.entrypoints import load_features
+    from metaxy.graph import (
+        GraphvizRenderer,
+        MermaidRenderer,
+        TerminalCardsRenderer,
+        TerminalRenderer,
+    )
+    from metaxy.models.feature import FeatureGraph
+
+    # Validate format
+    valid_formats = ["terminal", "mermaid", "graphviz"]
+    if format not in valid_formats:
+        console.print(
+            f"[red]Error:[/red] Invalid format '{format}'. Must be one of: {', '.join(valid_formats)}"
+        )
+        raise SystemExit(1)
+
+    # Validate type (only applies to terminal format)
+    valid_types = ["graph", "cards"]
+    if type not in valid_types:
+        console.print(
+            f"[red]Error:[/red] Invalid type '{type}'. Must be one of: {', '.join(valid_types)}"
+        )
+        raise SystemExit(1)
+
+    # Validate type is only used with terminal format
+    if type != "graph" and format != "terminal":
+        console.print(
+            "[red]Error:[/red] --type can only be used with --format terminal"
+        )
+        raise SystemExit(1)
+
+    # Resolve configuration from presets
+    if minimal and verbose:
+        console.print("[red]Error:[/red] Cannot specify both --minimal and --verbose")
+        raise SystemExit(1)
+
+    # If config is None, create a default instance
+    if config is None:
+        config = RenderConfig()
+
+    # Apply presets if specified (overrides display settings but preserves filtering)
+    if minimal:
+        preset = RenderConfig.minimal()
+        # Preserve filtering parameters from original config
+        preset.feature = config.feature
+        preset.up = config.up
+        preset.down = config.down
+        config = preset
+    elif verbose:
+        preset = RenderConfig.verbose()
+        # Preserve filtering parameters from original config
+        preset.feature = config.feature
+        preset.up = config.up
+        preset.down = config.down
+        config = preset
+
+    # Validate direction
+    if config.direction not in ["TB", "LR"]:
+        console.print(
+            f"[red]Error:[/red] Invalid direction '{config.direction}'. Must be TB or LR."
+        )
+        raise SystemExit(1)
+
+    # Validate filtering options
+    if (config.up is not None or config.down is not None) and config.feature is None:
+        console.print(
+            "[red]Error:[/red] --up and --down require --feature to be specified"
+        )
+        raise SystemExit(1)
+
+    # Auto-disable field versions if fields are disabled
+    if not config.show_fields and config.show_field_versions:
+        config.show_field_versions = False
+
+    # Load features from entrypoints
+    load_features()
+
+    # Validate feature exists if specified
+    if config.feature is not None:
+        focus_key = config.get_feature_key()
+        graph = FeatureGraph.get_active()
+        if focus_key not in graph.features_by_key:
+            console.print(
+                f"[red]Error:[/red] Feature '{config.feature}' not found in graph"
+            )
+            console.print("\nAvailable features:")
+            for key in sorted(
+                graph.features_by_key.keys(), key=lambda k: k.to_string()
+            ):
+                console.print(f"  • {'/'.join(key)}")
+            raise SystemExit(1)
+
+    # Determine which graph to render
+    if snapshot is None:
+        # Use current graph from code
+        graph = FeatureGraph.get_active()
+
+        if len(graph.features_by_key) == 0:
+            console.print(
+                "[yellow]Warning:[/yellow] Graph is empty (no features found)"
+            )
+            if output:
+                # Write empty output to file
+                with open(output, "w") as f:
+                    f.write("")
+            return
+    else:
+        # Load historical snapshot from store
+        metadata_store = get_store(store)
+
+        with metadata_store:
+            # Read features for this snapshot
+            features_df = metadata_store.read_features(
+                current=False, snapshot_id=snapshot
+            )
+
+            if features_df.height == 0:
+                console.print(f"[red]✗[/red] No features found for snapshot {snapshot}")
+                raise SystemExit(1)
+
+            # Convert DataFrame to snapshot_data format expected by from_snapshot
+            import json
+
+            snapshot_data = {}
+            for row in features_df.iter_rows(named=True):
+                feature_key_str = row["feature_key"]
+                snapshot_data[feature_key_str] = {
+                    "feature_spec": json.loads(row["feature_spec"]),
+                    "feature_class_path": row["feature_class_path"],
+                    "feature_version": row["feature_version"],
+                }
+
+            # Reconstruct graph from snapshot
+            try:
+                graph = FeatureGraph.from_snapshot(snapshot_data)
+                console.print(
+                    f"[green]✓[/green] Loaded {len(graph.features_by_key)} features from snapshot {snapshot[:8]}..."
+                )
+            except ImportError as e:
+                console.print(f"[red]✗[/red] Failed to load snapshot: {e}")
+                console.print(
+                    "[yellow]Hint:[/yellow] Feature classes may have been moved or deleted."
+                )
+                console.print(
+                    "[yellow]Hint:[/yellow] Use --store to ensure feature code is available at recorded paths."
+                )
+                raise SystemExit(1)
+            except Exception as e:
+                console.print(f"[red]✗[/red] Failed to load snapshot: {e}")
+                raise SystemExit(1)
+
+    # Instantiate renderer based on format and type
+    if format == "terminal":
+        if type == "graph":
+            renderer = TerminalRenderer(graph, config)
+        elif type == "cards":
+            renderer = TerminalCardsRenderer(graph, config)
+        else:
+            # Should not reach here due to validation above
+            console.print(f"[red]Error:[/red] Unknown type: {type}")
+            raise SystemExit(1)
+    elif format == "mermaid":
+        renderer = MermaidRenderer(graph, config)
+    elif format == "graphviz":
+        try:
+            renderer = GraphvizRenderer(graph, config)
+        except ImportError as e:
+            console.print(f"[red]✗[/red] {e}")
+            raise SystemExit(1)
+    else:
+        # Should not reach here due to validation above
+        console.print(f"[red]Error:[/red] Unknown format: {format}")
+        raise SystemExit(1)
+
+    # Render graph
+    try:
+        rendered = renderer.render()
+    except Exception as e:
+        console.print(f"[red]✗[/red] Rendering failed: {e}")
+        import traceback
+
+        traceback.print_exc()
+        raise SystemExit(1)
+
+    # Output to stdout or file
+    if output:
+        try:
+            with open(output, "w") as f:
+                f.write(rendered)
+            console.print(f"[green]✓[/green] Rendered graph saved to: {output}")
+        except Exception as e:
+            console.print(f"[red]✗[/red] Failed to write to file: {e}")
+            raise SystemExit(1)
+    else:
+        # Print to stdout
+        # For terminal/dag formats, the output already contains ANSI codes from Rich
+        # so we print directly to avoid double-escaping
+        if format in ("terminal", "dag"):
+            print(rendered)
+        else:
+            console.print(rendered)

--- a/src/metaxy/graph/__init__.py
+++ b/src/metaxy/graph/__init__.py
@@ -1,0 +1,19 @@
+"""Graph visualization and rendering utilities."""
+
+from metaxy.graph.renderers import (
+    GraphRenderer,
+    GraphvizRenderer,
+    MermaidRenderer,
+    RenderConfig,
+    TerminalCardsRenderer,
+    TerminalRenderer,
+)
+
+__all__ = [
+    "GraphRenderer",
+    "RenderConfig",
+    "TerminalRenderer",
+    "TerminalCardsRenderer",
+    "MermaidRenderer",
+    "GraphvizRenderer",
+]

--- a/src/metaxy/graph/renderers/__init__.py
+++ b/src/metaxy/graph/renderers/__init__.py
@@ -1,0 +1,16 @@
+"""Graph renderers for different output formats."""
+
+from metaxy.graph.renderers.base import GraphRenderer, RenderConfig
+from metaxy.graph.renderers.cards import TerminalCardsRenderer
+from metaxy.graph.renderers.graphviz import GraphvizRenderer
+from metaxy.graph.renderers.mermaid import MermaidRenderer
+from metaxy.graph.renderers.rich import TerminalRenderer
+
+__all__ = [
+    "GraphRenderer",
+    "RenderConfig",
+    "TerminalRenderer",
+    "TerminalCardsRenderer",
+    "MermaidRenderer",
+    "GraphvizRenderer",
+]

--- a/src/metaxy/graph/renderers/base.py
+++ b/src/metaxy/graph/renderers/base.py
@@ -1,0 +1,334 @@
+"""Base classes and configuration for graph rendering."""
+
+from dataclasses import dataclass, field
+
+from metaxy.models.feature import FeatureGraph
+from metaxy.models.types import FeatureKey, FieldKey
+
+
+@dataclass
+class RenderConfig:
+    """Configuration for graph rendering.
+
+    Controls what information is displayed and how it's formatted.
+    """
+
+    # What to show
+    show_fields: bool = field(
+        default=True,
+        metadata={"help": "Show field-level details within features"},
+    )
+
+    show_feature_versions: bool = field(
+        default=True,
+        metadata={"help": "Show feature version hashes"},
+    )
+
+    show_field_versions: bool = field(
+        default=True,
+        metadata={"help": "Show field version hashes (requires --show-fields)"},
+    )
+
+    show_code_versions: bool = field(
+        default=False,
+        metadata={"help": "Show feature and field code versions"},
+    )
+
+    show_snapshot_id: bool = field(
+        default=True,
+        metadata={"help": "Show graph snapshot ID in output"},
+    )
+
+    # Display options
+    hash_length: int = field(
+        default=8,
+        metadata={
+            "help": "Number of characters to show for version hashes (0 for full)"
+        },
+    )
+
+    direction: str = field(
+        default="TB",
+        metadata={"help": "Graph layout direction: TB (top-bottom) or LR (left-right)"},
+    )
+
+    # Filtering options
+    feature: str | None = field(
+        default=None,
+        metadata={
+            "help": "Focus on a specific feature (e.g., 'video/files' or 'video__files')"
+        },
+    )
+
+    up: int | None = field(
+        default=None,
+        metadata={
+            "help": "Number of dependency levels to render upstream (default: all)"
+        },
+    )
+
+    down: int | None = field(
+        default=None,
+        metadata={
+            "help": "Number of dependency levels to render downstream (default: all)"
+        },
+    )
+
+    def get_feature_key(self) -> FeatureKey | None:
+        """Parse feature string into FeatureKey.
+
+        Returns:
+            FeatureKey if feature is set, None otherwise
+        """
+        if self.feature is None:
+            return None
+
+        # Support both formats: "video__files" or "video/files"
+        if "/" in self.feature:
+            return FeatureKey(self.feature.split("/"))
+        else:
+            return FeatureKey(self.feature.split("__"))
+
+    @classmethod
+    def minimal(cls) -> "RenderConfig":
+        """Preset: minimal information (structure only)."""
+        return cls(
+            show_fields=False,
+            show_feature_versions=False,
+            show_field_versions=False,
+            show_code_versions=False,
+            show_snapshot_id=False,
+        )
+
+    @classmethod
+    def default(cls) -> "RenderConfig":
+        """Preset: default information level (balanced)."""
+        return cls(
+            show_fields=True,
+            show_feature_versions=True,
+            show_field_versions=True,
+            show_code_versions=False,
+            show_snapshot_id=True,
+            hash_length=8,
+        )
+
+    @classmethod
+    def verbose(cls) -> "RenderConfig":
+        """Preset: maximum information (everything)."""
+        return cls(
+            show_fields=True,
+            show_feature_versions=True,
+            show_field_versions=True,
+            show_code_versions=True,
+            show_snapshot_id=True,
+            hash_length=0,  # Full hashes
+        )
+
+
+class GraphRenderer:
+    """Base class for graph renderers.
+
+    Provides common utilities for formatting keys and hashes.
+    """
+
+    def __init__(self, graph: FeatureGraph, config: RenderConfig):
+        self.graph = graph
+        self.config = config
+
+    def _format_hash(self, hash_str: str) -> str:
+        """Format hash according to config.
+
+        Args:
+            hash_str: Full hash string
+
+        Returns:
+            Truncated hash if hash_length > 0, otherwise full hash
+        """
+        if self.config.hash_length == 0:
+            return hash_str
+        return hash_str[: self.config.hash_length]
+
+    def _format_feature_key(self, key: FeatureKey) -> str:
+        """Format feature key for display.
+
+        Uses / separator instead of __ for better readability.
+
+        Args:
+            key: Feature key
+
+        Returns:
+            Formatted string like "my/feature/key"
+        """
+        return "/".join(key)
+
+    def _format_field_key(self, key: FieldKey) -> str:
+        """Format field key for display.
+
+        Args:
+            key: Field key
+
+        Returns:
+            Formatted string like "field_name"
+        """
+        return "/".join(key)
+
+    def _get_filtered_features(self) -> set[FeatureKey]:
+        """Get features to render based on config filters.
+
+        Returns:
+            Set of feature keys to include in rendering
+        """
+        focus_key = self.config.get_feature_key()
+
+        # If no focus feature specified, include all features
+        if focus_key is None:
+            return set(self.graph.features_by_key.keys())
+
+        # Start with focus feature
+        features_to_render = {focus_key}
+
+        # Add upstream dependencies (up)
+        # If up is not specified, don't include upstream (default to 0)
+        # If up is 0, explicitly don't include upstream
+        # If up > 0, include that many levels
+        # If up < 0, include all upstream (unlimited)
+        up_levels = self.config.up if self.config.up is not None else 0
+        if up_levels != 0:
+            max_up = None if up_levels < 0 else up_levels
+            upstream = self._get_upstream_features(focus_key, max_levels=max_up)
+            features_to_render.update(upstream)
+
+        # Add downstream dependents (down)
+        # If down is not specified, don't include downstream (default to 0)
+        # If down is 0, explicitly don't include downstream
+        # If down > 0, include that many levels
+        # If down < 0, include all downstream (unlimited)
+        down_levels = self.config.down if self.config.down is not None else 0
+        if down_levels != 0:
+            max_down = None if down_levels < 0 else down_levels
+            downstream = self._get_downstream_features(focus_key, max_levels=max_down)
+            features_to_render.update(downstream)
+
+        return features_to_render
+
+    def _get_upstream_features(
+        self, start_key: FeatureKey, max_levels: int | None = None
+    ) -> set[FeatureKey]:
+        """Get all upstream dependencies of a feature.
+
+        Args:
+            start_key: Feature to start from
+            max_levels: Maximum levels to traverse (None = unlimited)
+                      1 means direct dependencies only
+                      2 means dependencies of dependencies, etc.
+
+        Returns:
+            Set of upstream feature keys
+        """
+        upstream = set()
+
+        def visit(key: FeatureKey, level: int):
+            feature_cls = self.graph.features_by_key.get(key)
+            if not feature_cls or not feature_cls.spec.deps:
+                return
+
+            for dep in feature_cls.spec.deps:
+                if dep.key in self.graph.features_by_key and dep.key not in upstream:
+                    upstream.add(dep.key)
+                    # Only recurse if we haven't reached the max level
+                    if max_levels is None or level + 1 < max_levels:
+                        visit(dep.key, level + 1)
+
+        visit(start_key, 0)
+        return upstream
+
+    def _get_downstream_features(
+        self, start_key: FeatureKey, max_levels: int | None = None
+    ) -> set[FeatureKey]:
+        """Get all downstream dependents of a feature.
+
+        Args:
+            start_key: Feature to start from
+            max_levels: Maximum levels to traverse (None = unlimited)
+                      1 means direct dependents only
+                      2 means dependents of dependents, etc.
+
+        Returns:
+            Set of downstream feature keys
+        """
+        downstream = set()
+
+        # Build reverse dependency map
+        dependents_map = {}  # feature_key -> list of features that depend on it
+        for key, feature_cls in self.graph.features_by_key.items():
+            if feature_cls.spec.deps:
+                for dep in feature_cls.spec.deps:
+                    if dep.key not in dependents_map:
+                        dependents_map[dep.key] = []
+                    dependents_map[dep.key].append(key)
+
+        def visit(key: FeatureKey, level: int):
+            if key not in dependents_map:
+                return
+
+            for dependent_key in dependents_map[key]:
+                if dependent_key not in downstream:
+                    downstream.add(dependent_key)
+                    # Only recurse if we haven't reached the max level
+                    if max_levels is None or level + 1 < max_levels:
+                        visit(dependent_key, level + 1)
+
+        visit(start_key, 0)
+        return downstream
+
+    def _get_topological_order(self) -> list[FeatureKey]:
+        """Get features in topological order (dependencies first).
+
+        Only includes features that pass the filter criteria.
+
+        Returns:
+            List of feature keys sorted so dependencies appear before dependents
+        """
+        features_to_include = self._get_filtered_features()
+        visited = set()
+        result = []
+
+        def visit(key: FeatureKey):
+            if key in visited or key not in features_to_include:
+                return
+            visited.add(key)
+
+            # Visit dependencies first (only if they're also in features_to_include)
+            feature_cls = self.graph.features_by_key[key]
+            if feature_cls.spec.deps:
+                for dep in feature_cls.spec.deps:
+                    if dep.key in features_to_include:
+                        visit(dep.key)
+
+            result.append(key)
+
+        # Visit all features that should be included
+        for key in features_to_include:
+            visit(key)
+
+        return result
+
+    def _is_root_feature(self, key: FeatureKey) -> bool:
+        """Check if feature is a root (has no dependencies).
+
+        Args:
+            key: Feature key
+
+        Returns:
+            True if feature has no dependencies
+        """
+        feature_cls = self.graph.features_by_key[key]
+        return not feature_cls.spec.deps
+
+    def render(self) -> str:
+        """Render the graph and return string output.
+
+        Returns:
+            Rendered graph as string
+        """
+        raise NotImplementedError

--- a/src/metaxy/graph/renderers/cards.py
+++ b/src/metaxy/graph/renderers/cards.py
@@ -1,0 +1,154 @@
+"""Cards renderer using Rich panels for graph visualization.
+
+Requires rich library to be installed.
+"""
+
+from metaxy.graph.renderers.base import GraphRenderer
+from metaxy.models.plan import FQFieldKey
+
+
+class TerminalCardsRenderer(GraphRenderer):
+    """Renders graph as cards with edges for terminal display.
+
+    Uses Rich panels to show features as cards/boxes with dependency information.
+    """
+
+    def render(self) -> str:
+        """Render graph as cards.
+
+        Returns:
+            Rendered cards as string with ANSI color codes
+        """
+        from rich.columns import Columns
+        from rich.console import Console, Group
+        from rich.text import Text
+
+        console = Console()
+
+        # Build feature panels in topological order
+        feature_panels = []
+        feature_labels = {}  # key -> display label
+
+        for feature_key in self._get_topological_order():
+            feature_cls = self.graph.features_by_key[feature_key]
+            panel = self._build_feature_panel(feature_key, feature_cls)
+            feature_panels.append(panel)
+            feature_labels[feature_key] = self._format_feature_key(feature_key)
+
+        # Build edges representation
+        edges_text = Text()
+        if self.config.show_snapshot_id:
+            snapshot_id = self._format_hash(self.graph.snapshot_id)
+            edges_text.append(f"📊 Graph (snapshot: {snapshot_id})\n\n", style="bold")
+        else:
+            edges_text.append("📊 Graph\n\n", style="bold")
+
+        # Show dependency edges
+        edges_text.append("Dependencies:\n", style="bold cyan")
+        for feature_key in self._get_topological_order():
+            feature_cls = self.graph.features_by_key[feature_key]
+            if feature_cls.spec.deps:
+                source_label = self._format_feature_key(feature_key)
+                for dep in feature_cls.spec.deps:
+                    if dep.key in self.graph.features_by_key:
+                        target_label = self._format_feature_key(dep.key)
+                        edges_text.append(f"  {target_label} ", style="cyan")
+                        edges_text.append("→", style="yellow bold")
+                        edges_text.append(f" {source_label}\n", style="cyan")
+
+        # Combine everything
+        output_group = Group(
+            edges_text,
+            Text("\nFeatures:", style="bold"),
+            Columns(feature_panels, equal=True, expand=True),
+        )
+
+        # Render to string
+        with console.capture() as capture:
+            console.print(output_group)
+        return capture.get()
+
+    def _build_feature_panel(self, feature_key, feature_cls):
+        """Build a Rich Panel for a feature.
+
+        Args:
+            feature_key: Feature key
+            feature_cls: Feature class
+
+        Returns:
+            Rich Panel with feature information
+        """
+        from rich.panel import Panel
+        from rich.text import Text
+
+        content = Text()
+
+        # Feature name
+        content.append(self._format_feature_key(feature_key), style="bold cyan")
+        content.append("\n")
+
+        # Versions
+        if self.config.show_feature_versions:
+            version = self._format_hash(feature_cls.feature_version())
+            content.append(f"v: {version}", style="yellow")
+            content.append("\n")
+
+        if self.config.show_code_versions:
+            content.append(f"cv: {feature_cls.spec.code_version}", style="dim")
+            content.append("\n")
+
+        # Fields
+        if self.config.show_fields and feature_cls.spec.fields:
+            content.append("\nFields:\n", style="bold green")
+            for field in feature_cls.spec.fields:
+                field_text = self._format_field_info(feature_key, field)
+                content.append(f"  • {field_text}\n")
+
+        return Panel(content, border_style="cyan", padding=(0, 1))
+
+    def _format_field_info(self, feature_key, field_spec) -> str:
+        """Format field information as a string.
+
+        Args:
+            feature_key: Feature key (for version lookup)
+            field_spec: Field specification
+
+        Returns:
+            Formatted field string
+        """
+        parts = [self._format_field_key(field_spec.key)]
+
+        if self.config.show_field_versions:
+            fq_key = FQFieldKey(feature=feature_key, field=field_spec.key)
+            version = self._format_hash(self.graph.get_field_version(fq_key))
+            parts.append(f"(v: {version})")
+
+        if self.config.show_code_versions:
+            parts.append(f"(cv: {field_spec.code_version})")
+
+        # Add field dependencies
+        if field_spec.deps:
+            from metaxy.models.field import SpecialFieldDep
+
+            if isinstance(field_spec.deps, SpecialFieldDep):
+                # Special dependency (e.g., ALL) - skip displaying as it's the default sentinel
+                pass
+            else:
+                # List of specific field dependencies
+                dep_strs = []
+                for dep in field_spec.deps:
+                    dep_feature = self._format_feature_key(dep.feature_key)
+
+                    # Check if this dep uses ALL fields or specific fields
+                    if isinstance(dep.fields, SpecialFieldDep):
+                        # ALL fields - just show the feature name
+                        dep_strs.append(dep_feature)
+                    else:
+                        # Specific fields
+                        for field_key in dep.fields:
+                            dep_field = self._format_field_key(field_key)
+                            dep_strs.append(f"{dep_feature}.{dep_field}")
+                if dep_strs:
+                    parts.append(f"← {', '.join(dep_strs)}")
+
+        return " ".join(parts)

--- a/src/metaxy/graph/renderers/graphviz.py
+++ b/src/metaxy/graph/renderers/graphviz.py
@@ -1,0 +1,147 @@
+"""Graphviz renderer for DOT format generation.
+
+Requires pygraphviz library to be installed.
+"""
+
+from metaxy.graph.renderers.base import GraphRenderer
+from metaxy.models.plan import FQFieldKey
+
+
+class GraphvizRenderer(GraphRenderer):
+    """Renders graph using pygraphviz.
+
+    Creates DOT format output using pygraphviz library.
+    Requires pygraphviz to be installed as optional dependency.
+    """
+
+    def render(self) -> str:
+        """Render graph as Graphviz DOT format.
+
+        Returns:
+            DOT format as string
+        """
+        lines = []
+
+        # Graph header
+        rankdir = self.config.direction
+        lines.append("strict digraph {")
+        lines.append(f"    rankdir={rankdir};")
+
+        # Graph attributes
+        if self.config.show_snapshot_id:
+            label = f"Graph (snapshot: {self._format_hash(self.graph.snapshot_id)})"
+        else:
+            label = "Graph"
+        lines.append(f'    label="{label}";')
+        lines.append("    labelloc=t;")
+        lines.append("    fontsize=14;")
+        lines.append("    fontname=helvetica;")
+        lines.append("")
+
+        # Add nodes for features
+        features_to_include = self._get_filtered_features()
+        for feature_key in features_to_include:
+            if feature_key not in self.graph.features_by_key:
+                continue
+
+            feature_cls = self.graph.features_by_key[feature_key]
+            node_id = feature_key.to_string()
+            label = self._build_feature_label(feature_key, feature_cls)
+
+            # Root features get different shape
+            shape = "box" if not self._is_root_feature(feature_key) else "doubleoctagon"
+
+            lines.append(
+                f'    "{node_id}" [label="{label}", shape={shape}, '
+                f"style=filled, fillcolor=lightblue];"
+            )
+
+        lines.append("")
+
+        # Add edges for feature dependencies
+        for feature_key in features_to_include:
+            if feature_key not in self.graph.features_by_key:
+                continue
+
+            feature_cls = self.graph.features_by_key[feature_key]
+            if feature_cls.spec.deps:
+                target_id = feature_key.to_string()
+                for dep in feature_cls.spec.deps:
+                    if dep.key in features_to_include:
+                        source_id = dep.key.to_string()
+                        lines.append(f'    "{source_id}" -> "{target_id}";')
+
+        lines.append("")
+
+        # Add field nodes if configured
+        if self.config.show_fields:
+            for feature_key in features_to_include:
+                if feature_key not in self.graph.features_by_key:
+                    continue
+
+                feature_cls = self.graph.features_by_key[feature_key]
+                parent_id = feature_key.to_string()
+
+                if not feature_cls.spec.fields:
+                    continue
+
+                for field in feature_cls.spec.fields:
+                    field_id = f"{parent_id}::{field.key.to_string()}"
+                    label = self._build_field_label(feature_key, field)
+
+                    lines.append(
+                        f'    "{field_id}" [label="{label}", shape=ellipse, '
+                        f"style=filled, fillcolor=lightyellow, fontsize=10];"
+                    )
+
+                    # Connect field to feature with dashed line
+                    lines.append(
+                        f'    "{parent_id}" -> "{field_id}" [style=dashed, arrowhead=none];'
+                    )
+
+        lines.append("}")
+
+        return "\n".join(lines)
+
+    def _build_feature_label(self, feature_key, feature_cls) -> str:
+        """Build label for feature node.
+
+        Args:
+            feature_key: Feature key
+            feature_cls: Feature class
+
+        Returns:
+            Formatted label with optional version info
+        """
+        parts = [self._format_feature_key(feature_key)]
+
+        if self.config.show_feature_versions:
+            version = self._format_hash(feature_cls.feature_version())
+            parts.append(f"\\nv: {version}")
+
+        if self.config.show_code_versions:
+            parts.append(f"\\ncv: {feature_cls.spec.code_version}")
+
+        return "".join(parts)
+
+    def _build_field_label(self, feature_key, field_spec) -> str:
+        """Build label for field node.
+
+        Args:
+            feature_key: Feature key (for version lookup)
+            field_spec: Field specification
+
+        Returns:
+            Formatted label with optional version info
+        """
+        parts = [self._format_field_key(field_spec.key)]
+
+        if self.config.show_field_versions:
+            fq_key = FQFieldKey(feature=feature_key, field=field_spec.key)
+            version = self._format_hash(self.graph.get_field_version(fq_key))
+            parts.append(f"\\nv: {version}")
+
+        if self.config.show_code_versions:
+            parts.append(f"\\ncv: {field_spec.code_version}")
+
+        return "".join(parts)

--- a/src/metaxy/graph/renderers/mermaid.py
+++ b/src/metaxy/graph/renderers/mermaid.py
@@ -1,0 +1,143 @@
+"""Mermaid renderer for flowchart generation.
+
+Requires mermaid-py library to be installed.
+"""
+
+from metaxy.graph.renderers.base import GraphRenderer
+from metaxy.models.plan import FQFieldKey
+from metaxy.models.types import FeatureKey
+
+
+class MermaidRenderer(GraphRenderer):
+    """Generates Mermaid flowchart markup using mermaid-py.
+
+    Creates flowchart with type-safe API.
+    """
+
+    def render(self) -> str:
+        """Render graph as Mermaid flowchart.
+
+        Returns:
+            Mermaid markup as string
+        """
+        from mermaid.flowchart import FlowChart, Link, Node
+
+        # Create nodes with fields as sub-items in the label
+        nodes = []
+        node_map = {}  # feature_key -> Node
+
+        for feature_key in self._get_topological_order():
+            feature_cls = self.graph.features_by_key[feature_key]
+            node_id = self._node_id_from_key(feature_key)
+
+            # Build label with fields inside
+            label = self._build_feature_label_with_fields(feature_key, feature_cls)
+
+            node = Node(id_=node_id, content=label, shape="normal")
+            nodes.append(node)
+            node_map[feature_key] = node
+
+        # Create links for dependencies
+        links = []
+        for feature_key, feature_cls in self.graph.features_by_key.items():
+            if feature_cls.spec.deps:
+                target_node = node_map[feature_key]
+                for dep in feature_cls.spec.deps:
+                    if dep.key in node_map:
+                        source_node = node_map[dep.key]
+                        links.append(Link(origin=source_node, end=target_node))
+
+        # Create flowchart
+        title = ""
+        if self.config.show_snapshot_id:
+            snapshot_hash = self._format_hash(self.graph.snapshot_id)
+            title = f"Feature Graph (snapshot: {snapshot_hash})"
+        else:
+            title = "Feature Graph"
+
+        chart = FlowChart(
+            title=title,
+            nodes=nodes,
+            links=links,
+            orientation=self.config.direction,
+        )
+
+        return chart.script
+
+    def _node_id_from_key(self, key: FeatureKey) -> str:
+        """Generate valid node ID from feature key.
+
+        Args:
+            key: Feature key
+
+        Returns:
+            Valid node identifier (lowercase, no special chars)
+        """
+        return key.to_string().replace("__", "_").lower()
+
+    def _build_feature_label_with_fields(
+        self, feature_key: FeatureKey, feature_cls
+    ) -> str:
+        """Build label for feature node with fields displayed inside.
+
+        Args:
+            feature_key: Feature key
+            feature_cls: Feature class
+
+        Returns:
+            Formatted label with feature info and fields as sub-items
+        """
+        lines = []
+
+        # Feature key (bold)
+        feature_name = self._format_feature_key(feature_key)
+        lines.append(f"<b>{feature_name}</b>")
+
+        # Feature version info
+        if self.config.show_feature_versions or self.config.show_code_versions:
+            version_parts = []
+
+            if self.config.show_feature_versions:
+                version = self._format_hash(feature_cls.feature_version())
+                version_parts.append(f"v: {version}")
+
+            if self.config.show_code_versions:
+                version_parts.append(f"cv: {feature_cls.spec.code_version}")
+
+            lines.append(f"<small>({', '.join(version_parts)})</small>")
+
+        # Fields (if configured)
+        if self.config.show_fields and feature_cls.spec.fields:
+            lines.append("---")
+            for field in feature_cls.spec.fields:
+                field_line = self._build_field_line(feature_key, field)
+                lines.append(field_line)
+
+        return "<br/>".join(lines)
+
+    def _build_field_line(self, feature_key: FeatureKey, field_spec) -> str:
+        """Build single line for field display.
+
+        Args:
+            feature_key: Feature key (for version lookup)
+            field_spec: Field specification
+
+        Returns:
+            Formatted field line
+        """
+        parts = [f"• {self._format_field_key(field_spec.key)}"]
+
+        if self.config.show_field_versions or self.config.show_code_versions:
+            version_parts = []
+
+            if self.config.show_field_versions:
+                fq_key = FQFieldKey(feature=feature_key, field=field_spec.key)
+                version = self._format_hash(self.graph.get_field_version(fq_key))
+                version_parts.append(f"v: {version}")
+
+            if self.config.show_code_versions:
+                version_parts.append(f"cv: {field_spec.code_version}")
+
+            parts.append(f"<small>({', '.join(version_parts)})</small>")
+
+        return " ".join(parts)

--- a/src/metaxy/graph/renderers/rich.py
+++ b/src/metaxy/graph/renderers/rich.py
@@ -1,0 +1,121 @@
+"""Terminal renderer using Rich Tree for hierarchical display.
+
+Requires rich library to be installed.
+"""
+
+from metaxy.graph.renderers.base import GraphRenderer
+from metaxy.models.plan import FQFieldKey
+
+
+class TerminalRenderer(GraphRenderer):
+    """Renders graph using Rich Tree for terminal display.
+
+    Creates a hierarchical tree view with colors and icons.
+    """
+
+    def render(self) -> str:
+        """Render graph as Rich Tree for terminal.
+
+        Returns:
+            Rendered tree as string with ANSI color codes
+        """
+        from rich.console import Console
+        from rich.tree import Tree
+
+        console = Console()
+
+        # Create root node
+        if self.config.show_snapshot_id:
+            snapshot_id = self._format_hash(self.graph.snapshot_id)
+            root = Tree(f"📊 [bold]Graph[/bold] [dim](snapshot: {snapshot_id})[/dim]")
+        else:
+            root = Tree("📊 [bold]Graph[/bold]")
+
+        # Add features in topological order
+        for feature_key in self._get_topological_order():
+            feature_cls = self.graph.features_by_key[feature_key]
+            self._render_feature_node(root, feature_key, feature_cls)
+
+        # Render to string
+        with console.capture() as capture:
+            console.print(root)
+        return capture.get()
+
+    def _render_feature_node(self, parent, feature_key, feature_cls):
+        """Add a feature node to the tree.
+
+        Args:
+            parent: Parent tree node
+            feature_key: Feature key
+            feature_cls: Feature class
+        """
+        # Build feature label
+        label_parts = [f"[cyan]{self._format_feature_key(feature_key)}[/cyan]"]
+
+        if self.config.show_feature_versions:
+            version = self._format_hash(feature_cls.feature_version())
+            label_parts.append(f"[yellow](v: {version})[/yellow]")
+
+        if self.config.show_code_versions:
+            label_parts.append(f"[dim](cv: {feature_cls.spec.code_version})[/dim]")
+
+        label = " ".join(label_parts)
+        feature_branch = parent.add(label)
+
+        # Add fields
+        if self.config.show_fields and feature_cls.spec.fields:
+            fields_branch = feature_branch.add("🔧 [green]fields[/green]")
+            for field in feature_cls.spec.fields:
+                self._render_field_node(fields_branch, feature_key, field)
+
+        # Add dependencies
+        if feature_cls.spec.deps:
+            deps_branch = feature_branch.add("⬅️  [blue]depends on[/blue]")
+            for dep in feature_cls.spec.deps:
+                deps_branch.add(f"[cyan]{self._format_feature_key(dep.key)}[/cyan]")
+
+    def _render_field_node(self, parent, feature_key, field_spec):
+        """Add a field node to the tree.
+
+        Args:
+            parent: Parent tree node
+            feature_key: Feature key (for version lookup)
+            field_spec: Field specification
+        """
+        label_parts = [self._format_field_key(field_spec.key)]
+
+        if self.config.show_field_versions:
+            fq_key = FQFieldKey(feature=feature_key, field=field_spec.key)
+            version = self._format_hash(self.graph.get_field_version(fq_key))
+            label_parts.append(f"[yellow](v: {version})[/yellow]")
+
+        if self.config.show_code_versions:
+            label_parts.append(f"[dim](cv: {field_spec.code_version})[/dim]")
+
+        # Add field dependencies if present
+        if field_spec.deps:
+            from metaxy.models.field import SpecialFieldDep
+
+            if isinstance(field_spec.deps, SpecialFieldDep):
+                # Special dependency (e.g., ALL) - skip displaying as it's the default sentinel
+                pass
+            else:
+                # List of specific field dependencies
+                dep_strs = []
+                for dep in field_spec.deps:
+                    dep_feature = self._format_feature_key(dep.feature_key)
+
+                    # Check if this dep uses ALL fields or specific fields
+                    if isinstance(dep.fields, SpecialFieldDep):
+                        # ALL fields - just show the feature name
+                        dep_strs.append(dep_feature)
+                    else:
+                        # Specific fields
+                        for field_key in dep.fields:
+                            dep_field = self._format_field_key(field_key)
+                            dep_strs.append(f"{dep_feature}.{dep_field}")
+                if dep_strs:
+                    label_parts.append(f"[dim]← {', '.join(dep_strs)}[/dim]")
+
+        label = " ".join(label_parts)
+        parent.add(label)

--- a/tests/cli/__snapshots__/test_cli_graph.ambr
+++ b/tests/cli/__snapshots__/test_cli_graph.ambr
@@ -1,0 +1,23 @@
+# serializer version: 1
+# name: test_graph_render_graphviz_format
+  '''
+  strict digraph {
+      rankdir=TB;
+      label="Graph (snapshot: 4bd49031)";
+      labelloc=t;
+      fontsize=14;
+      fontname=helvetica;
+  
+      "examples__child" ;
+      "examples__parent" ;
+  
+      "examples__parent" -> "examples__child";
+  
+      "examples__child::predictions" ;
+      "examples__child" -> "examples__child::predictions" ;
+      "examples__parent::embeddings" ;
+      "examples__parent" -> "examples__parent::embeddings" ;
+  }
+  
+  '''
+# ---

--- a/uv.lock
+++ b/uv.lock
@@ -71,6 +71,95 @@ wheels = [
 ]
 
 [[package]]
+name = "charset-normalizer"
+version = "3.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/69/33ddede1939fdd074bce5434295f38fae7136463422fe4fd3e0e89b98062/charset_normalizer-3.4.4.tar.gz", hash = "sha256:94537985111c35f28720e43603b8e7b43a6ecfb2ce1d3058bbe955b73404e21a", size = 129418, upload-time = "2025-10-14T04:42:32.879Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/b8/6d51fc1d52cbd52cd4ccedd5b5b2f0f6a11bbf6765c782298b0f3e808541/charset_normalizer-3.4.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e824f1492727fa856dd6eda4f7cee25f8518a12f3c4a56a74e8095695089cf6d", size = 209709, upload-time = "2025-10-14T04:40:11.385Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/af/1f9d7f7faafe2ddfb6f72a2e07a548a629c61ad510fe60f9630309908fef/charset_normalizer-3.4.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4bd5d4137d500351a30687c2d3971758aac9a19208fc110ccb9d7188fbe709e8", size = 148814, upload-time = "2025-10-14T04:40:13.135Z" },
+    { url = "https://files.pythonhosted.org/packages/79/3d/f2e3ac2bbc056ca0c204298ea4e3d9db9b4afe437812638759db2c976b5f/charset_normalizer-3.4.4-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:027f6de494925c0ab2a55eab46ae5129951638a49a34d87f4c3eda90f696b4ad", size = 144467, upload-time = "2025-10-14T04:40:14.728Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/85/1bf997003815e60d57de7bd972c57dc6950446a3e4ccac43bc3070721856/charset_normalizer-3.4.4-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f820802628d2694cb7e56db99213f930856014862f3fd943d290ea8438d07ca8", size = 162280, upload-time = "2025-10-14T04:40:16.14Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/8e/6aa1952f56b192f54921c436b87f2aaf7c7a7c3d0d1a765547d64fd83c13/charset_normalizer-3.4.4-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:798d75d81754988d2565bff1b97ba5a44411867c0cf32b77a7e8f8d84796b10d", size = 159454, upload-time = "2025-10-14T04:40:17.567Z" },
+    { url = "https://files.pythonhosted.org/packages/36/3b/60cbd1f8e93aa25d1c669c649b7a655b0b5fb4c571858910ea9332678558/charset_normalizer-3.4.4-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d1bb833febdff5c8927f922386db610b49db6e0d4f4ee29601d71e7c2694313", size = 153609, upload-time = "2025-10-14T04:40:19.08Z" },
+    { url = "https://files.pythonhosted.org/packages/64/91/6a13396948b8fd3c4b4fd5bc74d045f5637d78c9675585e8e9fbe5636554/charset_normalizer-3.4.4-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9cd98cdc06614a2f768d2b7286d66805f94c48cde050acdbbb7db2600ab3197e", size = 151849, upload-time = "2025-10-14T04:40:20.607Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/7a/59482e28b9981d105691e968c544cc0df3b7d6133152fb3dcdc8f135da7a/charset_normalizer-3.4.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:077fbb858e903c73f6c9db43374fd213b0b6a778106bc7032446a8e8b5b38b93", size = 151586, upload-time = "2025-10-14T04:40:21.719Z" },
+    { url = "https://files.pythonhosted.org/packages/92/59/f64ef6a1c4bdd2baf892b04cd78792ed8684fbc48d4c2afe467d96b4df57/charset_normalizer-3.4.4-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:244bfb999c71b35de57821b8ea746b24e863398194a4014e4c76adc2bbdfeff0", size = 145290, upload-time = "2025-10-14T04:40:23.069Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/63/3bf9f279ddfa641ffa1962b0db6a57a9c294361cc2f5fcac997049a00e9c/charset_normalizer-3.4.4-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:64b55f9dce520635f018f907ff1b0df1fdc31f2795a922fb49dd14fbcdf48c84", size = 163663, upload-time = "2025-10-14T04:40:24.17Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/09/c9e38fc8fa9e0849b172b581fd9803bdf6e694041127933934184e19f8c3/charset_normalizer-3.4.4-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:faa3a41b2b66b6e50f84ae4a68c64fcd0c44355741c6374813a800cd6695db9e", size = 151964, upload-time = "2025-10-14T04:40:25.368Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/d1/d28b747e512d0da79d8b6a1ac18b7ab2ecfd81b2944c4c710e166d8dd09c/charset_normalizer-3.4.4-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:6515f3182dbe4ea06ced2d9e8666d97b46ef4c75e326b79bb624110f122551db", size = 161064, upload-time = "2025-10-14T04:40:26.806Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/9a/31d62b611d901c3b9e5500c36aab0ff5eb442043fb3a1c254200d3d397d9/charset_normalizer-3.4.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:cc00f04ed596e9dc0da42ed17ac5e596c6ccba999ba6bd92b0e0aef2f170f2d6", size = 155015, upload-time = "2025-10-14T04:40:28.284Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f3/107e008fa2bff0c8b9319584174418e5e5285fef32f79d8ee6a430d0039c/charset_normalizer-3.4.4-cp310-cp310-win32.whl", hash = "sha256:f34be2938726fc13801220747472850852fe6b1ea75869a048d6f896838c896f", size = 99792, upload-time = "2025-10-14T04:40:29.613Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/66/e396e8a408843337d7315bab30dbf106c38966f1819f123257f5520f8a96/charset_normalizer-3.4.4-cp310-cp310-win_amd64.whl", hash = "sha256:a61900df84c667873b292c3de315a786dd8dac506704dea57bc957bd31e22c7d", size = 107198, upload-time = "2025-10-14T04:40:30.644Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/58/01b4f815bf0312704c267f2ccb6e5d42bcc7752340cd487bc9f8c3710597/charset_normalizer-3.4.4-cp310-cp310-win_arm64.whl", hash = "sha256:cead0978fc57397645f12578bfd2d5ea9138ea0fac82b2f63f7f7c6877986a69", size = 100262, upload-time = "2025-10-14T04:40:32.108Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/27/c6491ff4954e58a10f69ad90aca8a1b6fe9c5d3c6f380907af3c37435b59/charset_normalizer-3.4.4-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6e1fcf0720908f200cd21aa4e6750a48ff6ce4afe7ff5a79a90d5ed8a08296f8", size = 206988, upload-time = "2025-10-14T04:40:33.79Z" },
+    { url = "https://files.pythonhosted.org/packages/94/59/2e87300fe67ab820b5428580a53cad894272dbb97f38a7a814a2a1ac1011/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f819d5fe9234f9f82d75bdfa9aef3a3d72c4d24a6e57aeaebba32a704553aa0", size = 147324, upload-time = "2025-10-14T04:40:34.961Z" },
+    { url = "https://files.pythonhosted.org/packages/07/fb/0cf61dc84b2b088391830f6274cb57c82e4da8bbc2efeac8c025edb88772/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a59cb51917aa591b1c4e6a43c132f0cdc3c76dbad6155df4e28ee626cc77a0a3", size = 142742, upload-time = "2025-10-14T04:40:36.105Z" },
+    { url = "https://files.pythonhosted.org/packages/62/8b/171935adf2312cd745d290ed93cf16cf0dfe320863ab7cbeeae1dcd6535f/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8ef3c867360f88ac904fd3f5e1f902f13307af9052646963ee08ff4f131adafc", size = 160863, upload-time = "2025-10-14T04:40:37.188Z" },
+    { url = "https://files.pythonhosted.org/packages/09/73/ad875b192bda14f2173bfc1bc9a55e009808484a4b256748d931b6948442/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d9e45d7faa48ee908174d8fe84854479ef838fc6a705c9315372eacbc2f02897", size = 157837, upload-time = "2025-10-14T04:40:38.435Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/fc/de9cce525b2c5b94b47c70a4b4fb19f871b24995c728e957ee68ab1671ea/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:840c25fb618a231545cbab0564a799f101b63b9901f2569faecd6b222ac72381", size = 151550, upload-time = "2025-10-14T04:40:40.053Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c2/43edd615fdfba8c6f2dfbd459b25a6b3b551f24ea21981e23fb768503ce1/charset_normalizer-3.4.4-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ca5862d5b3928c4940729dacc329aa9102900382fea192fc5e52eb69d6093815", size = 149162, upload-time = "2025-10-14T04:40:41.163Z" },
+    { url = "https://files.pythonhosted.org/packages/03/86/bde4ad8b4d0e9429a4e82c1e8f5c659993a9a863ad62c7df05cf7b678d75/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d9c7f57c3d666a53421049053eaacdd14bbd0a528e2186fcb2e672effd053bb0", size = 150019, upload-time = "2025-10-14T04:40:42.276Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/86/a151eb2af293a7e7bac3a739b81072585ce36ccfb4493039f49f1d3cae8c/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:277e970e750505ed74c832b4bf75dac7476262ee2a013f5574dd49075879e161", size = 143310, upload-time = "2025-10-14T04:40:43.439Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/fe/43dae6144a7e07b87478fdfc4dbe9efd5defb0e7ec29f5f58a55aeef7bf7/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:31fd66405eaf47bb62e8cd575dc621c56c668f27d46a61d975a249930dd5e2a4", size = 162022, upload-time = "2025-10-14T04:40:44.547Z" },
+    { url = "https://files.pythonhosted.org/packages/80/e6/7aab83774f5d2bca81f42ac58d04caf44f0cc2b65fc6db2b3b2e8a05f3b3/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:0d3d8f15c07f86e9ff82319b3d9ef6f4bf907608f53fe9d92b28ea9ae3d1fd89", size = 149383, upload-time = "2025-10-14T04:40:46.018Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/e8/b289173b4edae05c0dde07f69f8db476a0b511eac556dfe0d6bda3c43384/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:9f7fcd74d410a36883701fafa2482a6af2ff5ba96b9a620e9e0721e28ead5569", size = 159098, upload-time = "2025-10-14T04:40:47.081Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/df/fe699727754cae3f8478493c7f45f777b17c3ef0600e28abfec8619eb49c/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ebf3e58c7ec8a8bed6d66a75d7fb37b55e5015b03ceae72a8e7c74495551e224", size = 152991, upload-time = "2025-10-14T04:40:48.246Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/86/584869fe4ddb6ffa3bd9f491b87a01568797fb9bd8933f557dba9771beaf/charset_normalizer-3.4.4-cp311-cp311-win32.whl", hash = "sha256:eecbc200c7fd5ddb9a7f16c7decb07b566c29fa2161a16cf67b8d068bd21690a", size = 99456, upload-time = "2025-10-14T04:40:49.376Z" },
+    { url = "https://files.pythonhosted.org/packages/65/f6/62fdd5feb60530f50f7e38b4f6a1d5203f4d16ff4f9f0952962c044e919a/charset_normalizer-3.4.4-cp311-cp311-win_amd64.whl", hash = "sha256:5ae497466c7901d54b639cf42d5b8c1b6a4fead55215500d2f486d34db48d016", size = 106978, upload-time = "2025-10-14T04:40:50.844Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/9d/0710916e6c82948b3be62d9d398cb4fcf4e97b56d6a6aeccd66c4b2f2bd5/charset_normalizer-3.4.4-cp311-cp311-win_arm64.whl", hash = "sha256:65e2befcd84bc6f37095f5961e68a6f077bf44946771354a28ad434c2cce0ae1", size = 99969, upload-time = "2025-10-14T04:40:52.272Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/85/1637cd4af66fa687396e757dec650f28025f2a2f5a5531a3208dc0ec43f2/charset_normalizer-3.4.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0a98e6759f854bd25a58a73fa88833fba3b7c491169f86ce1180c948ab3fd394", size = 208425, upload-time = "2025-10-14T04:40:53.353Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/6a/04130023fef2a0d9c62d0bae2649b69f7b7d8d24ea5536feef50551029df/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b5b290ccc2a263e8d185130284f8501e3e36c5e02750fc6b6bdeb2e9e96f1e25", size = 148162, upload-time = "2025-10-14T04:40:54.558Z" },
+    { url = "https://files.pythonhosted.org/packages/78/29/62328d79aa60da22c9e0b9a66539feae06ca0f5a4171ac4f7dc285b83688/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:74bb723680f9f7a6234dcf67aea57e708ec1fbdf5699fb91dfd6f511b0a320ef", size = 144558, upload-time = "2025-10-14T04:40:55.677Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bb/b32194a4bf15b88403537c2e120b817c61cd4ecffa9b6876e941c3ee38fe/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f1e34719c6ed0b92f418c7c780480b26b5d9c50349e9a9af7d76bf757530350d", size = 161497, upload-time = "2025-10-14T04:40:57.217Z" },
+    { url = "https://files.pythonhosted.org/packages/19/89/a54c82b253d5b9b111dc74aca196ba5ccfcca8242d0fb64146d4d3183ff1/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2437418e20515acec67d86e12bf70056a33abdacb5cb1655042f6538d6b085a8", size = 159240, upload-time = "2025-10-14T04:40:58.358Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/10/d20b513afe03acc89ec33948320a5544d31f21b05368436d580dec4e234d/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:11d694519d7f29d6cd09f6ac70028dba10f92f6cdd059096db198c283794ac86", size = 153471, upload-time = "2025-10-14T04:40:59.468Z" },
+    { url = "https://files.pythonhosted.org/packages/61/fa/fbf177b55bdd727010f9c0a3c49eefa1d10f960e5f09d1d887bf93c2e698/charset_normalizer-3.4.4-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ac1c4a689edcc530fc9d9aa11f5774b9e2f33f9a0c6a57864e90908f5208d30a", size = 150864, upload-time = "2025-10-14T04:41:00.623Z" },
+    { url = "https://files.pythonhosted.org/packages/05/12/9fbc6a4d39c0198adeebbde20b619790e9236557ca59fc40e0e3cebe6f40/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:21d142cc6c0ec30d2efee5068ca36c128a30b0f2c53c1c07bd78cb6bc1d3be5f", size = 150647, upload-time = "2025-10-14T04:41:01.754Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/6a9a593d52e3e8c5d2b167daf8c6b968808efb57ef4c210acb907c365bc4/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:5dbe56a36425d26d6cfb40ce79c314a2e4dd6211d51d6d2191c00bed34f354cc", size = 145110, upload-time = "2025-10-14T04:41:03.231Z" },
+    { url = "https://files.pythonhosted.org/packages/30/42/9a52c609e72471b0fc54386dc63c3781a387bb4fe61c20231a4ebcd58bdd/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:5bfbb1b9acf3334612667b61bd3002196fe2a1eb4dd74d247e0f2a4d50ec9bbf", size = 162839, upload-time = "2025-10-14T04:41:04.715Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/5b/c0682bbf9f11597073052628ddd38344a3d673fda35a36773f7d19344b23/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:d055ec1e26e441f6187acf818b73564e6e6282709e9bcb5b63f5b23068356a15", size = 150667, upload-time = "2025-10-14T04:41:05.827Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/24/a41afeab6f990cf2daf6cb8c67419b63b48cf518e4f56022230840c9bfb2/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:af2d8c67d8e573d6de5bc30cdb27e9b95e49115cd9baad5ddbd1a6207aaa82a9", size = 160535, upload-time = "2025-10-14T04:41:06.938Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/e5/6a4ce77ed243c4a50a1fecca6aaaab419628c818a49434be428fe24c9957/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:780236ac706e66881f3b7f2f32dfe90507a09e67d1d454c762cf642e6e1586e0", size = 154816, upload-time = "2025-10-14T04:41:08.101Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/ef/89297262b8092b312d29cdb2517cb1237e51db8ecef2e9af5edbe7b683b1/charset_normalizer-3.4.4-cp312-cp312-win32.whl", hash = "sha256:5833d2c39d8896e4e19b689ffc198f08ea58116bee26dea51e362ecc7cd3ed26", size = 99694, upload-time = "2025-10-14T04:41:09.23Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/2d/1e5ed9dd3b3803994c155cd9aacb60c82c331bad84daf75bcb9c91b3295e/charset_normalizer-3.4.4-cp312-cp312-win_amd64.whl", hash = "sha256:a79cfe37875f822425b89a82333404539ae63dbdddf97f84dcbc3d339aae9525", size = 107131, upload-time = "2025-10-14T04:41:10.467Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/d9/0ed4c7098a861482a7b6a95603edce4c0d9db2311af23da1fb2b75ec26fc/charset_normalizer-3.4.4-cp312-cp312-win_arm64.whl", hash = "sha256:376bec83a63b8021bb5c8ea75e21c4ccb86e7e45ca4eb81146091b56599b80c3", size = 100390, upload-time = "2025-10-14T04:41:11.915Z" },
+    { url = "https://files.pythonhosted.org/packages/97/45/4b3a1239bbacd321068ea6e7ac28875b03ab8bc0aa0966452db17cd36714/charset_normalizer-3.4.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e1f185f86a6f3403aa2420e815904c67b2f9ebc443f045edd0de921108345794", size = 208091, upload-time = "2025-10-14T04:41:13.346Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/62/73a6d7450829655a35bb88a88fca7d736f9882a27eacdca2c6d505b57e2e/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b39f987ae8ccdf0d2642338faf2abb1862340facc796048b604ef14919e55ed", size = 147936, upload-time = "2025-10-14T04:41:14.461Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c5/adb8c8b3d6625bef6d88b251bbb0d95f8205831b987631ab0c8bb5d937c2/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3162d5d8ce1bb98dd51af660f2121c55d0fa541b46dff7bb9b9f86ea1d87de72", size = 144180, upload-time = "2025-10-14T04:41:15.588Z" },
+    { url = "https://files.pythonhosted.org/packages/91/ed/9706e4070682d1cc219050b6048bfd293ccf67b3d4f5a4f39207453d4b99/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:81d5eb2a312700f4ecaa977a8235b634ce853200e828fbadf3a9c50bab278328", size = 161346, upload-time = "2025-10-14T04:41:16.738Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/0d/031f0d95e4972901a2f6f09ef055751805ff541511dc1252ba3ca1f80cf5/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5bd2293095d766545ec1a8f612559f6b40abc0eb18bb2f5d1171872d34036ede", size = 158874, upload-time = "2025-10-14T04:41:17.923Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/83/6ab5883f57c9c801ce5e5677242328aa45592be8a00644310a008d04f922/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a8a8b89589086a25749f471e6a900d3f662d1d3b6e2e59dcecf787b1cc3a1894", size = 153076, upload-time = "2025-10-14T04:41:19.106Z" },
+    { url = "https://files.pythonhosted.org/packages/75/1e/5ff781ddf5260e387d6419959ee89ef13878229732732ee73cdae01800f2/charset_normalizer-3.4.4-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc7637e2f80d8530ee4a78e878bce464f70087ce73cf7c1caf142416923b98f1", size = 150601, upload-time = "2025-10-14T04:41:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/57/71be810965493d3510a6ca79b90c19e48696fb1ff964da319334b12677f0/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f8bf04158c6b607d747e93949aa60618b61312fe647a6369f88ce2ff16043490", size = 150376, upload-time = "2025-10-14T04:41:21.398Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/d5/c3d057a78c181d007014feb7e9f2e65905a6c4ef182c0ddf0de2924edd65/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:554af85e960429cf30784dd47447d5125aaa3b99a6f0683589dbd27e2f45da44", size = 144825, upload-time = "2025-10-14T04:41:22.583Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8c/d0406294828d4976f275ffbe66f00266c4b3136b7506941d87c00cab5272/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:74018750915ee7ad843a774364e13a3db91682f26142baddf775342c3f5b1133", size = 162583, upload-time = "2025-10-14T04:41:23.754Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/24/e2aa1f18c8f15c4c0e932d9287b8609dd30ad56dbe41d926bd846e22fb8d/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:c0463276121fdee9c49b98908b3a89c39be45d86d1dbaa22957e38f6321d4ce3", size = 150366, upload-time = "2025-10-14T04:41:25.27Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/5b/1e6160c7739aad1e2df054300cc618b06bf784a7a164b0f238360721ab86/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:362d61fd13843997c1c446760ef36f240cf81d3ebf74ac62652aebaf7838561e", size = 160300, upload-time = "2025-10-14T04:41:26.725Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/10/f882167cd207fbdd743e55534d5d9620e095089d176d55cb22d5322f2afd/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9a26f18905b8dd5d685d6d07b0cdf98a79f3c7a918906af7cc143ea2e164c8bc", size = 154465, upload-time = "2025-10-14T04:41:28.322Z" },
+    { url = "https://files.pythonhosted.org/packages/89/66/c7a9e1b7429be72123441bfdbaf2bc13faab3f90b933f664db506dea5915/charset_normalizer-3.4.4-cp313-cp313-win32.whl", hash = "sha256:9b35f4c90079ff2e2edc5b26c0c77925e5d2d255c42c74fdb70fb49b172726ac", size = 99404, upload-time = "2025-10-14T04:41:29.95Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/26/b9924fa27db384bdcd97ab83b4f0a8058d96ad9626ead570674d5e737d90/charset_normalizer-3.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:b435cba5f4f750aa6c0a0d92c541fb79f69a387c91e61f1795227e4ed9cece14", size = 107092, upload-time = "2025-10-14T04:41:31.188Z" },
+    { url = "https://files.pythonhosted.org/packages/af/8f/3ed4bfa0c0c72a7ca17f0380cd9e4dd842b09f664e780c13cff1dcf2ef1b/charset_normalizer-3.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:542d2cee80be6f80247095cc36c418f7bddd14f4a6de45af91dfad36d817bba2", size = 100408, upload-time = "2025-10-14T04:41:32.624Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/35/7051599bd493e62411d6ede36fd5af83a38f37c4767b92884df7301db25d/charset_normalizer-3.4.4-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:da3326d9e65ef63a817ecbcc0df6e94463713b754fe293eaa03da99befb9a5bd", size = 207746, upload-time = "2025-10-14T04:41:33.773Z" },
+    { url = "https://files.pythonhosted.org/packages/10/9a/97c8d48ef10d6cd4fcead2415523221624bf58bcf68a802721a6bc807c8f/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8af65f14dc14a79b924524b1e7fffe304517b2bff5a58bf64f30b98bbc5079eb", size = 147889, upload-time = "2025-10-14T04:41:34.897Z" },
+    { url = "https://files.pythonhosted.org/packages/10/bf/979224a919a1b606c82bd2c5fa49b5c6d5727aa47b4312bb27b1734f53cd/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:74664978bb272435107de04e36db5a9735e78232b85b77d45cfb38f758efd33e", size = 143641, upload-time = "2025-10-14T04:41:36.116Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/33/0ad65587441fc730dc7bd90e9716b30b4702dc7b617e6ba4997dc8651495/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:752944c7ffbfdd10c074dc58ec2d5a8a4cd9493b314d367c14d24c17684ddd14", size = 160779, upload-time = "2025-10-14T04:41:37.229Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ed/331d6b249259ee71ddea93f6f2f0a56cfebd46938bde6fcc6f7b9a3d0e09/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d1f13550535ad8cff21b8d757a3257963e951d96e20ec82ab44bc64aeb62a191", size = 159035, upload-time = "2025-10-14T04:41:38.368Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ff/f6b948ca32e4f2a4576aa129d8bed61f2e0543bf9f5f2b7fc3758ed005c9/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ecaae4149d99b1c9e7b88bb03e3221956f68fd6d50be2ef061b2381b61d20838", size = 152542, upload-time = "2025-10-14T04:41:39.862Z" },
+    { url = "https://files.pythonhosted.org/packages/16/85/276033dcbcc369eb176594de22728541a925b2632f9716428c851b149e83/charset_normalizer-3.4.4-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cb6254dc36b47a990e59e1068afacdcd02958bdcce30bb50cc1700a8b9d624a6", size = 149524, upload-time = "2025-10-14T04:41:41.319Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/f2/6a2a1f722b6aba37050e626530a46a68f74e63683947a8acff92569f979a/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c8ae8a0f02f57a6e61203a31428fa1d677cbe50c93622b4149d5c0f319c1d19e", size = 150395, upload-time = "2025-10-14T04:41:42.539Z" },
+    { url = "https://files.pythonhosted.org/packages/60/bb/2186cb2f2bbaea6338cad15ce23a67f9b0672929744381e28b0592676824/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:47cc91b2f4dd2833fddaedd2893006b0106129d4b94fdb6af1f4ce5a9965577c", size = 143680, upload-time = "2025-10-14T04:41:43.661Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/a5/bf6f13b772fbb2a90360eb620d52ed8f796f3c5caee8398c3b2eb7b1c60d/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:82004af6c302b5d3ab2cfc4cc5f29db16123b1a8417f2e25f9066f91d4411090", size = 162045, upload-time = "2025-10-14T04:41:44.821Z" },
+    { url = "https://files.pythonhosted.org/packages/df/c5/d1be898bf0dc3ef9030c3825e5d3b83f2c528d207d246cbabe245966808d/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:2b7d8f6c26245217bd2ad053761201e9f9680f8ce52f0fcd8d0755aeae5b2152", size = 149687, upload-time = "2025-10-14T04:41:46.442Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/42/90c1f7b9341eef50c8a1cb3f098ac43b0508413f33affd762855f67a410e/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:799a7a5e4fb2d5898c60b640fd4981d6a25f1c11790935a44ce38c54e985f828", size = 160014, upload-time = "2025-10-14T04:41:47.631Z" },
+    { url = "https://files.pythonhosted.org/packages/76/be/4d3ee471e8145d12795ab655ece37baed0929462a86e72372fd25859047c/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:99ae2cffebb06e6c22bdc25801d7b30f503cc87dbd283479e7b606f70aff57ec", size = 154044, upload-time = "2025-10-14T04:41:48.81Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/6f/8f7af07237c34a1defe7defc565a9bc1807762f672c0fde711a4b22bf9c0/charset_normalizer-3.4.4-cp314-cp314-win32.whl", hash = "sha256:f9d332f8c2a2fcbffe1378594431458ddbef721c1769d78e2cbc06280d8155f9", size = 99940, upload-time = "2025-10-14T04:41:49.946Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/51/8ade005e5ca5b0d80fb4aff72a3775b325bdc3d27408c8113811a7cbe640/charset_normalizer-3.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:8a6562c3700cce886c5be75ade4a5db4214fda19fede41d9792d100288d8f94c", size = 107104, upload-time = "2025-10-14T04:41:51.051Z" },
+    { url = "https://files.pythonhosted.org/packages/da/5f/6b8f83a55bb8278772c5ae54a577f3099025f9ade59d0136ac24a0df4bde/charset_normalizer-3.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:de00632ca48df9daf77a2c65a484531649261ec9f25489917f09e455cb09ddb2", size = 100743, upload-time = "2025-10-14T04:41:52.122Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4c/925909008ed5a988ccbb72dcc897407e5d6d3bd72410d69e051fc0c14647/charset_normalizer-3.4.4-py3-none-any.whl", hash = "sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f", size = 53402, upload-time = "2025-10-14T04:42:31.76Z" },
+]
+
+[[package]]
 name = "clickhouse-connect"
 version = "0.9.2"
 source = { registry = "https://pypi.org/simple" }
@@ -326,6 +415,15 @@ sqlite = [
 ]
 
 [[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -492,6 +590,18 @@ wheels = [
 ]
 
 [[package]]
+name = "mermaid-py"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cb/b6/b5973f5b4b726f8b09e6558f459f0d6b70ee00206aacd873c8ed972a16cf/mermaid_py-0.8.0.tar.gz", hash = "sha256:8ba7853f88c09ebf9c2d355c0ebd1e272e877c9568c10612ae9d0f57245608ef", size = 21229, upload-time = "2025-05-12T14:42:26.354Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/0e/fbcc38fef8ff71e5df09d9d629e8b620fe974709664b81da2774b6debfe2/mermaid_py-0.8.0-py3-none-any.whl", hash = "sha256:dab0463ffe67fb3f13f0058cf5c0c2fa2685136cdc7e4ae3067d8b9d9c9e378a", size = 31741, upload-time = "2025-05-12T14:42:25.04Z" },
+]
+
+[[package]]
 name = "metaxy"
 version = "0.0.0"
 source = { editable = "." }
@@ -507,9 +617,16 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+graphviz = [
+    { name = "pygraphviz" },
+]
 ibis = [
     { name = "ibis-framework" },
     { name = "pyarrow" },
+]
+rendering = [
+    { name = "mermaid-py" },
+    { name = "rich" },
 ]
 
 [package.dev-dependencies]
@@ -532,16 +649,19 @@ dev = [
 requires-dist = [
     { name = "cyclopts", specifier = "==4.0.0b1" },
     { name = "ibis-framework", marker = "extra == 'ibis'", specifier = ">=11.0.0" },
+    { name = "mermaid-py", marker = "extra == 'rendering'", specifier = ">=0.8.0" },
     { name = "narwhals", specifier = ">=2.9.0" },
     { name = "polars", specifier = ">=1.33.1" },
     { name = "polars-hash", specifier = ">=0.5.1" },
     { name = "pyarrow", marker = "extra == 'ibis'", specifier = ">=18.0.0" },
     { name = "pydantic", specifier = ">=2.11.9" },
     { name = "pydantic-settings", specifier = ">=2.11.0" },
+    { name = "pygraphviz", marker = "extra == 'graphviz'", specifier = ">=1.14" },
     { name = "pyyaml", specifier = ">=6.0.0" },
+    { name = "rich", marker = "extra == 'rendering'", specifier = ">=13.0.0" },
     { name = "tomli", specifier = ">=2.3.0" },
 ]
-provides-extras = ["ibis"]
+provides-extras = ["ibis", "rendering", "graphviz"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1124,6 +1244,12 @@ wheels = [
 ]
 
 [[package]]
+name = "pygraphviz"
+version = "1.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/ca/823d5c74a73d6b8b08e1f5aea12468ef334f0732c65cbb18df2a7f285c87/pygraphviz-1.14.tar.gz", hash = "sha256:c10df02377f4e39b00ae17c862f4ee7e5767317f1c6b2dfd04cea6acc7fc2bea", size = 106003, upload-time = "2024-09-29T18:31:12.471Z" }
+
+[[package]]
 name = "pyrefly"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1371,6 +1497,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d3/d9/fbef87ba02d3668678b7a71b2d79a2ca092089dc530d83c609d83a82c9f8/regex-2025.10.22-cp314-cp314t-win32.whl", hash = "sha256:20ad0f712ff769003d90b442175779ad8ce7028e2640e10e0878b8a24e6373d1", size = 274427, upload-time = "2025-10-21T00:47:57.097Z" },
     { url = "https://files.pythonhosted.org/packages/db/df/58fd290ae0b5e223f42e25f1b3a1f445ceeee7d56016b615ab0207fd6552/regex-2025.10.22-cp314-cp314t-win_amd64.whl", hash = "sha256:94485cf318cd628f61dede6e1f9ab1956818ee7dcc59fb51d82e589c1c1a8f03", size = 284141, upload-time = "2025-10-21T00:47:59.661Z" },
     { url = "https://files.pythonhosted.org/packages/31/f2/01599f68ca68ded192f04209effb8630be4ff261b51b888000aea6f5a752/regex-2025.10.22-cp314-cp314t-win_arm64.whl", hash = "sha256:76bc9875244f1cf27e2e75dd9c8faf2c6dc8c9ff33afa98cf55e94969bea6fdd", size = 274499, upload-time = "2025-10-21T00:48:01.985Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.32.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
 ]
 
 [[package]]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a new graph render CLI to visualize feature dependencies as a terminal tree/DAG, Mermaid, or Graphviz DOT. Improves observability with filtering, version toggles, and snapshot rendering, plus the ability to save diagrams.

- **New Features**
  - Added metaxy graph render with formats: terminal tree, terminal DAG, Mermaid, and Graphviz DOT.
  - Config presets (minimal, default, verbose) and flags for fields, versions, hash length, and layout direction (TB/LR).
  - Focus on a feature with upstream/downstream levels to limit context.
  - Load and render historical snapshots from a metadata store.
  - Output to stdout or save to file (e.g., Mermaid/Graphviz).
  - Examples and comprehensive tests covering formats, filtering, and file output.

- **Dependencies**
  - New optional extras: rendering (rich, mermaid-py) and graphviz (pygraphviz).
  - Nix shell adds graphviz; CLI gracefully errors if a chosen format’s dependency is missing.

<!-- End of auto-generated description by cubic. -->

