### PR TITLE
fix basedpyright errors in src/metaxy

### DIFF
--- a/justfile
+++ b/justfile
@@ -2,5 +2,8 @@ ruff:
     uv run ruff check --fix
     uv run ruff format
 
+typecheck:
+    uv run basedpyright --level error
+
 generate-docs-cli:
     uv run cyclopts generate-docs src/metaxy/cli/app.py:app -f md -o docs/cli.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,3 +92,15 @@ exclude = [
     "examples/**/feature*.py",
 ]
 min_confidence = 60
+
+[tool.pyright]
+reportAny = "none"
+reportExplicitAny = "none"
+include = [
+    "src/metaxy",
+]
+exclude = [
+    "**/node_modules",
+    "**/__pycache__",
+    "**/*venv/**/*",
+]

--- a/src/metaxy/_testing.py
+++ b/src/metaxy/_testing.py
@@ -3,6 +3,7 @@ import sys
 import tempfile
 from functools import cached_property
 from pathlib import Path
+from typing import Any
 
 from metaxy import (
     FeatureSpec,
@@ -70,7 +71,7 @@ class TempFeatureModule:
         if self.module_name in sys.modules:
             importlib.reload(sys.modules[self.module_name])
 
-    def _generate_spec_repr(self, spec_dict: dict) -> str:
+    def _generate_spec_repr(self, spec_dict: dict[str, Any]) -> str:
         """Generate FeatureSpec constructor call from dict."""
         # This is a simple representation - could be made more robust
         parts = []
@@ -154,7 +155,7 @@ class TempFeatureModule:
         shutil.rmtree(self.temp_dir, ignore_errors=True)
 
 
-def assert_all_results_equal(results: dict, snapshot=None) -> None:
+def assert_all_results_equal(results: dict[str, Any], snapshot=None) -> None:
     """Compare all results from different store type combinations.
 
     Ensures all variants produce identical results, then optionally snapshots all results.

--- a/src/metaxy/_utils.py
+++ b/src/metaxy/_utils.py
@@ -1,8 +1,10 @@
+from typing import Any
+
 import narwhals as nw
 import polars as pl
 
 
-def collect_to_polars(lazy_frame: nw.LazyFrame) -> pl.DataFrame:
+def collect_to_polars(lazy_frame: nw.LazyFrame[Any]) -> pl.DataFrame:
     """Helper to collect a Narwhals LazyFrame and convert to Polars DataFrame.
 
     This handles all backend conversions (Polars, DuckDB/PyArrow, etc.) transparently.

--- a/src/metaxy/config.py
+++ b/src/metaxy/config.py
@@ -1,10 +1,11 @@
 """Configuration system for Metaxy using pydantic-settings."""
+# pyright: reportImportCycles=false
 
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeVar
 
 try:
-    import tomllib  # Python 3.11+
+    import tomllib  # Python 3.11+  # pyright: ignore[reportMissingImports]
 except ImportError:
     import tomli as tomllib  # Fallback for Python 3.10
 
@@ -16,7 +17,9 @@ from pydantic_settings import (
 )
 
 if TYPE_CHECKING:
-    from metaxy.metadata_store.base import MetadataStore
+    from metaxy.metadata_store.base import (
+        MetadataStore,  # pyright: ignore[reportImportCycles]
+    )
 
 T = TypeVar("T")
 

--- a/src/metaxy/data_versioning/calculators/base.py
+++ b/src/metaxy/data_versioning/calculators/base.py
@@ -1,7 +1,7 @@
 """Abstract base class for data version calculators."""
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import narwhals as nw
 
@@ -61,12 +61,12 @@ class DataVersionCalculator(ABC):
     @abstractmethod
     def calculate_data_versions(
         self,
-        joined_upstream: nw.LazyFrame,
+        joined_upstream: nw.LazyFrame[Any],
         feature_spec: "FeatureSpec",
         feature_plan: "FeaturePlan",
         upstream_column_mapping: dict[str, str],
         hash_algorithm: HashAlgorithm | None = None,
-    ) -> nw.LazyFrame:
+    ) -> nw.LazyFrame[Any]:
         """Calculate data_version column from joined upstream data.
 
         Computes a Merkle tree hash for each sample by:

--- a/src/metaxy/data_versioning/calculators/duckdb.py
+++ b/src/metaxy/data_versioning/calculators/duckdb.py
@@ -3,6 +3,7 @@
 This calculator extends IbisDataVersionCalculator to handle DuckDB-specific
 extension loading (e.g., hashfuncs for xxHash support).
 """
