### PR TITLE
fix basedpyright errors in tests

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -5,7 +5,7 @@
 {
   "languages": {
     "Python": {
-      "language_servers": ["pyrefly", "ruff", "!pyright", "!pylsp"]
+      "language_servers": ["basedpyright", "ruff", "!pyrefly", "!pyright", "!pylsp"]
     }
   }
 }

--- a/examples/src/examples/recompute/compute_parent.py
+++ b/examples/src/examples/recompute/compute_parent.py
@@ -34,7 +34,7 @@ with MetaxyConfig.load().get_store() as store:
     # Check if metadata already exists for current feature_version (avoid duplicates)
     try:
         existing = store.read_metadata(ParentFeature, current_only=True)
-        if existing.collect().height > 0:
+        if existing.collect().shape[0] > 0:
             print(
                 f"Metadata already exists for feature {parent_key} (feature_version: {ParentFeature.feature_version()[:16]}...)"
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,8 @@ reportAny = "none"
 reportExplicitAny = "none"
 include = [
     "src/metaxy",
+    "tests",
+    "examples",
 ]
 exclude = [
     "**/node_modules",

--- a/tests/__snapshots__/test_data_versioning_components.ambr
+++ b/tests/__snapshots__/test_data_versioning_components.ambr
@@ -1,0 +1,120 @@
+# serializer version: 1
+# name: test_code_version_changes_snapshots
+  dict({
+    'code_v1': '10167418423534341111',
+    'code_v10': '6407017139336446128',
+    'code_v2': '17724424375143333935',
+    'code_v5': '1603558698768056863',
+  })
+# ---
+# name: test_diff_result_snapshots
+  dict({
+    'added_ids': list([
+      4,
+      5,
+    ]),
+    'changed_ids': list([
+      2,
+    ]),
+    'removed_ids': list([
+      6,
+    ]),
+  })
+# ---
+# name: test_hash_output_snapshots
+  list([
+    '16401394179783035154',
+    '1766329184577422370',
+    '7930906766220635975',
+  ])
+# ---
+# name: test_multi_field_hash_snapshots
+  dict({
+    'analysis': '7182592377912622692',
+    'fusion': '15253767068807735795',
+  })
+# ---
+# name: test_multi_upstream_multi_field_snapshots[HashAlgorithm.SHA256]
+  list([
+    dict({
+      'analysis': '2f84e757b1addd884db7365ed37557a320ab69dbd4fe09975f509c07b336a43f',
+      'fusion': 'ad303eba05da467ded17cc6eaf72d16dbc40c338c802a0911a4aa229d7bdd482',
+      'sample_id': 1,
+    }),
+    dict({
+      'analysis': '39cd90847cb18c3f7c31a73be7f6d269364e8263dce2a9d923144489a78338c6',
+      'fusion': '5dba65c3be22714cfaf969bcd63c4df6d329761b62f01e430316bde62b2ea53a',
+      'sample_id': 2,
+    }),
+  ])
+# ---
+# name: test_multi_upstream_multi_field_snapshots[HashAlgorithm.WYHASH]
+  list([
+    dict({
+      'analysis': '13727348181400861260',
+      'fusion': '370342096193421791',
+      'sample_id': 1,
+    }),
+    dict({
+      'analysis': '5047585375639731387',
+      'fusion': '1768440773501995386',
+      'sample_id': 2,
+    }),
+  ])
+# ---
+# name: test_multi_upstream_multi_field_snapshots[HashAlgorithm.XXHASH64]
+  list([
+    dict({
+      'analysis': '11444342552948413717',
+      'fusion': '3008611161107019102',
+      'sample_id': 1,
+    }),
+    dict({
+      'analysis': '10628887372866074486',
+      'fusion': '14013057675311053626',
+      'sample_id': 2,
+    }),
+  ])
+# ---
+# name: test_single_upstream_single_field_snapshots[HashAlgorithm.MD5]
+  list([
+    '6adfd76497c9621a5a70cc6f0e5988c5',
+    'af599634188a17615f28c1f7ac69ef3d',
+    '8c4021310e97f146994c5dc176839a1c',
+  ])
+# ---
+# name: test_single_upstream_single_field_snapshots[HashAlgorithm.SHA256]
+  list([
+    '2ef4ffd693f92e72447dc47a09ecdf25c1c6f18acf88715aeb5472937ae19419',
+    'ba08ef288e228285b68179cd8bb18a3a1e0180c058232182c00b12e5e1e94cee',
+    'dc371b4ee27230a953f1bd87bb895edfdb12f3cd79b7668de9eed57f81e349c2',
+  ])
+# ---
+# name: test_single_upstream_single_field_snapshots[HashAlgorithm.WYHASH]
+  list([
+    '13136332531082150110',
+    '13387170137092530908',
+    '3652911779766440235',
+  ])
+# ---
+# name: test_single_upstream_single_field_snapshots[HashAlgorithm.XXHASH32]
+  list([
+    '4058237226',
+    '1188157467',
+    '2632372314',
+  ])
+# ---
+# name: test_single_upstream_single_field_snapshots[HashAlgorithm.XXHASH64]
+  list([
+    '10823186911388391974',
+    '18274202742589849974',
+    '10301923923001759408',
+  ])
+# ---
+# name: test_upstream_data_changes_snapshots
+  dict({
+    'different': '13001925192780457010',
+    'modified': '6049362021993965297',
+    'original': '8924297014343013831',
+  })
+# ---

--- a/tests/__snapshots__/test_feature_data_version.ambr
+++ b/tests/__snapshots__/test_feature_data_version.ambr
@@ -1,0 +1,102 @@
+# serializer version: 1
+# name: test_code_version_changes_propagate
+  dict({
+    'base': dict({
+      'data': '4c4a9f5d680468f38542e678b9fe8ef73c45714ae2bad795f008364f2e883dbd',
+    }),
+    'derived': dict({
+      'processed': '0589e503fa9229073a90ff01c5588a34557b02f3bff0d9fc28e6bc616f64f1f0',
+    }),
+  })
+# ---
+# name: test_complex_multi_level_graph
+  dict({
+    'analysis': dict({
+      'full_analysis': 'cf80aff98c9f876b15753f1375f86162eeff225c95c688fbc735573615503d97',
+      'visual_metadata': '3191f125ed53b813cad8c458ff1a81e42c803e9ca272bf28a94b18d035adecd7',
+    }),
+    'processed_video': dict({
+      'enhanced_frames': '909fa8c63882392a163500b3bcb426d81875d465487a92d8fb3dd08deb36c177',
+      'normalized_audio': '5e4947940ae343feec23dc0a68e1f83a5f82662e46996892dba89cce98a62d94',
+    }),
+    'raw_metadata': dict({
+      'info': '762fd106b00226d3ba49ce0f4204f68a0a4cf63fe84a003f544b3d4e1f6cfd8e',
+    }),
+    'raw_video': dict({
+      'audio': 'aa2eb77108681306dce586821337565d86a376c5458a21e78f070340cce423be',
+      'frames': '3da1d9817abfaf6a7cd936a27654d4b380f4e2b0575e1deb5ddb572f62bd9fd7',
+    }),
+  })
+# ---
+# name: test_diamond_dependency_graph
+  dict({
+    'branch_left': dict({
+      'left_processed': '117cbeba8f64bbe8d621c6e7c18b2d2a06b892a49e8f3f9d99908d6fa738aaf5',
+    }),
+    'branch_right': dict({
+      'right_processed': '189ab2150cf910aa890d12b3c0d0a8c44795d3db5c950c56ad4450a4a7fd2a57',
+    }),
+    'merged': dict({
+      'fusion': 'f91e2e67cad0a4c2f8cf18ad4152f7197f5208044698d388b323063441af2df3',
+    }),
+    'root': dict({
+      'data': '27a4d7603b466599a64a16d036d0e277a13705ea38dbd96619bcdfec54506cb5',
+    }),
+  })
+# ---
+# name: test_feature_with_multiple_fields
+  dict({
+    'audio': '4c0dc244aa810846c4211759251a117b83da98c455d897ab74f02c3c149cfbef',
+    'frames': '3081ee93fda4b4a8388d60f090fd202ec8510e88aceb4b9727ee83fd5d29aabb',
+    'metadata': '0f1afba6adb09746506b1d90468a1955a90a7949ee9772034c31bb38adcbd5e0',
+  })
+# ---
+# name: test_linear_dependency_chain
+  dict({
+    'a': dict({
+      'raw': '520c9eecbe731350e126e2494c9020868232538030ad1c2e879c7fe31b6f17cd',
+    }),
+    'b': dict({
+      'processed': '42f231657d815ab66825b2f91293c566fed03be65f184ba8978f9fe69c8654df',
+    }),
+    'c': dict({
+      'final': 'ce8b78182f2440e685aa0aed0eabce2f9ecd9efc6cc73d303ed00ea7c095380a',
+    }),
+  })
+# ---
+# name: test_multiple_fields_different_deps
+  dict({
+    'x': dict({
+      'x1': '81937486de8791d1683829da57b7d3550d62ce1a659a8fb1d8a22afa1420913a',
+      'x2': 'a11b3accfe12d4a755228c3986399c8592a75ee658884242196e07232477cc31',
+    }),
+    'y': dict({
+      'y1': '9b8521b33ba438c3d440bde17454c29e4c53cc96c123925d730c06857921e10b',
+      'y2': '68ea5edf063a5c158c5456a112751697e3582e4ba187603c1aba57e1a7b59102',
+    }),
+    'z': dict({
+      'z1': '60d0ed1bf0c8abd35051d6febcdb78fa4d027dcb32366e4c172ab1a1b9498f08',
+      'z2': '2b3f131b4e17ab4c2cc1eff3707d2ae979af77993ed590b0b221a8a92e6bb0e2',
+      'z3': '7482c990ae86e7360f098cb3e0fcffa6d420e894f4a06037af20c729c4764faf',
+    }),
+  })
+# ---
+# name: test_single_feature_data_version
+  dict({
+    'default': '8aa2ac16379005571ba10a1d73d038001526faf4b0abc62db9dd2f3c8afeea6c',
+  })
+# ---
+# name: test_specific_field_dependencies
+  dict({
+    'multi': dict({
+      'audio': 'a0adde3c223350027245d9b1cd5d9137befc0b833ef94ac857df431cf553ab5d',
+      'frames': 'c1cd5f751322d6d8910b33f91236779fcf74efdd64824a371366088be87b26b9',
+      'text': '3b03a87362c4680790dbdf1d7fbffd08e78219979af0816196b64d827e0f46c8',
+    }),
+    'selective': dict({
+      'audio_only': 'bb5ec0041d2e41fa8f0e6c4967f42a8ffd9d336987092c995a2cfae904118286',
+      'mixed': '1e9b5457f80a747f4eab7c77ff20cf8b206f724ddaea7f6fa1b6f7c2b96bd9a6',
+      'visual': '30286c9ae703eab9c9af38debc9a3078e4c282ff731af603172cab4fb58d7a1a',
+    }),
+  })
+# ---

--- a/tests/__snapshots__/test_feature_version.ambr
+++ b/tests/__snapshots__/test_feature_version.ambr
@@ -1,0 +1,25 @@
+# serializer version: 1
+# name: test_feature_version_changes_with_code_version
+  dict({
+    'v1': '91f7c94e73755d022c1f24a3c1f9f782a932d816549b9551241f4ccc0761a301',
+    'v2': '08e434bc19a18ffead69a715c270b45efc13402131f47780d76dc85577f7cd08',
+  })
+# ---
+# name: test_feature_version_changes_with_dependencies
+  dict({
+    'no_deps': '4ff4cc0d87a5a834f10c99562e33e2c15edafa809d32235472f80014ad748cdb',
+    'with_deps': 'f866c09ad015e91622495a5778daebec1cc4540c7af50e001a3f488d779f99d1',
+  })
+# ---
+# name: test_feature_version_deterministic
+  '3731d5aef6d53cfda612433171c52401406f94fd1c3482e7754ef2b24d85d170'
+# ---
+# name: test_feature_version_multi_field
+  'c0fac23533a31dcb0e2dcba4372faf4c922d4af8c52b1bbca6bccf25f16f54fd'
+# ---
+# name: test_feature_version_with_field_deps
+  dict({
+    'no_field_deps': '0c79595b09d7b13c3053e59ffd4463acebbcb2fb87c9542dc89894b811c6bc3a',
+    'with_field_deps': '0503b693b39cb50aae61d1644aaa0a18c960a40c976042fd6d93fac51c292c1f',
+  })
+# ---

--- a/tests/__snapshots__/test_migrations.ambr
+++ b/tests/__snapshots__/test_migrations.ambr
@@ -8,6 +8,55 @@
     'operation_count': 2,
   })
 # ---