+# pyright: reportImportCycles=false
 
 from typing import TYPE_CHECKING
 
@@ -13,7 +14,9 @@ if TYPE_CHECKING:
     import ibis
 
     from metaxy.data_versioning.calculators.ibis import HashSQLGenerator
-    from metaxy.metadata_store.duckdb import ExtensionSpec
+    from metaxy.metadata_store.duckdb import (
+        ExtensionSpec,  # pyright: ignore[reportImportCycles]
+    )
 
 
 class DuckDBDataVersionCalculator(IbisDataVersionCalculator):

--- a/src/metaxy/data_versioning/calculators/ibis.py
+++ b/src/metaxy/data_versioning/calculators/ibis.py
@@ -4,7 +4,7 @@ This calculator uses Ibis to generate backend-specific SQL for hash computation,
 executing entirely in the database without pulling data into memory.
 """
 
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 
 import narwhals as nw
 
@@ -91,12 +91,12 @@ class IbisDataVersionCalculator(DataVersionCalculator):
 
     def calculate_data_versions(
         self,
-        joined_upstream: nw.LazyFrame,
+        joined_upstream: nw.LazyFrame[Any],
         feature_spec: "FeatureSpec",
         feature_plan: "FeaturePlan",
         upstream_column_mapping: dict[str, str],
         hash_algorithm: HashAlgorithm | None = None,
-    ) -> nw.LazyFrame:
+    ) -> nw.LazyFrame[Any]:
         """Calculate data_version using SQL hash functions.
 
         Args:
@@ -188,7 +188,7 @@ class IbisDataVersionCalculator(DataVersionCalculator):
             # Concatenate all components with separator
             concat_expr = components[0]
             for component in components[1:]:
-                concat_expr = concat_expr.concat(ibis.literal("|")).concat(component)  # type: ignore[attr-defined]
+                concat_expr = concat_expr.concat(ibis.literal("|")).concat(component)  # pyright: ignore[reportAttributeAccessIssue]
 
             # Store concat column for this field
             concat_col_name = f"__concat_{field_key_str}"
@@ -199,7 +199,7 @@ class IbisDataVersionCalculator(DataVersionCalculator):
         hash_sql = hash_sql_gen(ibis_table, concat_columns)
 
         # Execute SQL to get table with hash columns
-        result_table = self._backend.sql(hash_sql)  # type: ignore[attr-defined]
+        result_table = self._backend.sql(hash_sql)  # pyright: ignore[reportAttributeAccessIssue]
 
         # Build data_version struct from hash columns
         hash_col_names = [f"__hash_{k}" for k in concat_columns.keys()]

--- a/src/metaxy/data_versioning/calculators/polars.py
+++ b/src/metaxy/data_versioning/calculators/polars.py
@@ -1,7 +1,7 @@
 """Polars implementation of data version calculator."""
 
 from collections.abc import Callable
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import narwhals as nw
 import polars as pl
@@ -25,11 +25,11 @@ class PolarsDataVersionCalculator(DataVersionCalculator):
 
     # Map HashAlgorithm enum to polars-hash functions
     _HASH_FUNCTION_MAP: dict[HashAlgorithm, Callable[[pl.Expr], pl.Expr]] = {
-        HashAlgorithm.XXHASH64: lambda expr: expr.nchash.xxhash64(),  # type: ignore[attr-defined]
-        HashAlgorithm.XXHASH32: lambda expr: expr.nchash.xxhash32(),  # type: ignore[attr-defined]
-        HashAlgorithm.WYHASH: lambda expr: expr.nchash.wyhash(),  # type: ignore[attr-defined]
-        HashAlgorithm.SHA256: lambda expr: expr.chash.sha2_256(),  # type: ignore[attr-defined]
-        HashAlgorithm.MD5: lambda expr: expr.nchash.md5(),  # type: ignore[attr-defined]
+        HashAlgorithm.XXHASH64: lambda expr: expr.nchash.xxhash64(),  # pyright: ignore[reportAttributeAccessIssue]
+        HashAlgorithm.XXHASH32: lambda expr: expr.nchash.xxhash32(),  # pyright: ignore[reportAttributeAccessIssue]
+        HashAlgorithm.WYHASH: lambda expr: expr.nchash.wyhash(),  # pyright: ignore[reportAttributeAccessIssue]
+        HashAlgorithm.SHA256: lambda expr: expr.chash.sha2_256(),  # pyright: ignore[reportAttributeAccessIssue]
+        HashAlgorithm.MD5: lambda expr: expr.nchash.md5(),  # pyright: ignore[reportAttributeAccessIssue]
     }
 
     @property
@@ -44,12 +44,12 @@ class PolarsDataVersionCalculator(DataVersionCalculator):
 
     def calculate_data_versions(
         self,
-        joined_upstream: nw.LazyFrame,
+        joined_upstream: nw.LazyFrame[Any],
         feature_spec: "FeatureSpec",
         feature_plan: "FeaturePlan",
         upstream_column_mapping: dict[str, str],
         hash_algorithm: HashAlgorithm | None = None,
-    ) -> nw.LazyFrame:
+    ) -> nw.LazyFrame[Any]:
         """Calculate data_version using polars-hash.
 
         Args:

--- a/src/metaxy/data_versioning/diff/base.py
+++ b/src/metaxy/data_versioning/diff/base.py
@@ -1,10 +1,12 @@
 """Abstract base class for metadata diff resolvers."""
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
+
+import narwhals as nw
 
 if TYPE_CHECKING:
-    import narwhals as nw
+    pass
 
 
 class LazyDiffResult(NamedTuple):
@@ -36,9 +38,9 @@ class LazyDiffResult(NamedTuple):
         depending on what was passed to resolve_update() via align_upstream_metadata.
     """
 
-    added: "nw.LazyFrame"
-    changed: "nw.LazyFrame"
-    removed: "nw.LazyFrame"
+    added: nw.LazyFrame[Any]
+    changed: nw.LazyFrame[Any]
+    removed: nw.LazyFrame[Any]
 
     def collect(self) -> "DiffResult":
         """Materialize all lazy frames to create a DiffResult.
@@ -76,9 +78,9 @@ class DiffResult(NamedTuple):
         depending on what was passed to resolve_update() via align_upstream_metadata.
     """
 
-    added: "nw.DataFrame"
-    changed: "nw.DataFrame"
-    removed: "nw.DataFrame"
+    added: nw.DataFrame[Any]
+    changed: nw.DataFrame[Any]
+    removed: nw.DataFrame[Any]
 
 
 class MetadataDiffResolver(ABC):
@@ -113,8 +115,8 @@ class MetadataDiffResolver(ABC):
     @abstractmethod
     def find_changes(
         self,
-        target_versions: "nw.LazyFrame",
-        current_metadata: "nw.LazyFrame | None",
+        target_versions: nw.LazyFrame[Any],
+        current_metadata: nw.LazyFrame[Any] | None,
     ) -> LazyDiffResult:
         """Find all changes between target and current metadata.
 

--- a/src/metaxy/data_versioning/diff/narwhals.py
+++ b/src/metaxy/data_versioning/diff/narwhals.py
@@ -3,7 +3,7 @@
 Unified diff resolver that works with any backend (Polars, Ibis/SQL) through Narwhals.
 """
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import narwhals as nw
 
@@ -34,8 +34,8 @@ class NarwhalsDiffResolver(MetadataDiffResolver):
 
     def find_changes(
         self,
-        target_versions: nw.LazyFrame,
-        current_metadata: nw.LazyFrame | None,
+        target_versions: nw.LazyFrame[Any],
+        current_metadata: nw.LazyFrame[Any] | None,
     ) -> LazyDiffResult:
         """Find all changes between target and current.
 

--- a/src/metaxy/data_versioning/joiners/base.py
+++ b/src/metaxy/data_versioning/joiners/base.py
@@ -1,7 +1,7 @@
 """Abstract base class for upstream joiners."""
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import narwhals as nw
 
@@ -31,10 +31,10 @@ class UpstreamJoiner(ABC):
     @abstractmethod
     def join_upstream(
         self,
-        upstream_refs: dict[str, nw.LazyFrame],
+        upstream_refs: dict[str, nw.LazyFrame[Any]],
         feature_spec: "FeatureSpec",
         feature_plan: "FeaturePlan",
-    ) -> tuple[nw.LazyFrame, dict[str, str]]:
+    ) -> tuple[nw.LazyFrame[Any], dict[str, str]]:
         """Join all upstream features together.
 
         Joins upstream feature metadata on sample_id to create a unified reference