+# name: test_feature_versions_snapshot
+  dict({
+    'downstream_v1': '675dfe2e05602e8cc9bf7e06a323024b74658f1bee5cc30e28138dfd75cefd4c',
+    'downstream_v2': 'd012d1fa4c2bce96f6266089e29fa86c278f5a3d17c8fefcfc36d819eb20d635',
+    'upstream_v1': '575a5b1721e400a133b041ca4c332316a5fbb13e35dc51de164d65336b1c80d6',
+    'upstream_v2': '4c01d97517a1cb8dd38c48de02b1976ea738a96c690209e3795ed1a7f92a8e04',
+  })
+# ---
+# name: test_generated_migration_yaml_snapshot
+  dict({
+    'operations': list([
+      dict({
+        'feature_key': list([
+          'test_migrations',
+          'downstream',
+        ]),
+        'operation_id': 'reconcile_test_migrations/downstream',
+        'reason': 'TODO: Describe what changed and why',
+      }),
+      dict({
+        'feature_key': list([
+          'test_migrations',
+          'upstream',
+        ]),
+        'operation_id': 'reconcile_test_migrations/upstream',
+        'reason': 'TODO: Describe what changed and why',
+      }),
+    ]),
+    'version': 1,
+  })
+# ---
+# name: test_migration_result_snapshots
+  dict({
+    'affected_features': list([
+    ]),
+    'has_errors': True,
+    'operations_applied': 0,
+    'operations_failed': 1,
+    'status': 'failed',
+  })
+# ---
+# name: test_migration_vs_recompute_comparison
+  dict({
+    'initial_data_versions_count': 3,
+    'migrated_data_versions_count': 6,
+    'migration_skipped_computation': True,
+    'migration_updated_hashes': True,
+  })
+# ---
 # name: test_record_feature_graph_snapshot
   '48fec02b57390ae1fcd5c825ad681f4766689922c3c33660c46c430dad29d5b6'
 # ---

--- a/tests/cli/__snapshots__/test_cli.ambr
+++ b/tests/cli/__snapshots__/test_cli.ambr
@@ -1,0 +1,25 @@
+# serializer version: 1
+# name: test_migrations_apply_dry_run
+  '''
+  === DRY RUN MODE ===
+  
+  Applying 1 migration(s) to reach 'test_migration':
+  
+  ⊘ test_migration (already applied)
+  
+  Summary:
+    Applied: 0
+    Skipped: 1
+    Failed: 0
+  '''
+# ---
+# name: test_migrations_generate_no_changes
+  '''
+  From: latest snapshot 21b7b49f704b703f65231d951bf97b4d11df239fdb6f32505bb5381fc2c00c65...
+  To: current active graph (snapshot 21b7b49f704b703f65231d951bf97b4d11df239fdb6f32505bb5381fc2c00c65... already recorded)
+  No feature changes detected. All features up to date!
+  '''
+# ---
+# name: test_migrations_status_empty
+  'No migrations found.'
+# ---

--- a/tests/cli/__snapshots__/test_cli_graph.ambr
+++ b/tests/cli/__snapshots__/test_cli_graph.ambr
@@ -1,0 +1,23 @@
+# serializer version: 1
+# name: test_graph_render_graphviz_format
+  '''
+  strict digraph {
+      rankdir=TB;
+      label="Graph (snapshot: d49e39c7)";
+      labelloc=t;
+      fontsize=14;
+      fontname=helvetica;
+  
+      "examples/child" ;
+      "examples/parent" ;
+  
+      "examples/parent" -> "examples/child";
+  
+      "examples/child::predictions" ;
+      "examples/child" -> "examples/child::predictions" ;
+      "examples/parent::embeddings" ;
+      "examples/parent" -> "examples/parent::embeddings" ;
+  }
+  
+  '''
+# ---

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -183,8 +183,6 @@ config.database = "{db_path}"
                 DataVersionReconciliation(
                     id="test_op",
                     feature_key=["test_cli", "feature"],
-                    from_="abc123",
-                    to="def456",
                     reason="Test migration",
                 ).model_dump(by_alias=True)
             ],