--- a/src/metaxy/data_versioning/joiners/narwhals.py
+++ b/src/metaxy/data_versioning/joiners/narwhals.py
@@ -3,7 +3,7 @@
 Unified joiner that works with any backend (Polars, Ibis/SQL) through Narwhals.
 """
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import narwhals as nw
 
@@ -34,10 +34,10 @@ class NarwhalsJoiner(UpstreamJoiner):
 
     def join_upstream(
         self,
-        upstream_refs: dict[str, nw.LazyFrame],
+        upstream_refs: dict[str, nw.LazyFrame[Any]],
         feature_spec: "FeatureSpec",
         feature_plan: "FeaturePlan",
-    ) -> tuple[nw.LazyFrame, dict[str, str]]:
+    ) -> tuple[nw.LazyFrame[Any], dict[str, str]]:
         """Join upstream Narwhals LazyFrames together.
 
         Args:

--- a/src/metaxy/metadata_store/base.py
+++ b/src/metaxy/metadata_store/base.py
@@ -7,7 +7,7 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, TypeGuard, overload
+from typing import TYPE_CHECKING, Any, Literal, TypeGuard, overload
 
 import narwhals as nw
 import polars as pl
@@ -405,7 +405,7 @@ class MetadataStore(ABC):
     def write_metadata(
         self,
         feature: FeatureKey | type[Feature],
-        df: nw.DataFrame | pl.DataFrame,
+        df: nw.DataFrame[Any] | pl.DataFrame,
     ) -> None:
         """
         Write metadata for a feature (immutable, append-only).
@@ -653,7 +653,7 @@ class MetadataStore(ABC):
         feature_version: str | None = None,
         filters: list[nw.Expr] | None = None,
         columns: list[str] | None = None,
-    ) -> nw.LazyFrame | None:
+    ) -> nw.LazyFrame[Any] | None:
         """
         Read metadata from THIS store only (no fallback).
 
@@ -678,7 +678,7 @@ class MetadataStore(ABC):
         columns: list[str] | None = None,
         allow_fallback: bool = True,
         current_only: bool = True,
-    ) -> nw.LazyFrame:
+    ) -> nw.LazyFrame[Any]:
         """
         Read metadata with optional fallback to upstream stores.
 
@@ -1260,7 +1260,7 @@ class MetadataStore(ABC):
         *,
         allow_fallback: bool = True,
         current_only: bool = True,
-    ) -> dict[str, nw.LazyFrame]:
+    ) -> dict[str, nw.LazyFrame[Any]]:
         """
         Read all upstream dependencies for a feature/field.
 
@@ -1364,7 +1364,7 @@ class MetadataStore(ABC):
         feature: type[Feature],
         *,
         samples: nw.DataFrame[Any] | nw.LazyFrame[Any] | None = None,
-        lazy: bool = False,
+        lazy: Literal[False] = False,
         **kwargs,
     ) -> DiffResult: ...
 
@@ -1374,7 +1374,7 @@ class MetadataStore(ABC):
         feature: type[Feature],
         *,
         samples: nw.DataFrame[Any] | nw.LazyFrame[Any] | None = None,
-        lazy: bool = True,
+        lazy: Literal[True],
         **kwargs,
     ) -> LazyDiffResult: ...
 
@@ -1598,7 +1598,7 @@ class MetadataStore(ABC):
             )
 
         # Load upstream as Narwhals LazyFrames (stays lazy in SQL for native stores)
-        upstream_refs: dict[str, nw.LazyFrame] = {}
+        upstream_refs: dict[str, nw.LazyFrame[Any]] = {}
         for upstream_spec in plan.deps or []:
             upstream_key_str = (
                 upstream_spec.key.to_string()

--- a/src/metaxy/metadata_store/clickhouse.py
+++ b/src/metaxy/metadata_store/clickhouse.py
@@ -1,6 +1,6 @@
 """ClickHouse metadata store - thin wrapper around IbisMetadataStore."""
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from metaxy.data_versioning.calculators.ibis import HashSQLGenerator
@@ -54,7 +54,7 @@ class ClickHouseMetadataStore(IbisMetadataStore):
         self,
         connection_string: str | None = None,
         *,
-        connection_params: dict | None = None,
+        connection_params: dict[str, Any] | None = None,
         fallback_stores: list["MetadataStore"] | None = None,
         **kwargs,
     ):

--- a/src/metaxy/metadata_store/memory.py
+++ b/src/metaxy/metadata_store/memory.py
@@ -1,5 +1,7 @@
 """In-memory metadata store implementation."""
 
+from typing import Any
+
 import narwhals as nw
 import polars as pl
 
@@ -117,7 +119,7 @@ class InMemoryMetadataStore(MetadataStore):
         feature_version: str | None = None,
         filters: list[nw.Expr] | None = None,
         columns: list[str] | None = None,
-    ) -> nw.LazyFrame | None:
+    ) -> nw.LazyFrame[Any] | None:
         """
         Read metadata from this store only (no fallback).
 

--- a/src/metaxy/migrations/executor.py
+++ b/src/metaxy/migrations/executor.py
@@ -358,7 +358,7 @@ def _register_operation(
         {
             "migration_id": [migration_id],
             "operation_id": [operation.id],
-            "operation_type": [operation.type],  # type: ignore[attr-defined]
+            "operation_type": [operation.type],  # pyright: ignore[reportAttributeAccessIssue]
             "feature_key": [FeatureKey(operation.feature_key).to_string()],
             "expected_steps": [expected_steps_json],
             "operation_config_hash": [operation.operation_config_hash()],

--- a/src/metaxy/migrations/generator.py
+++ b/src/metaxy/migrations/generator.py
@@ -149,6 +149,9 @@ def generate_migration(
     # Step 3: Detect changes by comparing snapshot_ids directly
     # We don't reconstruct from_graph - just compare snapshot_ids from the store
     # This avoids issues with stale cached imports when files have changed
+    assert from_snapshot_id is not None, "from_snapshot_id must be set by now"
+    assert to_snapshot_id is not None, "to_snapshot_id must be set by now"
+
     root_operations = detect_feature_changes(
         store,
         from_snapshot_id,

--- a/src/metaxy/migrations/models.py
+++ b/src/metaxy/migrations/models.py
@@ -1,7 +1,7 @@
 """Data models for migration system."""
 
 from datetime import datetime
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import pydantic
 
@@ -33,7 +33,7 @@ def _load_operation_class(class_path: str) -> type:
     return cls
 
 
-def _register_operation_classes(operations_data: list[dict]) -> None:
+def _register_operation_classes(operations_data: list[dict[str, Any]]) -> None:
     """Register all operation classes for Pydantic discriminated union.
 
     Dynamically imports user-defined operation classes so Pydantic can
@@ -87,7 +87,7 @@ class Migration(pydantic.BaseModel):
 
     # Operations as list of dicts - will be validated/loaded dynamically
     # Can't use Union with discriminator because we support user-defined subclasses
-    operations: list[dict]
+    operations: list[dict[str, Any]]
 
     def get_operations(self) -> list["BaseOperation"]:
         """Parse operations into BaseOperation objects.

--- a/src/metaxy/migrations/ops.py
+++ b/src/metaxy/migrations/ops.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from metaxy.metadata_store.base import MetadataStore
 
 
-class BaseOperation(pydantic.BaseModel, ABC):
+class BaseOperation(pydantic.BaseModel, ABC):  # pyright: ignore[reportUnsafeMultipleInheritance]
     """Base class for all migration operations.
 
     All operations must have:

--- a/src/metaxy/models/feature.py
+++ b/src/metaxy/models/feature.py
@@ -231,7 +231,7 @@ class FeatureGraph:
             hasher.update(self.get_feature_version(feature_key).encode("utf-8"))
         return hasher.hexdigest()
 