--- a/tests/cli/test_cli_e2e.py
+++ b/tests/cli/test_cli_e2e.py
@@ -220,7 +220,7 @@ class VideoProcessing(Feature, spec=FeatureSpec(
             "operations": [
                 {
                     "id": op.id,
-                    "type": op.type,  # type: ignore[attr-defined]
+                    "type": op.type,  # pyright: ignore[reportAttributeAccessIssue]
                     "feature_key": op.feature_key,
                     "reason": op.reason,
                 }

--- a/tests/metadata_stores/__snapshots__/test_fallback_stores.ambr
+++ b/tests/metadata_stores/__snapshots__/test_fallback_stores.ambr
@@ -1,0 +1,265 @@
+# serializer version: 1
+# name: test_fallback_store_switches_to_polars_components[inmemory-duckdb-md5]
+  dict({
+    tuple(
+      'duckdb',
+      'inmemory',
+      'all_local',
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': 'cfc410b7d4428aeb47c3e69793831e1d',
+        }),
+        dict({
+          'default': '7a06ff64cf44a164b8c9032785420f9a',
+        }),
+        dict({
+          'default': '1a2984d8cbb982cd7adbf302d1fbbfb4',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      'inmemory',
+      'with_fallback',
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': 'cfc410b7d4428aeb47c3e69793831e1d',
+        }),
+        dict({
+          'default': '7a06ff64cf44a164b8c9032785420f9a',
+        }),
+        dict({
+          'default': '1a2984d8cbb982cd7adbf302d1fbbfb4',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_fallback_store_switches_to_polars_components[inmemory-duckdb-xxhash32]
+  dict({
+    tuple(
+      'duckdb',
+      'inmemory',
+      'all_local',
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '820994320',
+        }),
+        dict({
+          'default': '1359843373',
+        }),
+        dict({
+          'default': '3025128646',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      'inmemory',
+      'with_fallback',
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '820994320',
+        }),
+        dict({
+          'default': '1359843373',
+        }),
+        dict({
+          'default': '3025128646',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_fallback_store_switches_to_polars_components[inmemory-duckdb-xxhash64]
+  dict({
+    tuple(
+      'duckdb',
+      'inmemory',
+      'all_local',
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '8781274474994251810',
+        }),
+        dict({
+          'default': '2477696910468939981',
+        }),
+        dict({
+          'default': '7707417068700355918',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      'inmemory',
+      'with_fallback',
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '8781274474994251810',
+        }),
+        dict({
+          'default': '2477696910468939981',
+        }),
+        dict({
+          'default': '7707417068700355918',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_fallback_store_warning_issued[inmemory-duckdb-md5]
+  dict({
+    tuple(
+      'duckdb',
+      'inmemory',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': 'cfc410b7d4428aeb47c3e69793831e1d',
+        }),
+        dict({
+          'default': '7a06ff64cf44a164b8c9032785420f9a',
+        }),
+        dict({
+          'default': '1a2984d8cbb982cd7adbf302d1fbbfb4',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      'inmemory',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': 'cfc410b7d4428aeb47c3e69793831e1d',
+        }),
+        dict({
+          'default': '7a06ff64cf44a164b8c9032785420f9a',
+        }),
+        dict({
+          'default': '1a2984d8cbb982cd7adbf302d1fbbfb4',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_fallback_store_warning_issued[inmemory-duckdb-xxhash32]
+  dict({
+    tuple(
+      'duckdb',
+      'inmemory',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '820994320',
+        }),
+        dict({
+          'default': '1359843373',
+        }),
+        dict({
+          'default': '3025128646',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      'inmemory',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '820994320',
+        }),
+        dict({
+          'default': '1359843373',
+        }),
+        dict({
+          'default': '3025128646',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_fallback_store_warning_issued[inmemory-duckdb-xxhash64]
+  dict({
+    tuple(
+      'duckdb',
+      'inmemory',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '8781274474994251810',
+        }),
+        dict({
+          'default': '2477696910468939981',
+        }),
+        dict({
+          'default': '7707417068700355918',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      'inmemory',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '8781274474994251810',
+        }),
+        dict({
+          'default': '2477696910468939981',
+        }),
+        dict({
+          'default': '7707417068700355918',
+        }),
+      ]),
+    }),
+  })
+# ---

--- a/tests/metadata_stores/__snapshots__/test_resolve_update.ambr
+++ b/tests/metadata_stores/__snapshots__/test_resolve_update.ambr
@@ -1,0 +1,8433 @@
+# serializer version: 1
+# name: test_resolve_update_detects_changes[diamond_graph-md5]
+  dict({
+    tuple(
+      'clickhouse',
+      False,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 9,
+      'changed_sample_ids': list([
+        1,
+        1,
+        1,
+        2,
+        2,
+        2,
+        3,
+        3,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'clickhouse',
+      True,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 9,
+      'changed_sample_ids': list([
+        1,
+        1,
+        1,
+        2,
+        2,
+        2,
+        3,
+        3,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'duckdb',
+      False,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 9,
+      'changed_sample_ids': list([
+        1,
+        1,
+        1,
+        2,
+        2,
+        2,
+        3,
+        3,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'duckdb',
+      True,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 9,
+      'changed_sample_ids': list([
+        1,
+        1,
+        1,
+        2,
+        2,
+        2,
+        3,
+        3,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'inmemory',
+      False,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 9,
+      'changed_sample_ids': list([
+        1,
+        1,
+        1,
+        2,
+        2,
+        2,
+        3,
+        3,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'inmemory',
+      True,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 9,
+      'changed_sample_ids': list([
+        1,
+        1,
+        1,
+        2,
+        2,
+        2,
+        3,
+        3,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'sqlite',
+      False,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 9,
+      'changed_sample_ids': list([
+        1,
+        1,
+        1,
+        2,
+        2,
+        2,
+        3,
+        3,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'sqlite',
+      True,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 9,
+      'changed_sample_ids': list([
+        1,
+        1,
+        1,
+        2,
+        2,
+        2,
+        3,
+        3,
+        3,
+      ]),
+      'removed': 0,
+    }),
+  })
+# ---
+# name: test_resolve_update_detects_changes[diamond_graph-sha256]
+  dict({
+    tuple(
+      'inmemory',
+      False,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 9,
+      'changed_sample_ids': list([
+        1,
+        1,
+        1,
+        2,
+        2,
+        2,
+        3,
+        3,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'inmemory',
+      True,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 9,
+      'changed_sample_ids': list([
+        1,
+        1,
+        1,
+        2,
+        2,
+        2,
+        3,
+        3,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'sqlite',
+      False,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 9,
+      'changed_sample_ids': list([
+        1,
+        1,
+        1,
+        2,
+        2,
+        2,
+        3,
+        3,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'sqlite',
+      True,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 9,
+      'changed_sample_ids': list([
+        1,
+        1,
+        1,
+        2,
+        2,
+        2,
+        3,
+        3,
+        3,
+      ]),
+      'removed': 0,
+    }),
+  })
+# ---
+# name: test_resolve_update_detects_changes[diamond_graph-wyhash]
+  dict({
+    tuple(
+      'inmemory',
+      False,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 9,
+      'changed_sample_ids': list([
+        1,
+        1,
+        1,
+        2,
+        2,
+        2,
+        3,
+        3,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'inmemory',
+      True,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 9,
+      'changed_sample_ids': list([
+        1,
+        1,
+        1,
+        2,
+        2,
+        2,
+        3,
+        3,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'sqlite',
+      False,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 9,
+      'changed_sample_ids': list([
+        1,
+        1,
+        1,
+        2,
+        2,
+        2,
+        3,
+        3,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'sqlite',
+      True,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 9,
+      'changed_sample_ids': list([
+        1,
+        1,
+        1,
+        2,
+        2,
+        2,
+        3,
+        3,
+        3,
+      ]),
+      'removed': 0,
+    }),
+  })
+# ---
+# name: test_resolve_update_detects_changes[diamond_graph-xxhash32]
+  dict({
+    tuple(
+      'clickhouse',
+      False,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 9,
+      'changed_sample_ids': list([
+        1,
+        1,
+        1,
+        2,
+        2,
+        2,
+        3,
+        3,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'clickhouse',
+      True,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 9,
+      'changed_sample_ids': list([
+        1,
+        1,
+        1,
+        2,
+        2,
+        2,
+        3,
+        3,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'duckdb',
+      False,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 9,
+      'changed_sample_ids': list([
+        1,
+        1,
+        1,
+        2,
+        2,
+        2,
+        3,
+        3,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'duckdb',
+      True,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 9,
+      'changed_sample_ids': list([
+        1,
+        1,
+        1,
+        2,
+        2,
+        2,
+        3,
+        3,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'inmemory',
+      False,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 9,
+      'changed_sample_ids': list([
+        1,
+        1,
+        1,
+        2,
+        2,
+        2,
+        3,
+        3,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'inmemory',
+      True,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 9,
+      'changed_sample_ids': list([
+        1,
+        1,
+        1,
+        2,
+        2,
+        2,
+        3,
+        3,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'sqlite',
+      False,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 9,
+      'changed_sample_ids': list([
+        1,
+        1,
+        1,
+        2,
+        2,
+        2,
+        3,
+        3,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'sqlite',
+      True,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 9,
+      'changed_sample_ids': list([
+        1,
+        1,
+        1,
+        2,
+        2,
+        2,
+        3,
+        3,
+        3,
+      ]),
+      'removed': 0,
+    }),
+  })
+# ---
+# name: test_resolve_update_detects_changes[diamond_graph-xxhash64]
+  dict({
+    tuple(
+      'clickhouse',
+      False,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 9,
+      'changed_sample_ids': list([
+        1,
+        1,
+        1,
+        2,
+        2,
+        2,
+        3,
+        3,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'clickhouse',
+      True,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 9,
+      'changed_sample_ids': list([
+        1,
+        1,
+        1,
+        2,
+        2,
+        2,
+        3,
+        3,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'duckdb',
+      False,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 9,
+      'changed_sample_ids': list([
+        1,
+        1,
+        1,
+        2,
+        2,
+        2,
+        3,
+        3,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'duckdb',
+      True,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 9,
+      'changed_sample_ids': list([
+        1,
+        1,
+        1,
+        2,
+        2,
+        2,
+        3,
+        3,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'inmemory',
+      False,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 9,
+      'changed_sample_ids': list([
+        1,
+        1,
+        1,
+        2,
+        2,
+        2,
+        3,
+        3,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'inmemory',
+      True,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 9,
+      'changed_sample_ids': list([
+        1,
+        1,
+        1,
+        2,
+        2,
+        2,
+        3,
+        3,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'sqlite',
+      False,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 9,
+      'changed_sample_ids': list([
+        1,
+        1,
+        1,
+        2,
+        2,
+        2,
+        3,
+        3,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'sqlite',
+      True,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 9,
+      'changed_sample_ids': list([
+        1,
+        1,
+        1,
+        2,
+        2,
+        2,
+        3,
+        3,
+        3,
+      ]),
+      'removed': 0,
+    }),
+  })
+# ---
+# name: test_resolve_update_detects_changes[multi_field-md5]
+  dict({
+    tuple(
+      'clickhouse',
+      False,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'clickhouse',
+      True,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'duckdb',
+      False,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'duckdb',
+      True,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'inmemory',
+      False,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'inmemory',
+      True,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'sqlite',
+      False,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'sqlite',
+      True,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+  })
+# ---
+# name: test_resolve_update_detects_changes[multi_field-sha256]
+  dict({
+    tuple(
+      'inmemory',
+      False,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'inmemory',
+      True,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'sqlite',
+      False,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'sqlite',
+      True,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+  })
+# ---
+# name: test_resolve_update_detects_changes[multi_field-wyhash]
+  dict({
+    tuple(
+      'inmemory',
+      False,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'inmemory',
+      True,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'sqlite',
+      False,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'sqlite',
+      True,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+  })
+# ---
+# name: test_resolve_update_detects_changes[multi_field-xxhash32]
+  dict({
+    tuple(
+      'clickhouse',
+      False,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'clickhouse',
+      True,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'duckdb',
+      False,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'duckdb',
+      True,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'inmemory',
+      False,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'inmemory',
+      True,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'sqlite',
+      False,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'sqlite',
+      True,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+  })
+# ---
+# name: test_resolve_update_detects_changes[multi_field-xxhash64]
+  dict({
+    tuple(
+      'clickhouse',
+      False,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'clickhouse',
+      True,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'duckdb',
+      False,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'duckdb',
+      True,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'inmemory',
+      False,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'inmemory',
+      True,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'sqlite',
+      False,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'sqlite',
+      True,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+  })
+# ---
+# name: test_resolve_update_detects_changes[simple_chain-md5]
+  dict({
+    tuple(
+      'clickhouse',
+      False,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'clickhouse',
+      True,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'duckdb',
+      False,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'duckdb',
+      True,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'inmemory',
+      False,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'inmemory',
+      True,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'sqlite',
+      False,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'sqlite',
+      True,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+  })
+# ---
+# name: test_resolve_update_detects_changes[simple_chain-sha256]
+  dict({
+    tuple(
+      'inmemory',
+      False,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'inmemory',
+      True,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'sqlite',
+      False,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'sqlite',
+      True,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+  })
+# ---
+# name: test_resolve_update_detects_changes[simple_chain-wyhash]
+  dict({
+    tuple(
+      'inmemory',
+      False,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'inmemory',
+      True,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'sqlite',
+      False,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'sqlite',
+      True,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+  })
+# ---
+# name: test_resolve_update_detects_changes[simple_chain-xxhash32]
+  dict({
+    tuple(
+      'clickhouse',
+      False,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'clickhouse',
+      True,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'duckdb',
+      False,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'duckdb',
+      True,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'inmemory',
+      False,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'inmemory',
+      True,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'sqlite',
+      False,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'sqlite',
+      True,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+  })
+# ---
+# name: test_resolve_update_detects_changes[simple_chain-xxhash64]
+  dict({
+    tuple(
+      'clickhouse',
+      False,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'clickhouse',
+      True,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'duckdb',
+      False,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'duckdb',
+      True,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'inmemory',
+      False,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'inmemory',
+      True,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'sqlite',
+      False,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+    tuple(
+      'sqlite',
+      True,
+    ): dict({
+      'added': 0,
+      'any_version_changed': True,
+      'changed': 3,
+      'changed_sample_ids': list([
+        1,
+        2,
+        3,
+      ]),
+      'removed': 0,
+    }),
+  })
+# ---
+# name: test_resolve_update_feature_version_change_idempotency[multi_field-md5]
+  dict({
+    'clickhouse_native=False': dict({
+      'feature_version': '70c6be12249631e16e814cba005c5653f999e7a659400ff3efc4ee7196f6370f',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'clickhouse_native=True': dict({
+      'feature_version': '70c6be12249631e16e814cba005c5653f999e7a659400ff3efc4ee7196f6370f',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'duckdb_native=False': dict({
+      'feature_version': '70c6be12249631e16e814cba005c5653f999e7a659400ff3efc4ee7196f6370f',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'duckdb_native=True': dict({
+      'feature_version': '70c6be12249631e16e814cba005c5653f999e7a659400ff3efc4ee7196f6370f',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'inmemory_native=False': dict({
+      'feature_version': '70c6be12249631e16e814cba005c5653f999e7a659400ff3efc4ee7196f6370f',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'inmemory_native=True': dict({
+      'feature_version': '70c6be12249631e16e814cba005c5653f999e7a659400ff3efc4ee7196f6370f',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'sqlite_native=False': dict({
+      'feature_version': '70c6be12249631e16e814cba005c5653f999e7a659400ff3efc4ee7196f6370f',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'sqlite_native=True': dict({
+      'feature_version': '70c6be12249631e16e814cba005c5653f999e7a659400ff3efc4ee7196f6370f',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+  })
+# ---
+# name: test_resolve_update_feature_version_change_idempotency[multi_field-sha256]
+  dict({
+    'inmemory_native=False': dict({
+      'feature_version': '70c6be12249631e16e814cba005c5653f999e7a659400ff3efc4ee7196f6370f',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'inmemory_native=True': dict({
+      'feature_version': '70c6be12249631e16e814cba005c5653f999e7a659400ff3efc4ee7196f6370f',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'sqlite_native=False': dict({
+      'feature_version': '70c6be12249631e16e814cba005c5653f999e7a659400ff3efc4ee7196f6370f',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'sqlite_native=True': dict({
+      'feature_version': '70c6be12249631e16e814cba005c5653f999e7a659400ff3efc4ee7196f6370f',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+  })
+# ---
+# name: test_resolve_update_feature_version_change_idempotency[multi_field-wyhash]
+  dict({
+    'inmemory_native=False': dict({
+      'feature_version': '70c6be12249631e16e814cba005c5653f999e7a659400ff3efc4ee7196f6370f',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'inmemory_native=True': dict({
+      'feature_version': '70c6be12249631e16e814cba005c5653f999e7a659400ff3efc4ee7196f6370f',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'sqlite_native=False': dict({
+      'feature_version': '70c6be12249631e16e814cba005c5653f999e7a659400ff3efc4ee7196f6370f',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'sqlite_native=True': dict({
+      'feature_version': '70c6be12249631e16e814cba005c5653f999e7a659400ff3efc4ee7196f6370f',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+  })
+# ---
+# name: test_resolve_update_feature_version_change_idempotency[multi_field-xxhash32]
+  dict({
+    'clickhouse_native=False': dict({
+      'feature_version': '70c6be12249631e16e814cba005c5653f999e7a659400ff3efc4ee7196f6370f',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'clickhouse_native=True': dict({
+      'feature_version': '70c6be12249631e16e814cba005c5653f999e7a659400ff3efc4ee7196f6370f',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'duckdb_native=False': dict({
+      'feature_version': '70c6be12249631e16e814cba005c5653f999e7a659400ff3efc4ee7196f6370f',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'duckdb_native=True': dict({
+      'feature_version': '70c6be12249631e16e814cba005c5653f999e7a659400ff3efc4ee7196f6370f',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'inmemory_native=False': dict({
+      'feature_version': '70c6be12249631e16e814cba005c5653f999e7a659400ff3efc4ee7196f6370f',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'inmemory_native=True': dict({
+      'feature_version': '70c6be12249631e16e814cba005c5653f999e7a659400ff3efc4ee7196f6370f',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'sqlite_native=False': dict({
+      'feature_version': '70c6be12249631e16e814cba005c5653f999e7a659400ff3efc4ee7196f6370f',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'sqlite_native=True': dict({
+      'feature_version': '70c6be12249631e16e814cba005c5653f999e7a659400ff3efc4ee7196f6370f',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+  })
+# ---
+# name: test_resolve_update_feature_version_change_idempotency[multi_field-xxhash64]
+  dict({
+    'clickhouse_native=False': dict({
+      'feature_version': '70c6be12249631e16e814cba005c5653f999e7a659400ff3efc4ee7196f6370f',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'clickhouse_native=True': dict({
+      'feature_version': '70c6be12249631e16e814cba005c5653f999e7a659400ff3efc4ee7196f6370f',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'duckdb_native=False': dict({
+      'feature_version': '70c6be12249631e16e814cba005c5653f999e7a659400ff3efc4ee7196f6370f',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'duckdb_native=True': dict({
+      'feature_version': '70c6be12249631e16e814cba005c5653f999e7a659400ff3efc4ee7196f6370f',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'inmemory_native=False': dict({
+      'feature_version': '70c6be12249631e16e814cba005c5653f999e7a659400ff3efc4ee7196f6370f',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'inmemory_native=True': dict({
+      'feature_version': '70c6be12249631e16e814cba005c5653f999e7a659400ff3efc4ee7196f6370f',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'sqlite_native=False': dict({
+      'feature_version': '70c6be12249631e16e814cba005c5653f999e7a659400ff3efc4ee7196f6370f',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'sqlite_native=True': dict({
+      'feature_version': '70c6be12249631e16e814cba005c5653f999e7a659400ff3efc4ee7196f6370f',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+  })
+# ---
+# name: test_resolve_update_feature_version_change_idempotency[simple_chain-md5]
+  dict({
+    'clickhouse_native=False': dict({
+      'feature_version': '41c074195bddc1d5004115b121467b9c46d466f4820a60be1cd0b89eacad512d',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'clickhouse_native=True': dict({
+      'feature_version': '41c074195bddc1d5004115b121467b9c46d466f4820a60be1cd0b89eacad512d',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'duckdb_native=False': dict({
+      'feature_version': '41c074195bddc1d5004115b121467b9c46d466f4820a60be1cd0b89eacad512d',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'duckdb_native=True': dict({
+      'feature_version': '41c074195bddc1d5004115b121467b9c46d466f4820a60be1cd0b89eacad512d',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'inmemory_native=False': dict({
+      'feature_version': '41c074195bddc1d5004115b121467b9c46d466f4820a60be1cd0b89eacad512d',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'inmemory_native=True': dict({
+      'feature_version': '41c074195bddc1d5004115b121467b9c46d466f4820a60be1cd0b89eacad512d',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'sqlite_native=False': dict({
+      'feature_version': '41c074195bddc1d5004115b121467b9c46d466f4820a60be1cd0b89eacad512d',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'sqlite_native=True': dict({
+      'feature_version': '41c074195bddc1d5004115b121467b9c46d466f4820a60be1cd0b89eacad512d',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+  })
+# ---
+# name: test_resolve_update_feature_version_change_idempotency[simple_chain-sha256]
+  dict({
+    'inmemory_native=False': dict({
+      'feature_version': '41c074195bddc1d5004115b121467b9c46d466f4820a60be1cd0b89eacad512d',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'inmemory_native=True': dict({
+      'feature_version': '41c074195bddc1d5004115b121467b9c46d466f4820a60be1cd0b89eacad512d',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'sqlite_native=False': dict({
+      'feature_version': '41c074195bddc1d5004115b121467b9c46d466f4820a60be1cd0b89eacad512d',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'sqlite_native=True': dict({
+      'feature_version': '41c074195bddc1d5004115b121467b9c46d466f4820a60be1cd0b89eacad512d',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+  })
+# ---
+# name: test_resolve_update_feature_version_change_idempotency[simple_chain-wyhash]
+  dict({
+    'inmemory_native=False': dict({
+      'feature_version': '41c074195bddc1d5004115b121467b9c46d466f4820a60be1cd0b89eacad512d',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'inmemory_native=True': dict({
+      'feature_version': '41c074195bddc1d5004115b121467b9c46d466f4820a60be1cd0b89eacad512d',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'sqlite_native=False': dict({
+      'feature_version': '41c074195bddc1d5004115b121467b9c46d466f4820a60be1cd0b89eacad512d',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'sqlite_native=True': dict({
+      'feature_version': '41c074195bddc1d5004115b121467b9c46d466f4820a60be1cd0b89eacad512d',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+  })
+# ---
+# name: test_resolve_update_feature_version_change_idempotency[simple_chain-xxhash32]
+  dict({
+    'clickhouse_native=False': dict({
+      'feature_version': '41c074195bddc1d5004115b121467b9c46d466f4820a60be1cd0b89eacad512d',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'clickhouse_native=True': dict({
+      'feature_version': '41c074195bddc1d5004115b121467b9c46d466f4820a60be1cd0b89eacad512d',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'duckdb_native=False': dict({
+      'feature_version': '41c074195bddc1d5004115b121467b9c46d466f4820a60be1cd0b89eacad512d',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'duckdb_native=True': dict({
+      'feature_version': '41c074195bddc1d5004115b121467b9c46d466f4820a60be1cd0b89eacad512d',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'inmemory_native=False': dict({
+      'feature_version': '41c074195bddc1d5004115b121467b9c46d466f4820a60be1cd0b89eacad512d',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'inmemory_native=True': dict({
+      'feature_version': '41c074195bddc1d5004115b121467b9c46d466f4820a60be1cd0b89eacad512d',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'sqlite_native=False': dict({
+      'feature_version': '41c074195bddc1d5004115b121467b9c46d466f4820a60be1cd0b89eacad512d',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'sqlite_native=True': dict({
+      'feature_version': '41c074195bddc1d5004115b121467b9c46d466f4820a60be1cd0b89eacad512d',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+  })
+# ---
+# name: test_resolve_update_feature_version_change_idempotency[simple_chain-xxhash64]
+  dict({
+    'clickhouse_native=False': dict({
+      'feature_version': '41c074195bddc1d5004115b121467b9c46d466f4820a60be1cd0b89eacad512d',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'clickhouse_native=True': dict({
+      'feature_version': '41c074195bddc1d5004115b121467b9c46d466f4820a60be1cd0b89eacad512d',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'duckdb_native=False': dict({
+      'feature_version': '41c074195bddc1d5004115b121467b9c46d466f4820a60be1cd0b89eacad512d',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'duckdb_native=True': dict({
+      'feature_version': '41c074195bddc1d5004115b121467b9c46d466f4820a60be1cd0b89eacad512d',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'inmemory_native=False': dict({
+      'feature_version': '41c074195bddc1d5004115b121467b9c46d466f4820a60be1cd0b89eacad512d',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'inmemory_native=True': dict({
+      'feature_version': '41c074195bddc1d5004115b121467b9c46d466f4820a60be1cd0b89eacad512d',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'sqlite_native=False': dict({
+      'feature_version': '41c074195bddc1d5004115b121467b9c46d466f4820a60be1cd0b89eacad512d',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+    'sqlite_native=True': dict({
+      'feature_version': '41c074195bddc1d5004115b121467b9c46d466f4820a60be1cd0b89eacad512d',
+      'first_run': dict({
+        'added': 3,
+        'changed': 0,
+        'removed': 0,
+      }),
+      'second_run': dict({
+        'added': 0,
+        'changed': 0,
+        'removed': 0,
+      }),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[False-False-diamond_graph-md5]
+  dict({
+    tuple(
+      'clickhouse',
+      False,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      False,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      False,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      False,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[False-False-diamond_graph-sha256]
+  dict({
+    tuple(
+      'inmemory',
+      False,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      False,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[False-False-diamond_graph-wyhash]
+  dict({
+    tuple(
+      'inmemory',
+      False,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      False,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[False-False-diamond_graph-xxhash32]
+  dict({
+    tuple(
+      'clickhouse',
+      False,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      False,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      False,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      False,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[False-False-diamond_graph-xxhash64]
+  dict({
+    tuple(
+      'clickhouse',
+      False,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      False,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      False,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      False,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[False-False-multi_field-md5]
+  dict({
+    tuple(
+      'clickhouse',
+      False,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      False,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      False,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      False,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[False-False-multi_field-sha256]
+  dict({
+    tuple(
+      'inmemory',
+      False,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      False,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[False-False-multi_field-wyhash]
+  dict({
+    tuple(
+      'inmemory',
+      False,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      False,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[False-False-multi_field-xxhash32]
+  dict({
+    tuple(
+      'clickhouse',
+      False,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      False,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      False,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      False,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[False-False-multi_field-xxhash64]
+  dict({
+    tuple(
+      'clickhouse',
+      False,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      False,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      False,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      False,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[False-False-simple_chain-md5]
+  dict({
+    tuple(
+      'clickhouse',
+      False,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      False,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      False,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      False,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[False-False-simple_chain-sha256]
+  dict({
+    tuple(
+      'inmemory',
+      False,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      False,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[False-False-simple_chain-wyhash]
+  dict({
+    tuple(
+      'inmemory',
+      False,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      False,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[False-False-simple_chain-xxhash32]
+  dict({
+    tuple(
+      'clickhouse',
+      False,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      False,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      False,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      False,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[False-False-simple_chain-xxhash64]
+  dict({
+    tuple(
+      'clickhouse',
+      False,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      False,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      False,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      False,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[False-True-diamond_graph-md5]
+  dict({
+    tuple(
+      'clickhouse',
+      True,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      True,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      True,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      True,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[False-True-diamond_graph-sha256]
+  dict({
+    tuple(
+      'inmemory',
+      True,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      True,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[False-True-diamond_graph-wyhash]
+  dict({
+    tuple(
+      'inmemory',
+      True,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      True,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[False-True-diamond_graph-xxhash32]
+  dict({
+    tuple(
+      'clickhouse',
+      True,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      True,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      True,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      True,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[False-True-diamond_graph-xxhash64]
+  dict({
+    tuple(
+      'clickhouse',
+      True,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      True,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      True,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      True,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[False-True-multi_field-md5]
+  dict({
+    tuple(
+      'clickhouse',
+      True,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      True,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      True,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      True,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[False-True-multi_field-sha256]
+  dict({
+    tuple(
+      'inmemory',
+      True,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      True,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[False-True-multi_field-wyhash]
+  dict({
+    tuple(
+      'inmemory',
+      True,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      True,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[False-True-multi_field-xxhash32]
+  dict({
+    tuple(
+      'clickhouse',
+      True,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      True,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      True,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      True,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[False-True-multi_field-xxhash64]
+  dict({
+    tuple(
+      'clickhouse',
+      True,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      True,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      True,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      True,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[False-True-simple_chain-md5]
+  dict({
+    tuple(
+      'clickhouse',
+      True,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      True,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      True,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      True,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[False-True-simple_chain-sha256]
+  dict({
+    tuple(
+      'inmemory',
+      True,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      True,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[False-True-simple_chain-wyhash]
+  dict({
+    tuple(
+      'inmemory',
+      True,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      True,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[False-True-simple_chain-xxhash32]
+  dict({
+    tuple(
+      'clickhouse',
+      True,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      True,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      True,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      True,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[False-True-simple_chain-xxhash64]
+  dict({
+    tuple(
+      'clickhouse',
+      True,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      True,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      True,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      True,
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[True-False-diamond_graph-md5]
+  dict({
+    tuple(
+      'clickhouse',
+      False,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      False,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      False,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      False,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[True-False-diamond_graph-sha256]
+  dict({
+    tuple(
+      'inmemory',
+      False,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      False,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[True-False-diamond_graph-wyhash]
+  dict({
+    tuple(
+      'inmemory',
+      False,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      False,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[True-False-diamond_graph-xxhash32]
+  dict({
+    tuple(
+      'clickhouse',
+      False,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      False,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      False,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      False,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[True-False-diamond_graph-xxhash64]
+  dict({
+    tuple(
+      'clickhouse',
+      False,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      False,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      False,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      False,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[True-False-multi_field-md5]
+  dict({
+    tuple(
+      'clickhouse',
+      False,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      False,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      False,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      False,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[True-False-multi_field-sha256]
+  dict({
+    tuple(
+      'inmemory',
+      False,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      False,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[True-False-multi_field-wyhash]
+  dict({
+    tuple(
+      'inmemory',
+      False,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      False,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[True-False-multi_field-xxhash32]
+  dict({
+    tuple(
+      'clickhouse',
+      False,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      False,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      False,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      False,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[True-False-multi_field-xxhash64]
+  dict({
+    tuple(
+      'clickhouse',
+      False,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      False,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      False,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      False,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[True-False-simple_chain-md5]
+  dict({
+    tuple(
+      'clickhouse',
+      False,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      False,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      False,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      False,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[True-False-simple_chain-sha256]
+  dict({
+    tuple(
+      'inmemory',
+      False,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      False,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[True-False-simple_chain-wyhash]
+  dict({
+    tuple(
+      'inmemory',
+      False,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      False,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[True-False-simple_chain-xxhash32]
+  dict({
+    tuple(
+      'clickhouse',
+      False,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      False,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      False,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      False,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[True-False-simple_chain-xxhash64]
+  dict({
+    tuple(
+      'clickhouse',
+      False,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      False,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      False,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      False,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[True-True-diamond_graph-md5]
+  dict({
+    tuple(
+      'clickhouse',
+      True,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      True,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      True,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      True,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[True-True-diamond_graph-sha256]
+  dict({
+    tuple(
+      'inmemory',
+      True,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      True,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[True-True-diamond_graph-wyhash]
+  dict({
+    tuple(
+      'inmemory',
+      True,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      True,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[True-True-diamond_graph-xxhash32]
+  dict({
+    tuple(
+      'clickhouse',
+      True,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      True,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      True,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      True,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[True-True-diamond_graph-xxhash64]
+  dict({
+    tuple(
+      'clickhouse',
+      True,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      True,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      True,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      True,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[True-True-multi_field-md5]
+  dict({
+    tuple(
+      'clickhouse',
+      True,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      True,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      True,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      True,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[True-True-multi_field-sha256]
+  dict({
+    tuple(
+      'inmemory',
+      True,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      True,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[True-True-multi_field-wyhash]
+  dict({
+    tuple(
+      'inmemory',
+      True,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      True,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[True-True-multi_field-xxhash32]
+  dict({
+    tuple(
+      'clickhouse',
+      True,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      True,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      True,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      True,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[True-True-multi_field-xxhash64]
+  dict({
+    tuple(
+      'clickhouse',
+      True,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      True,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      True,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      True,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[True-True-simple_chain-md5]
+  dict({
+    tuple(
+      'clickhouse',
+      True,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      True,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      True,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      True,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[True-True-simple_chain-sha256]
+  dict({
+    tuple(
+      'inmemory',
+      True,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      True,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[True-True-simple_chain-wyhash]
+  dict({
+    tuple(
+      'inmemory',
+      True,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      True,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[True-True-simple_chain-xxhash32]
+  dict({
+    tuple(
+      'clickhouse',
+      True,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      True,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      True,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      True,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_no_upstream[True-True-simple_chain-xxhash64]
+  dict({
+    tuple(
+      'clickhouse',
+      True,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      True,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      True,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      True,
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'field_a': 'hash1',
+        }),
+        dict({
+          'field_a': 'hash2',
+        }),
+        dict({
+          'field_a': 'hash3',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_with_upstream[diamond_graph-md5]
+  dict({
+    tuple(
+      'clickhouse',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': 'dbe64534abd5e364d1f4ca1a6869795a',
+        }),
+        dict({
+          'default': 'cb822ef624057e3b28ad202916ac71dd',
+        }),
+        dict({
+          'default': '2ce6657c9d962fc2fe2a2f593b8483f0',
+        }),
+      ]),
+    }),
+    tuple(
+      'clickhouse',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': 'dbe64534abd5e364d1f4ca1a6869795a',
+        }),
+        dict({
+          'default': 'cb822ef624057e3b28ad202916ac71dd',
+        }),
+        dict({
+          'default': '2ce6657c9d962fc2fe2a2f593b8483f0',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': 'dbe64534abd5e364d1f4ca1a6869795a',
+        }),
+        dict({
+          'default': 'cb822ef624057e3b28ad202916ac71dd',
+        }),
+        dict({
+          'default': '2ce6657c9d962fc2fe2a2f593b8483f0',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': 'dbe64534abd5e364d1f4ca1a6869795a',
+        }),
+        dict({
+          'default': 'cb822ef624057e3b28ad202916ac71dd',
+        }),
+        dict({
+          'default': '2ce6657c9d962fc2fe2a2f593b8483f0',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': 'dbe64534abd5e364d1f4ca1a6869795a',
+        }),
+        dict({
+          'default': 'cb822ef624057e3b28ad202916ac71dd',
+        }),
+        dict({
+          'default': '2ce6657c9d962fc2fe2a2f593b8483f0',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': 'dbe64534abd5e364d1f4ca1a6869795a',
+        }),
+        dict({
+          'default': 'cb822ef624057e3b28ad202916ac71dd',
+        }),
+        dict({
+          'default': '2ce6657c9d962fc2fe2a2f593b8483f0',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': 'dbe64534abd5e364d1f4ca1a6869795a',
+        }),
+        dict({
+          'default': 'cb822ef624057e3b28ad202916ac71dd',
+        }),
+        dict({
+          'default': '2ce6657c9d962fc2fe2a2f593b8483f0',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': 'dbe64534abd5e364d1f4ca1a6869795a',
+        }),
+        dict({
+          'default': 'cb822ef624057e3b28ad202916ac71dd',
+        }),
+        dict({
+          'default': '2ce6657c9d962fc2fe2a2f593b8483f0',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_with_upstream[diamond_graph-sha256]
+  dict({
+    tuple(
+      'inmemory',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '406dd66c968d8c3d387fd4b4df6db41e7c8ba1a0b9e648a5e5dd7aa7afbc5622',
+        }),
+        dict({
+          'default': 'f8309593097668d4edead958395fd49b95893d2e9e7634503fa9f4b51fceca3b',
+        }),
+        dict({
+          'default': '2fa77b085ee491e7e97f72c247013f8478ba3cb4465444e3fcba320c8e7725f6',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '406dd66c968d8c3d387fd4b4df6db41e7c8ba1a0b9e648a5e5dd7aa7afbc5622',
+        }),
+        dict({
+          'default': 'f8309593097668d4edead958395fd49b95893d2e9e7634503fa9f4b51fceca3b',
+        }),
+        dict({
+          'default': '2fa77b085ee491e7e97f72c247013f8478ba3cb4465444e3fcba320c8e7725f6',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '406dd66c968d8c3d387fd4b4df6db41e7c8ba1a0b9e648a5e5dd7aa7afbc5622',
+        }),
+        dict({
+          'default': 'f8309593097668d4edead958395fd49b95893d2e9e7634503fa9f4b51fceca3b',
+        }),
+        dict({
+          'default': '2fa77b085ee491e7e97f72c247013f8478ba3cb4465444e3fcba320c8e7725f6',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '406dd66c968d8c3d387fd4b4df6db41e7c8ba1a0b9e648a5e5dd7aa7afbc5622',
+        }),
+        dict({
+          'default': 'f8309593097668d4edead958395fd49b95893d2e9e7634503fa9f4b51fceca3b',
+        }),
+        dict({
+          'default': '2fa77b085ee491e7e97f72c247013f8478ba3cb4465444e3fcba320c8e7725f6',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_with_upstream[diamond_graph-wyhash]
+  dict({
+    tuple(
+      'inmemory',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '12037023440008030266',
+        }),
+        dict({
+          'default': '17837839317980491560',
+        }),
+        dict({
+          'default': '14558290314565373206',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '12037023440008030266',
+        }),
+        dict({
+          'default': '17837839317980491560',
+        }),
+        dict({
+          'default': '14558290314565373206',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '12037023440008030266',
+        }),
+        dict({
+          'default': '17837839317980491560',
+        }),
+        dict({
+          'default': '14558290314565373206',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '12037023440008030266',
+        }),
+        dict({
+          'default': '17837839317980491560',
+        }),
+        dict({
+          'default': '14558290314565373206',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_with_upstream[diamond_graph-xxhash32]
+  dict({
+    tuple(
+      'clickhouse',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '3644544197',
+        }),
+        dict({
+          'default': '3150898318',
+        }),
+        dict({
+          'default': '3999303356',
+        }),
+      ]),
+    }),
+    tuple(
+      'clickhouse',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '3644544197',
+        }),
+        dict({
+          'default': '3150898318',
+        }),
+        dict({
+          'default': '3999303356',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '3644544197',
+        }),
+        dict({
+          'default': '3150898318',
+        }),
+        dict({
+          'default': '3999303356',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '3644544197',
+        }),
+        dict({
+          'default': '3150898318',
+        }),
+        dict({
+          'default': '3999303356',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '3644544197',
+        }),
+        dict({
+          'default': '3150898318',
+        }),
+        dict({
+          'default': '3999303356',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '3644544197',
+        }),
+        dict({
+          'default': '3150898318',
+        }),
+        dict({
+          'default': '3999303356',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '3644544197',
+        }),
+        dict({
+          'default': '3150898318',
+        }),
+        dict({
+          'default': '3999303356',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '3644544197',
+        }),
+        dict({
+          'default': '3150898318',
+        }),
+        dict({
+          'default': '3999303356',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_with_upstream[diamond_graph-xxhash64]
+  dict({
+    tuple(
+      'clickhouse',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '4102418655400604945',
+        }),
+        dict({
+          'default': '4485303282459113117',
+        }),
+        dict({
+          'default': '16541571895607920915',
+        }),
+      ]),
+    }),
+    tuple(
+      'clickhouse',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '4102418655400604945',
+        }),
+        dict({
+          'default': '4485303282459113117',
+        }),
+        dict({
+          'default': '16541571895607920915',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '4102418655400604945',
+        }),
+        dict({
+          'default': '4485303282459113117',
+        }),
+        dict({
+          'default': '16541571895607920915',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '4102418655400604945',
+        }),
+        dict({
+          'default': '4485303282459113117',
+        }),
+        dict({
+          'default': '16541571895607920915',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '4102418655400604945',
+        }),
+        dict({
+          'default': '4485303282459113117',
+        }),
+        dict({
+          'default': '16541571895607920915',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '4102418655400604945',
+        }),
+        dict({
+          'default': '4485303282459113117',
+        }),
+        dict({
+          'default': '16541571895607920915',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '4102418655400604945',
+        }),
+        dict({
+          'default': '4485303282459113117',
+        }),
+        dict({
+          'default': '16541571895607920915',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '4102418655400604945',
+        }),
+        dict({
+          'default': '4485303282459113117',
+        }),
+        dict({
+          'default': '16541571895607920915',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_with_upstream[multi_field-md5]
+  dict({
+    tuple(
+      'clickhouse',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '672f21cfef6762f70dcf94fa355db6b7',
+        }),
+        dict({
+          'default': 'e14fa6406edae92209947f24ee0dff64',
+        }),
+        dict({
+          'default': '72831a0fd08d2d33b5246095e906d6a4',
+        }),
+      ]),
+    }),
+    tuple(
+      'clickhouse',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '672f21cfef6762f70dcf94fa355db6b7',
+        }),
+        dict({
+          'default': 'e14fa6406edae92209947f24ee0dff64',
+        }),
+        dict({
+          'default': '72831a0fd08d2d33b5246095e906d6a4',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '672f21cfef6762f70dcf94fa355db6b7',
+        }),
+        dict({
+          'default': 'e14fa6406edae92209947f24ee0dff64',
+        }),
+        dict({
+          'default': '72831a0fd08d2d33b5246095e906d6a4',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '672f21cfef6762f70dcf94fa355db6b7',
+        }),
+        dict({
+          'default': 'e14fa6406edae92209947f24ee0dff64',
+        }),
+        dict({
+          'default': '72831a0fd08d2d33b5246095e906d6a4',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '672f21cfef6762f70dcf94fa355db6b7',
+        }),
+        dict({
+          'default': 'e14fa6406edae92209947f24ee0dff64',
+        }),
+        dict({
+          'default': '72831a0fd08d2d33b5246095e906d6a4',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '672f21cfef6762f70dcf94fa355db6b7',
+        }),
+        dict({
+          'default': 'e14fa6406edae92209947f24ee0dff64',
+        }),
+        dict({
+          'default': '72831a0fd08d2d33b5246095e906d6a4',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '672f21cfef6762f70dcf94fa355db6b7',
+        }),
+        dict({
+          'default': 'e14fa6406edae92209947f24ee0dff64',
+        }),
+        dict({
+          'default': '72831a0fd08d2d33b5246095e906d6a4',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '672f21cfef6762f70dcf94fa355db6b7',
+        }),
+        dict({
+          'default': 'e14fa6406edae92209947f24ee0dff64',
+        }),
+        dict({
+          'default': '72831a0fd08d2d33b5246095e906d6a4',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_with_upstream[multi_field-sha256]
+  dict({
+    tuple(
+      'inmemory',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '35fcd771d351a6d304dba3a390d062ae21db346d55dc0c37e17a4fad927f1481',
+        }),
+        dict({
+          'default': 'bd3c7556de2f864ed50db24b4f05564fcd4458250e3c45d5af9b015fca4e51ff',
+        }),
+        dict({
+          'default': '4e28090c2f0da85178a10f725e2ddcae0b19e6918c10b4e5eb8b0bb9c771ccbf',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '35fcd771d351a6d304dba3a390d062ae21db346d55dc0c37e17a4fad927f1481',
+        }),
+        dict({
+          'default': 'bd3c7556de2f864ed50db24b4f05564fcd4458250e3c45d5af9b015fca4e51ff',
+        }),
+        dict({
+          'default': '4e28090c2f0da85178a10f725e2ddcae0b19e6918c10b4e5eb8b0bb9c771ccbf',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '35fcd771d351a6d304dba3a390d062ae21db346d55dc0c37e17a4fad927f1481',
+        }),
+        dict({
+          'default': 'bd3c7556de2f864ed50db24b4f05564fcd4458250e3c45d5af9b015fca4e51ff',
+        }),
+        dict({
+          'default': '4e28090c2f0da85178a10f725e2ddcae0b19e6918c10b4e5eb8b0bb9c771ccbf',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '35fcd771d351a6d304dba3a390d062ae21db346d55dc0c37e17a4fad927f1481',
+        }),
+        dict({
+          'default': 'bd3c7556de2f864ed50db24b4f05564fcd4458250e3c45d5af9b015fca4e51ff',
+        }),
+        dict({
+          'default': '4e28090c2f0da85178a10f725e2ddcae0b19e6918c10b4e5eb8b0bb9c771ccbf',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_with_upstream[multi_field-wyhash]
+  dict({
+    tuple(
+      'inmemory',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '14384979659561295483',
+        }),
+        dict({
+          'default': '16393741906645701913',
+        }),
+        dict({
+          'default': '1503451087436268925',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '14384979659561295483',
+        }),
+        dict({
+          'default': '16393741906645701913',
+        }),
+        dict({
+          'default': '1503451087436268925',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '14384979659561295483',
+        }),
+        dict({
+          'default': '16393741906645701913',
+        }),
+        dict({
+          'default': '1503451087436268925',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '14384979659561295483',
+        }),
+        dict({
+          'default': '16393741906645701913',
+        }),
+        dict({
+          'default': '1503451087436268925',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_with_upstream[multi_field-xxhash32]
+  dict({
+    tuple(
+      'clickhouse',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '3076203247',
+        }),
+        dict({
+          'default': '2996209608',
+        }),
+        dict({
+          'default': '1133952890',
+        }),
+      ]),
+    }),
+    tuple(
+      'clickhouse',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '3076203247',
+        }),
+        dict({
+          'default': '2996209608',
+        }),
+        dict({
+          'default': '1133952890',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '3076203247',
+        }),
+        dict({
+          'default': '2996209608',
+        }),
+        dict({
+          'default': '1133952890',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '3076203247',
+        }),
+        dict({
+          'default': '2996209608',
+        }),
+        dict({
+          'default': '1133952890',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '3076203247',
+        }),
+        dict({
+          'default': '2996209608',
+        }),
+        dict({
+          'default': '1133952890',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '3076203247',
+        }),
+        dict({
+          'default': '2996209608',
+        }),
+        dict({
+          'default': '1133952890',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '3076203247',
+        }),
+        dict({
+          'default': '2996209608',
+        }),
+        dict({
+          'default': '1133952890',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '3076203247',
+        }),
+        dict({
+          'default': '2996209608',
+        }),
+        dict({
+          'default': '1133952890',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_with_upstream[multi_field-xxhash64]
+  dict({
+    tuple(
+      'clickhouse',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '5703117408664097056',
+        }),
+        dict({
+          'default': '6708236814926810383',
+        }),
+        dict({
+          'default': '7678115697944854051',
+        }),
+      ]),
+    }),
+    tuple(
+      'clickhouse',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '5703117408664097056',
+        }),
+        dict({
+          'default': '6708236814926810383',
+        }),
+        dict({
+          'default': '7678115697944854051',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '5703117408664097056',
+        }),
+        dict({
+          'default': '6708236814926810383',
+        }),
+        dict({
+          'default': '7678115697944854051',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '5703117408664097056',
+        }),
+        dict({
+          'default': '6708236814926810383',
+        }),
+        dict({
+          'default': '7678115697944854051',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '5703117408664097056',
+        }),
+        dict({
+          'default': '6708236814926810383',
+        }),
+        dict({
+          'default': '7678115697944854051',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '5703117408664097056',
+        }),
+        dict({
+          'default': '6708236814926810383',
+        }),
+        dict({
+          'default': '7678115697944854051',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '5703117408664097056',
+        }),
+        dict({
+          'default': '6708236814926810383',
+        }),
+        dict({
+          'default': '7678115697944854051',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '5703117408664097056',
+        }),
+        dict({
+          'default': '6708236814926810383',
+        }),
+        dict({
+          'default': '7678115697944854051',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_with_upstream[simple_chain-md5]
+  dict({
+    tuple(
+      'clickhouse',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '0306c660f4a3dacc3ceb756ef5f3fc6c',
+        }),
+        dict({
+          'default': '7e56c6df2f437a8885372d4cd1cd5a66',
+        }),
+        dict({
+          'default': '82b916af3feb89882deb331e90c903d5',
+        }),
+      ]),
+    }),
+    tuple(
+      'clickhouse',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '0306c660f4a3dacc3ceb756ef5f3fc6c',
+        }),
+        dict({
+          'default': '7e56c6df2f437a8885372d4cd1cd5a66',
+        }),
+        dict({
+          'default': '82b916af3feb89882deb331e90c903d5',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '0306c660f4a3dacc3ceb756ef5f3fc6c',
+        }),
+        dict({
+          'default': '7e56c6df2f437a8885372d4cd1cd5a66',
+        }),
+        dict({
+          'default': '82b916af3feb89882deb331e90c903d5',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '0306c660f4a3dacc3ceb756ef5f3fc6c',
+        }),
+        dict({
+          'default': '7e56c6df2f437a8885372d4cd1cd5a66',
+        }),
+        dict({
+          'default': '82b916af3feb89882deb331e90c903d5',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '0306c660f4a3dacc3ceb756ef5f3fc6c',
+        }),
+        dict({
+          'default': '7e56c6df2f437a8885372d4cd1cd5a66',
+        }),
+        dict({
+          'default': '82b916af3feb89882deb331e90c903d5',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '0306c660f4a3dacc3ceb756ef5f3fc6c',
+        }),
+        dict({
+          'default': '7e56c6df2f437a8885372d4cd1cd5a66',
+        }),
+        dict({
+          'default': '82b916af3feb89882deb331e90c903d5',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '0306c660f4a3dacc3ceb756ef5f3fc6c',
+        }),
+        dict({
+          'default': '7e56c6df2f437a8885372d4cd1cd5a66',
+        }),
+        dict({
+          'default': '82b916af3feb89882deb331e90c903d5',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '0306c660f4a3dacc3ceb756ef5f3fc6c',
+        }),
+        dict({
+          'default': '7e56c6df2f437a8885372d4cd1cd5a66',
+        }),
+        dict({
+          'default': '82b916af3feb89882deb331e90c903d5',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_with_upstream[simple_chain-sha256]
+  dict({
+    tuple(
+      'inmemory',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '2121e2490c3186daa2f01a15b0b1964870964899e34ea75ca7c2d5497fd12c21',
+        }),
+        dict({
+          'default': 'e06a446014c2fd4a83251e9f766a7059fac3e1be9adc75de7b8093042ba07f20',
+        }),
+        dict({
+          'default': 'c007a95606c4aef5d55bd9ea8297df277ac7141bb7a698882307efe73110e2f8',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '2121e2490c3186daa2f01a15b0b1964870964899e34ea75ca7c2d5497fd12c21',
+        }),
+        dict({
+          'default': 'e06a446014c2fd4a83251e9f766a7059fac3e1be9adc75de7b8093042ba07f20',
+        }),
+        dict({
+          'default': 'c007a95606c4aef5d55bd9ea8297df277ac7141bb7a698882307efe73110e2f8',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '2121e2490c3186daa2f01a15b0b1964870964899e34ea75ca7c2d5497fd12c21',
+        }),
+        dict({
+          'default': 'e06a446014c2fd4a83251e9f766a7059fac3e1be9adc75de7b8093042ba07f20',
+        }),
+        dict({
+          'default': 'c007a95606c4aef5d55bd9ea8297df277ac7141bb7a698882307efe73110e2f8',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '2121e2490c3186daa2f01a15b0b1964870964899e34ea75ca7c2d5497fd12c21',
+        }),
+        dict({
+          'default': 'e06a446014c2fd4a83251e9f766a7059fac3e1be9adc75de7b8093042ba07f20',
+        }),
+        dict({
+          'default': 'c007a95606c4aef5d55bd9ea8297df277ac7141bb7a698882307efe73110e2f8',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_with_upstream[simple_chain-wyhash]
+  dict({
+    tuple(
+      'inmemory',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '7390310183463134559',
+        }),
+        dict({
+          'default': '9345967191715740243',
+        }),
+        dict({
+          'default': '10240232034455902977',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '7390310183463134559',
+        }),
+        dict({
+          'default': '9345967191715740243',
+        }),
+        dict({
+          'default': '10240232034455902977',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '7390310183463134559',
+        }),
+        dict({
+          'default': '9345967191715740243',
+        }),
+        dict({
+          'default': '10240232034455902977',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '7390310183463134559',
+        }),
+        dict({
+          'default': '9345967191715740243',
+        }),
+        dict({
+          'default': '10240232034455902977',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_with_upstream[simple_chain-xxhash32]
+  dict({
+    tuple(
+      'clickhouse',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '2923999235',
+        }),
+        dict({
+          'default': '2678760928',
+        }),
+        dict({
+          'default': '3500821944',
+        }),
+      ]),
+    }),
+    tuple(
+      'clickhouse',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '2923999235',
+        }),
+        dict({
+          'default': '2678760928',
+        }),
+        dict({
+          'default': '3500821944',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '2923999235',
+        }),
+        dict({
+          'default': '2678760928',
+        }),
+        dict({
+          'default': '3500821944',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '2923999235',
+        }),
+        dict({
+          'default': '2678760928',
+        }),
+        dict({
+          'default': '3500821944',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '2923999235',
+        }),
+        dict({
+          'default': '2678760928',
+        }),
+        dict({
+          'default': '3500821944',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '2923999235',
+        }),
+        dict({
+          'default': '2678760928',
+        }),
+        dict({
+          'default': '3500821944',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '2923999235',
+        }),
+        dict({
+          'default': '2678760928',
+        }),
+        dict({
+          'default': '3500821944',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '2923999235',
+        }),
+        dict({
+          'default': '2678760928',
+        }),
+        dict({
+          'default': '3500821944',
+        }),
+      ]),
+    }),
+  })
+# ---
+# name: test_resolve_update_with_upstream[simple_chain-xxhash64]
+  dict({
+    tuple(
+      'clickhouse',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '10367360247745986975',
+        }),
+        dict({
+          'default': '11278615146878285687',
+        }),
+        dict({
+          'default': '2591597587625471298',
+        }),
+      ]),
+    }),
+    tuple(
+      'clickhouse',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '10367360247745986975',
+        }),
+        dict({
+          'default': '11278615146878285687',
+        }),
+        dict({
+          'default': '2591597587625471298',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '10367360247745986975',
+        }),
+        dict({
+          'default': '11278615146878285687',
+        }),
+        dict({
+          'default': '2591597587625471298',
+        }),
+      ]),
+    }),
+    tuple(
+      'duckdb',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '10367360247745986975',
+        }),
+        dict({
+          'default': '11278615146878285687',
+        }),
+        dict({
+          'default': '2591597587625471298',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '10367360247745986975',
+        }),
+        dict({
+          'default': '11278615146878285687',
+        }),
+        dict({
+          'default': '2591597587625471298',
+        }),
+      ]),
+    }),
+    tuple(
+      'inmemory',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '10367360247745986975',
+        }),
+        dict({
+          'default': '11278615146878285687',
+        }),
+        dict({
+          'default': '2591597587625471298',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      False,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '10367360247745986975',
+        }),
+        dict({
+          'default': '11278615146878285687',
+        }),
+        dict({
+          'default': '2591597587625471298',
+        }),
+      ]),
+    }),
+    tuple(
+      'sqlite',
+      True,
+    ): dict({
+      'added': 3,
+      'changed': 0,
+      'removed': 0,
+      'versions': list([
+        dict({
+          'default': '10367360247745986975',
+        }),
+        dict({
+          'default': '11278615146878285687',
+        }),
+        dict({
+          'default': '2591597587625471298',
+        }),
+      ]),
+    }),
+  })
+# ---

--- a/tests/metadata_stores/conftest.py
+++ b/tests/metadata_stores/conftest.py
@@ -316,14 +316,14 @@ class StoreCases:
 
     def case_inmemory(
         self, test_graph: FeatureGraph
-    ) -> tuple[type[MetadataStore], dict]:
+    ) -> tuple[type[MetadataStore], dict[str, Any]]:
         """InMemory store case."""
         # Registry is accessed globally via FeatureGraph.get_active()
         return (InMemoryMetadataStore, {})
 
     def case_duckdb(
         self, tmp_path: Path, test_graph: FeatureGraph
-    ) -> tuple[type[MetadataStore], dict]:
+    ) -> tuple[type[MetadataStore], dict[str, Any]]:
         """DuckDB store case."""
         db_path = tmp_path / "test.duckdb"
         # Registry is accessed globally via FeatureGraph.get_active()
@@ -331,7 +331,7 @@ class StoreCases:
 
     def case_sqlite(
         self, tmp_path: Path, test_graph: FeatureGraph
-    ) -> tuple[type[MetadataStore], dict]:
+    ) -> tuple[type[MetadataStore], dict[str, Any]]:
         """SQLite store case."""
         db_path = tmp_path / "test.sqlite"
         # Registry is accessed globally via FeatureGraph.get_active()
@@ -339,7 +339,7 @@ class StoreCases:
 
     def case_clickhouse(
         self, clickhouse_db: str, test_graph: FeatureGraph
-    ) -> tuple[type[MetadataStore], dict]:
+    ) -> tuple[type[MetadataStore], dict[str, Any]]:
         """ClickHouse store case."""
         # Registry is accessed globally via FeatureGraph.get_active()
         # clickhouse_db provides a clean database connection string
@@ -348,7 +348,9 @@ class StoreCases:
 
 @fixture
 @parametrize_with_cases("store_config", cases=StoreCases)
-def persistent_store(store_config: tuple[type[MetadataStore], dict]) -> MetadataStore:
+def persistent_store(
+    store_config: tuple[type[MetadataStore], dict[str, Any]],
+) -> MetadataStore:
     """Parametrized persistent store fixture.
 
     This fixture runs tests for all persistent store implementations.

--- a/tests/metadata_stores/test_duckdb.py
+++ b/tests/metadata_stores/test_duckdb.py
@@ -1,6 +1,7 @@
 """DuckDB-specific tests that don't apply to other stores."""
 
 from pathlib import Path
+from typing import Any
 
 import polars as pl
 import pytest
@@ -13,7 +14,9 @@ from metaxy._utils import collect_to_polars
 from metaxy.metadata_store.duckdb import DuckDBMetadataStore
 
 
-def test_duckdb_table_naming(tmp_path: Path, test_graph, test_features: dict) -> None:
+def test_duckdb_table_naming(
+    tmp_path: Path, test_graph, test_features: dict[str, Any]
+) -> None:
     """Test that feature keys are converted to table names correctly.
 
     Args:
@@ -39,7 +42,7 @@ def test_duckdb_table_naming(tmp_path: Path, test_graph, test_features: dict) ->
 
 
 def test_duckdb_with_custom_config(
-    tmp_path: Path, test_graph, test_features: dict
+    tmp_path: Path, test_graph, test_features: dict[str, Any]
 ) -> None:
     """Test creating DuckDB store with custom configuration.
 
@@ -61,7 +64,7 @@ def test_duckdb_with_custom_config(
 
 
 def test_duckdb_uses_ibis_backend(
-    tmp_path: Path, test_graph, test_features: dict
+    tmp_path: Path, test_graph, test_features: dict[str, Any]
 ) -> None:
     """Test that DuckDB store uses Ibis backend.
 
@@ -79,7 +82,7 @@ def test_duckdb_uses_ibis_backend(
 
 
 def test_duckdb_conn_property_enforcement(
-    tmp_path: Path, test_graph, test_features: dict
+    tmp_path: Path, test_graph, test_features: dict[str, Any]
 ) -> None:
     """Test that conn property enforces store is open.
 
@@ -103,7 +106,7 @@ def test_duckdb_conn_property_enforcement(
 
 
 def test_duckdb_persistence_across_instances(
-    tmp_path: Path, test_graph, test_features: dict
+    tmp_path: Path, test_graph, test_features: dict[str, Any]
 ) -> None:
     """Test that data persists across different store instances.
 
@@ -139,7 +142,7 @@ def test_duckdb_persistence_across_instances(
 
 
 def test_duckdb_close_idempotent(
-    tmp_path: Path, test_graph, test_features: dict
+    tmp_path: Path, test_graph, test_features: dict[str, Any]
 ) -> None:
     """Test that close() can be called multiple times safely.
 

--- a/tests/metadata_stores/test_fallback_stores.py
+++ b/tests/metadata_stores/test_fallback_stores.py
@@ -80,7 +80,7 @@ def create_store_for_fallback(
         return DuckDBMetadataStore(
             db_path,
             hash_algorithm=hash_algorithm,
-            extensions=extensions,  # type: ignore[arg-type]
+            extensions=extensions,  # pyright: ignore[reportArgumentType]
             prefer_native=prefer_native,
             fallback_stores=fallback_stores,
         )
@@ -147,7 +147,7 @@ class DownstreamFeature(
     "fallback_store_type", ["inmemory"]
 )  # Parametrized for future expansion
 def test_fallback_store_warning_issued(
-    store_params: dict,
+    store_params: dict[str, Any],
     hash_algorithm: HashAlgorithm,
     primary_store_type: str,
     fallback_store_type: str,
@@ -261,7 +261,7 @@ def test_fallback_store_warning_issued(
 @parametrize_with_cases("hash_algorithm", cases=HashAlgorithmCases)
 @pytest.mark.parametrize("store_type", get_available_store_types_for_fallback())
 def test_no_fallback_warning_when_all_local(
-    store_params: dict,
+    store_params: dict[str, Any],
     hash_algorithm: HashAlgorithm,
     store_type: str,
     caplog,
@@ -333,7 +333,7 @@ def test_no_fallback_warning_when_all_local(
 @pytest.mark.parametrize("primary_store_type", get_available_store_types_for_fallback())
 @pytest.mark.parametrize("fallback_store_type", ["inmemory"])
 def test_fallback_store_switches_to_polars_components(
-    store_params: dict,
+    store_params: dict[str, Any],
     hash_algorithm: HashAlgorithm,
     primary_store_type: str,
     fallback_store_type: str,
@@ -475,7 +475,7 @@ def test_fallback_store_switches_to_polars_components(
 @parametrize_with_cases("hash_algorithm", cases=HashAlgorithmCases)
 @pytest.mark.parametrize("store_type", get_available_store_types_for_fallback())
 def test_prefer_native_false_no_warning_even_without_fallback(
-    store_params: dict,
+    store_params: dict[str, Any],
     hash_algorithm: HashAlgorithm,
     store_type: str,
     caplog,
@@ -534,7 +534,7 @@ def test_prefer_native_false_no_warning_even_without_fallback(
 
 @parametrize_with_cases("hash_algorithm", cases=HashAlgorithmCases)
 def test_sqlite_no_warning_with_fallback_since_no_native(
-    store_params: dict,
+    store_params: dict[str, Any],
     hash_algorithm: HashAlgorithm,
     caplog,
 ):

--- a/tests/metadata_stores/test_persistent_stores.py
+++ b/tests/metadata_stores/test_persistent_stores.py
@@ -4,6 +4,8 @@ These tests run against all persistent store implementations
 (InMemoryMetadataStore, DuckDBMetadataStore, etc.) using pytest-cases parametrization.
 """
 
+from typing import Any
+
 import narwhals as nw
 import polars as pl
 import pytest
@@ -19,7 +21,7 @@ from metaxy.metadata_store import (
 
 
 def test_store_requires_context_manager(
-    persistent_store, test_graph, test_features: dict
+    persistent_store, test_graph, test_features: dict[str, Any]
 ) -> None:
     """Test that operations outside context manager raise error."""
     data = pl.DataFrame(
@@ -42,7 +44,7 @@ def test_store_requires_context_manager(
 
 
 def test_store_context_manager(
-    persistent_store, test_graph, test_features: dict
+    persistent_store, test_graph, test_features: dict[str, Any]
 ) -> None:
     """Test that store works as a context manager."""
     with persistent_store as store:
@@ -66,7 +68,7 @@ def test_store_context_manager(
 
 
 def test_write_and_read_metadata(
-    persistent_store, test_graph, test_features: dict
+    persistent_store, test_graph, test_features: dict[str, Any]
 ) -> None:
     """Test basic write and read operations."""
     with persistent_store as store:
@@ -94,7 +96,7 @@ def test_write_and_read_metadata(
 
 
 def test_write_invalid_schema(
-    persistent_store, test_graph, test_features: dict
+    persistent_store, test_graph, test_features: dict[str, Any]
 ) -> None:
     """Test that writing without data_version column raises error."""
     with persistent_store as store:
@@ -109,7 +111,9 @@ def test_write_invalid_schema(
             store.write_metadata(test_features["UpstreamFeatureA"], invalid_df)
 
 
-def test_write_append(persistent_store, test_graph, test_features: dict) -> None:
+def test_write_append(
+    persistent_store, test_graph, test_features: dict[str, Any]
+) -> None:
     """Test that writes are append-only."""
     with persistent_store as store:
         df1 = pl.DataFrame(
@@ -142,7 +146,9 @@ def test_write_append(persistent_store, test_graph, test_features: dict) -> None
         assert set(result["sample_id"].to_list()) == {1, 2, 3, 4}
 
 
-def test_read_with_filters(persistent_store, test_graph, test_features: dict) -> None:
+def test_read_with_filters(
+    persistent_store, test_graph, test_features: dict[str, Any]
+) -> None:
     """Test reading with Polars filter expressions."""
     with persistent_store as store:
         metadata = pl.DataFrame(
@@ -168,7 +174,7 @@ def test_read_with_filters(persistent_store, test_graph, test_features: dict) ->
 
 
 def test_read_with_column_selection(
-    persistent_store, test_graph, test_features: dict
+    persistent_store, test_graph, test_features: dict[str, Any]
 ) -> None:
     """Test reading specific columns."""
     with persistent_store as store:
@@ -196,7 +202,7 @@ def test_read_with_column_selection(
 
 
 def test_read_nonexistent_feature(
-    persistent_store, test_graph, test_features: dict
+    persistent_store, test_graph, test_features: dict[str, Any]
 ) -> None:
     """Test that reading nonexistent feature raises error."""
     with persistent_store as store:
@@ -207,7 +213,9 @@ def test_read_nonexistent_feature(
 # Feature Existence Tests
 
 
-def test_has_feature_local(persistent_store, test_graph, test_features: dict) -> None:
+def test_has_feature_local(
+    persistent_store, test_graph, test_features: dict[str, Any]
+) -> None:
     """Test has_feature for local store."""
     with persistent_store as store:
         assert not store.has_feature(
@@ -230,7 +238,9 @@ def test_has_feature_local(persistent_store, test_graph, test_features: dict) ->
         )
 
 
-def test_list_features(persistent_store, test_graph, test_features: dict) -> None:
+def test_list_features(
+    persistent_store, test_graph, test_features: dict[str, Any]
+) -> None:
     """Test listing features.
 
     Args:
@@ -274,7 +284,9 @@ def test_list_features(persistent_store, test_graph, test_features: dict) -> Non
 # System Tables Tests
 
 
-def test_system_tables(persistent_store, test_graph, test_features: dict) -> None:
+def test_system_tables(
+    persistent_store, test_graph, test_features: dict[str, Any]
+) -> None:
     """Test that system tables work correctly.
 
     Args:
@@ -336,7 +348,7 @@ def test_repr(persistent_store) -> None:
 
 
 def test_nested_context_managers(
-    persistent_store, test_graph, test_features: dict
+    persistent_store, test_graph, test_features: dict[str, Any]
 ) -> None:
     """Test that nested context managers work correctly.
 
@@ -372,7 +384,9 @@ def test_nested_context_managers(
 # Multiple Features Tests
 
 
-def test_multiple_features(persistent_store, test_graph, test_features: dict) -> None:
+def test_multiple_features(
+    persistent_store, test_graph, test_features: dict[str, Any]
+) -> None:
     """Test storing multiple features in same store.
 
     Args:

--- a/tests/metadata_stores/test_resolve_update.py
+++ b/tests/metadata_stores/test_resolve_update.py
@@ -97,7 +97,7 @@ def create_store(
         return DuckDBMetadataStore(
             db_path,
             hash_algorithm=hash_algorithm,
-            extensions=extensions,  # type: ignore[arg-type]
+            extensions=extensions,  # pyright: ignore[reportArgumentType]
             prefer_native=prefer_native,
         )
     elif store_type == "sqlite":
@@ -349,7 +349,7 @@ def simple_chain_graph():
 @pytest.mark.parametrize("prefer_native", [True, False])
 @pytest.mark.parametrize("use_native_samples", [True, False])
 def test_resolve_update_no_upstream(
-    store_params: dict,
+    store_params: dict[str, Any],
     graph_config: tuple[FeatureGraph, list[type[Feature]]],
     hash_algorithm: HashAlgorithm,
     prefer_native: bool,
@@ -518,7 +518,7 @@ def test_resolve_update_no_upstream(
 @parametrize_with_cases("hash_algorithm", cases=HashAlgorithmCases)
 @parametrize_with_cases("graph_config", cases=FeatureGraphCases)
 def test_resolve_update_with_upstream(
-    store_params: dict,
+    store_params: dict[str, Any],
     graph_config: tuple[FeatureGraph, list[type[Feature]]],
     hash_algorithm: HashAlgorithm,
     snapshot,
@@ -536,7 +536,7 @@ def test_resolve_update_with_upstream(
     downstream_feature = features[-1]
 
     # Helper to create data_version dicts for a feature's fields
-    def make_data_versions(feature: type[Feature], prefix: str) -> list[dict]:
+    def make_data_versions(feature: type[Feature], prefix: str) -> list[dict[str, Any]]:
         fields = [c.key for c in feature.spec.fields]
         if len(fields) == 1:
             field_name = "_".join(fields[0])
@@ -659,7 +659,7 @@ def test_resolve_update_with_upstream(
 @parametrize_with_cases("hash_algorithm", cases=HashAlgorithmCases)
 @parametrize_with_cases("graph_config", cases=FeatureGraphCases)
 def test_resolve_update_detects_changes(
-    store_params: dict,
+    store_params: dict[str, Any],
     graph_config: tuple[FeatureGraph, list[type[Feature]]],
     hash_algorithm: HashAlgorithm,
     snapshot,
@@ -680,7 +680,9 @@ def test_resolve_update_detects_changes(
     root_fields = [c.key for c in root_feature.spec.fields]
 
     # Create data version dicts for fields
-    def make_data_versions(version_prefix: str, sample_ids: list[int]) -> list[dict]:
+    def make_data_versions(
+        version_prefix: str, sample_ids: list[int]
+    ) -> list[dict[str, Any]]:
         if len(root_fields) == 1:
             field_name = "_".join(root_fields[0])
             return [{field_name: f"{version_prefix}{i}"} for i in sample_ids]
@@ -892,7 +894,7 @@ def test_resolve_update_detects_changes(
 @parametrize_with_cases("hash_algorithm", cases=HashAlgorithmCases)
 @parametrize_with_cases("graph_config", cases=FeatureGraphCases)
 def test_resolve_update_feature_version_change_idempotency(
-    store_params: dict,
+    store_params: dict[str, Any],
     graph_config: tuple[FeatureGraph, list[type[Feature]]],
     hash_algorithm: HashAlgorithm,
     snapshot,

--- a/tests/metadata_stores/test_resolve_update_root_features.py
+++ b/tests/metadata_stores/test_resolve_update_root_features.py
@@ -6,6 +6,8 @@ Root features are special because:
 3. resolve_update should compare user-provided data_version with stored metadata
 """
 
+from typing import Any
+
 import polars as pl
 import pytest
 from pytest_cases import parametrize_with_cases
@@ -46,7 +48,7 @@ class TestResolveUpdateRootFeatures:
     @parametrize_with_cases("store_config", cases=StoreCases)
     def test_resolve_update_root_feature_requires_samples(
         self,
-        store_config: tuple[type[MetadataStore], dict],
+        store_config: tuple[type[MetadataStore], dict[str, Any]],
     ):
         """Test that resolve_update raises ValueError without samples parameter.
 
@@ -67,7 +69,7 @@ class TestResolveUpdateRootFeatures:
     @parametrize_with_cases("store_config", cases=StoreCases)
     def test_resolve_update_root_feature_with_samples_no_existing_metadata(
         self,
-        store_config: tuple[type[MetadataStore], dict],
+        store_config: tuple[type[MetadataStore], dict[str, Any]],
     ):
         """Test resolve_update with samples for root feature (no existing metadata).
 
@@ -107,7 +109,7 @@ class TestResolveUpdateRootFeatures:
     @parametrize_with_cases("store_config", cases=StoreCases)
     def test_resolve_update_root_feature_with_samples_and_changes(
         self,
-        store_config: tuple[type[MetadataStore], dict],
+        store_config: tuple[type[MetadataStore], dict[str, Any]],
     ):
         """Test resolve_update with samples parameter detects all changes correctly.
 

--- a/tests/metadata_stores/test_sqlite.py
+++ b/tests/metadata_stores/test_sqlite.py
@@ -1,6 +1,7 @@
 """SQLite-specific tests that don't apply to other stores."""
 
 from pathlib import Path
+from typing import Any
 
 import polars as pl
 import pytest
@@ -12,7 +13,9 @@ from metaxy._utils import collect_to_polars
 from metaxy.metadata_store.sqlite import SQLiteMetadataStore
 
 
-def test_sqlite_table_naming(tmp_path: Path, test_graph, test_features: dict) -> None:
+def test_sqlite_table_naming(
+    tmp_path: Path, test_graph, test_features: dict[str, Any]
+) -> None:
     """Test that feature keys are converted to table names correctly.
 
     Args:
@@ -39,7 +42,7 @@ def test_sqlite_table_naming(tmp_path: Path, test_graph, test_features: dict) ->
 
 
 def test_sqlite_uses_ibis_backend(
-    tmp_path: Path, test_graph, test_features: dict
+    tmp_path: Path, test_graph, test_features: dict[str, Any]
 ) -> None:
     """Test that SQLite store uses Ibis backend.
 
@@ -57,7 +60,7 @@ def test_sqlite_uses_ibis_backend(
 
 
 def test_sqlite_conn_property_enforcement(
-    tmp_path: Path, test_graph, test_features: dict
+    tmp_path: Path, test_graph, test_features: dict[str, Any]
 ) -> None:
     """Test that conn property enforces store is open.
 
@@ -81,7 +84,7 @@ def test_sqlite_conn_property_enforcement(
 
 
 def test_sqlite_persistence_across_instances(
-    tmp_path: Path, test_graph, test_features: dict
+    tmp_path: Path, test_graph, test_features: dict[str, Any]
 ) -> None:
     """Test that data persists across different store instances.
 
@@ -117,7 +120,7 @@ def test_sqlite_persistence_across_instances(
         assert set(result["sample_id"].to_list()) == {1, 2, 3}
 
 
-def test_sqlite_in_memory(test_graph, test_features: dict) -> None:
+def test_sqlite_in_memory(test_graph, test_features: dict[str, Any]) -> None:
     """Test SQLite in-memory database.
 
     Args:
@@ -146,7 +149,7 @@ def test_sqlite_in_memory(test_graph, test_features: dict) -> None:
 
 
 def test_sqlite_close_idempotent(
-    tmp_path: Path, test_graph, test_features: dict
+    tmp_path: Path, test_graph, test_features: dict[str, Any]
 ) -> None:
     """Test that close() can be called multiple times safely.
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes basedpyright errors across tests and examples, aligns tooling to basedpyright, and refreshes snapshots to make type checking pass and stabilize test outputs.

- **Bug Fixes**
  - Typed test fixtures and params with dict[str, Any]; replaced broad ignores with targeted pyright directives.
  - Converted Narwhals frames to Polars where schema access or joins are needed; updated example to use collect().shape[0].
  - Updated migrations/CLI tests to the current reconciliation model (removed from_/to), and added snapshot assertions for feature versions, migration YAML, and CLI output.
  - Adjusted backfill execute signature to match base and used to_polars for joins; ensured resolve_data_version_diff returns eager DiffResult with lazy=False.

- **Dependencies**
  - Switched Zed to basedpyright and configured pyright in pyproject (include examples, suppress Any reports).
  - Updated docs with stricter QA/dev steps and Narwhals public types (nw.DataFrame[Any]/nw.LazyFrame[Any]); removed obsolete task-worker agent.
  - Added/updated test snapshots across data versioning, migrations, CLI, and metadata stores.

<!-- End of auto-generated description by cubic. -->