-    def to_snapshot(self) -> dict[str, dict]:
+    def to_snapshot(self) -> dict[str, dict[str, Any]]:
         """Serialize graph to snapshot format.
 
         Returns a dict mapping feature_key (string) to feature data dict,
@@ -272,7 +272,7 @@ class FeatureGraph:
     @classmethod
     def from_snapshot(
         cls,
-        snapshot_data: dict[str, dict],
+        snapshot_data: dict[str, dict[str, Any]],
         *,
         class_path_overrides: dict[str, str] | None = None,
         force_reload: bool = False,
@@ -493,7 +493,7 @@ class _FeatureMeta(ModelMetaclass):
         *,
         spec: FeatureSpec | None,
         **kwargs,
-    ) -> type[Self]:
+    ) -> type[Self]:  # pyright: ignore[reportGeneralTypeIssues]
         new_cls = super().__new__(cls, cls_name, bases, namespace)
 
         if spec:
@@ -661,8 +661,8 @@ class Feature(FrozenBaseModel, metaclass=_FeatureMeta, spec=None):
     def join_upstream_metadata(
         cls,
         joiner: "UpstreamJoiner",
-        upstream_refs: dict[str, "nw.LazyFrame"],
-    ) -> tuple["nw.LazyFrame", dict[str, str]]:
+        upstream_refs: dict[str, "nw.LazyFrame[Any]"],
+    ) -> tuple["nw.LazyFrame[Any]", dict[str, str]]:
         """Join upstream feature metadata.
 
         Override for custom join logic (1:many, different keys, filtering, etc.).
@@ -702,8 +702,8 @@ class Feature(FrozenBaseModel, metaclass=_FeatureMeta, spec=None):
     def resolve_data_version_diff(
         cls,
         diff_resolver: "MetadataDiffResolver",
-        target_versions: "nw.LazyFrame",
-        current_metadata: "nw.LazyFrame | None",
+        target_versions: "nw.LazyFrame[Any]",
+        current_metadata: "nw.LazyFrame[Any] | None",
         *,
         lazy: bool = False,
     ) -> "DiffResult | LazyDiffResult":

--- a/src/metaxy/models/types.py
+++ b/src/metaxy/models/types.py
@@ -7,7 +7,7 @@ FEATURE_KEY_SEPARATOR = "/"
 FIELD_KEY_SEPARATOR = "/"
 
 
-class FeatureKey(list):  # type: ignore[type-arg]
+class FeatureKey(list):  # pyright: ignore[reportMissingTypeArgument]
     """
     Feature key as a list of strings.
 
@@ -42,7 +42,7 @@ class FeatureKey(list):  # type: ignore[type-arg]
     def __repr__(self) -> str:
         return self.to_string()
 
-    def __hash__(self):
+    def __hash__(self):  # pyright: ignore[reportIncompatibleVariableOverride]
         return hash(tuple(self))
 
     def __eq__(self, other):
@@ -78,7 +78,7 @@ class FeatureKey(list):  # type: ignore[type-arg]
         return cls(validated)
 
 
-class FieldKey(list):
+class FieldKey(list):  # pyright: ignore[reportMissingTypeArgument]
     """
     Field key as a list of strings.
 
@@ -113,7 +113,7 @@ class FieldKey(list):
     def __repr__(self) -> str:
         return self.to_string()
 
-    def __hash__(self):
+    def __hash__(self):  # pyright: ignore[reportIncompatibleVariableOverride]
         return hash(tuple(self))
 
     def __eq__(self, other):


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed basedpyright errors across src/metaxy and enabled strict type checking to keep our Narwhals interfaces and metadata workflows type-safe. Also added pyright config, a typecheck task, and small guards to prevent runtime issues.

- **Refactors**
  - Annotated Narwhals frames with generics (nw.LazyFrame[Any], nw.DataFrame[Any]) and tightened dict types.
  - Updated signatures in calculators, joiners, diff resolvers, stores, and utils to use precise types and Literal overloads for resolve_update.
  - Added targeted pyright ignores for import cycles and third-party attribute access (ibis, polars hash, pydantic inheritance).
  - Added safety asserts in migrations/generator for snapshot IDs.
  - Introduced [tool.pyright] config and a just typecheck task; updated CLAUDE.md to use basedpyright.
  - Added agent docs (.claude/agents/manager.md, task-worker.md) and Narwhals SKILL tips for testing and backend checks.

<!-- End of auto-generated description by cubic. -->

