### PR TITLE
rename sample_id -> sample_uid and snapshot_id -> snapshot_version

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -91,15 +91,15 @@ $ metaxy migrations generate [OPTIONS]
 **Options**:
 
 * `--migrations-dir`: Directory for migration files (uses config if not specified)
-* `--from-snapshot`: Compare from this historical snapshot ID (optional)
-* `--to-snapshot`: Compare to this historical snapshot ID (optional)
+* `--from-snapshot`: Compare from this historical snapshot version (optional)
+* `--to-snapshot`: Compare to this historical snapshot version (optional)
 
 
 ## `metaxy migrations scaffold`
 
 Create an empty migration scaffold for user-defined operations.
 
-Generates a migration file template with: - Snapshot IDs from current store state - Empty operations list for manual 
+Generates a migration file template with: - Snapshot versions from current store state - Empty operations list for manual 
 editing - Proper structure and metadata
 
 Use this when you need to write custom migration operations that can't be auto-generated (e.g., complex data 
@@ -115,8 +115,8 @@ $ metaxy migrations scaffold [OPTIONS]
 
 * `--migrations-dir`: Directory for migration files (uses config if not specified)
 * `--description`: Migration description (optional)
-* `--from-snapshot`: Use this as from_snapshot_id (defaults to latest in store)
-* `--to-snapshot`: Use this as to_snapshot_id (defaults to current graph)
+* `--from-snapshot`: Use this as from_snapshot_version (defaults to latest in store)
+* `--to-snapshot`: Use this as to_snapshot_version (defaults to current graph)
 
 
 ## `metaxy migrations apply`
@@ -179,7 +179,7 @@ $ metaxy graph COMMAND
 
 Record all feature versions (push graph snapshot).
 
-Records all features in the active graph to the metadata store with a deterministic snapshot ID. This should be run 
+Records all features in the active graph to the metadata store with a deterministic snapshot version. This should be run 
 after deploying new feature definitions.
 
 **Usage**:
@@ -197,7 +197,7 @@ $ metaxy graph push [ARGS]
 
 Show history of recorded graph snapshots.
 
-Displays all recorded graph snapshots from the metadata store, showing snapshot IDs, when they were recorded, and 
+Displays all recorded graph snapshots from the metadata store, showing snapshot versions, when they were recorded, and 
 feature counts.
 
 **Usage**:
@@ -227,7 +227,7 @@ $ metaxy graph describe [ARGS]
 
 **Options**:
 
-* `SNAPSHOT, --snapshot`: Snapshot ID to describe (defaults to current graph from code)
+* `SNAPSHOT, --snapshot`: Snapshot version to describe (defaults to current graph from code)
 * `STORE, --store`: Metadata store to use (defaults to configured default store)
 
 
@@ -261,7 +261,7 @@ $ metaxy graph render [ARGS]
 * `SHOW-FEATURE-VERSIONS, --show-feature-versions, --no-show-feature-versions`: Render configuration  *[default: --show-feature-versions]*
 * `SHOW-FIELD-VERSIONS, --show-field-versions, --no-show-field-versions`: Render configuration  *[default: --show-field-versions]*
 * `SHOW-CODE-VERSIONS, --show-code-versions, --no-show-code-versions`: Render configuration  *[default: --no-show-code-versions]*
-* `SHOW-SNAPSHOT-ID, --show-snapshot-id, --no-show-snapshot-id`: Render configuration  *[default: --show-snapshot-id]*
+* `SHOW-SNAPSHOT-VERSION, --show-snapshot-version, --no-show-snapshot-version`: Render configuration  *[default: --show-snapshot-version]*
 * `HASH-LENGTH, --hash-length`: Render configuration  *[default: 8]*
 * `DIRECTION, --direction`: Render configuration  *[default: TB]*
 * `FEATURE, --feature`: Render configuration
@@ -270,7 +270,7 @@ $ metaxy graph render [ARGS]
 * `-f, --format`: Output format: terminal, mermaid, or graphviz  *[default: terminal]*
 * `-t, --type`: Terminal rendering type: graph or cards (only for --format terminal)  *[choices: graph, cards]*  *[default: graph]*
 * `-o, --output`: Output file path (default: stdout)
-* `SNAPSHOT, --snapshot`: Snapshot ID to render (default: current graph from code)
+* `SNAPSHOT, --snapshot`: Snapshot version to render (default: current graph from code)
 * `STORE, --store`: Metadata store to use (for loading historical snapshots)
 * `MINIMAL, --minimal, --no-minimal`: Minimal output: only feature keys and dependencies  *[default: --no-minimal]*
 * `VERBOSE, --verbose, --no-verbose`: Verbose output: show all available information  *[default: --no-verbose]*
@@ -324,9 +324,9 @@ Copies metadata for specified features from one store to another, optionally usi
 Migrating data between environments - Backfilling metadata - Copying specific feature versions
 
 Incremental Mode (default):
-    By default, performs an anti-join on sample_id to skip rows that already exist in the destination for the same 
-snapshot_id. This prevents duplicate writes.  Disabling incremental (--no-incremental) may improve performance when: - 
-The destination store is empty or has no overlap with source - The destination store has eventual deduplication
+    By default, performs an anti-join on sample_uid to skip rows that already exist in the destination for the same 
+snapshot_version. This prevents duplicate writes.  Disabling incremental (--no-incremental) may improve performance 
+when: - The destination store is empty or has no overlap with source - The destination store has eventual deduplication
 
 **Usage**:
 
@@ -344,7 +344,7 @@ $ metaxy metadata copy FROM TO [ARGS]
 * `FEATURE, --feature, --empty-feature`: Feature key to copy (e.g., 'my_feature' or 'group/my_feature'). Can be repeated multiple times. If not specified, uses 
 --all-features.
 * `ALL-FEATURES, --all-features, --no-all-features`: Copy all features from source store  *[default: --no-all-features]*
-* `SNAPSHOT, --snapshot`: Snapshot ID to copy (defaults to latest in source store). The snapshot_id is preserved in the destination.
+* `SNAPSHOT, --snapshot`: Snapshot version to copy (defaults to latest in source store). The snapshot_version is preserved in the destination.
 * `INCREMENTAL, --incremental, --no-incremental`: Use incremental copy (compare data_version to skip existing rows). Disable for better performance if destination is 
 empty or uses deduplication.  *[default: --incremental]*
 

--- a/examples/src/examples/migration/compute_child.py
+++ b/examples/src/examples/migration/compute_child.py
@@ -12,7 +12,7 @@ load_features()
 # Get feature class
 ChildFeature = get_feature_by_key(FeatureKey(["examples", "child"]))
 
-# Load upstream data for sample_ids
+# Load upstream data for sample_uids
 data_dir = Path("/tmp/migration_example_data")
 upstream_data = pl.read_parquet(data_dir / "upstream_data.parquet")
 
@@ -23,7 +23,7 @@ with config.get_store() as store:
     print(f"  feature_version: {ChildFeature.feature_version()[:16]}...")
 
     # Use resolve_update to calculate what needs computing
-    child_samples = upstream_data.select("sample_id")
+    child_samples = upstream_data.select("sample_uid")
     diff_result = store.resolve_update(ChildFeature, sample_df=child_samples)
 
     print(
@@ -47,4 +47,4 @@ with config.get_store() as store:
     print("\n📋 Child data_versions:")
     for row in child_eager.iter_rows(named=True):
         dv = row["data_version"]["predictions"]
-        print(f"  sample_id={row['sample_id']}: {dv[:16]}...")
+        print(f"  sample_uid={row['sample_uid']}: {dv[:16]}...")

--- a/examples/src/examples/migration/compute_parent.py
+++ b/examples/src/examples/migration/compute_parent.py
@@ -25,9 +25,9 @@ with config.get_store() as store:
     # Simulate computing embeddings - same computation in both versions
     parent_data = pl.DataFrame(
         {
-            "sample_id": upstream_data["sample_id"],
+            "sample_uid": upstream_data["sample_uid"],
             "data_version": [
-                {"embeddings": f"embed_{sid}"} for sid in upstream_data["sample_id"]
+                {"embeddings": f"embed_{sid}"} for sid in upstream_data["sample_uid"]
             ],
         }
     )

--- a/examples/src/examples/migration/metaxy/migrations/20251023_215316_update_examples_child.yaml
+++ b/examples/src/examples/migration/metaxy/migrations/20251023_215316_update_examples_child.yaml
@@ -1,8 +1,8 @@
 version: 1
 id: migration_20251023_215316
 parent_migration_id: null
-from_snapshot_id: 4bd4903139e33cd4923b59eaf577e1233aa28123968c48f063dc942f2188768a
-to_snapshot_id: 2dc63e7b0fa38ca5d98dcc343f24f954c5f6638c03989f5bb666acf7aec1b4d5
+from_snapshot_version: 4bd4903139e33cd4923b59eaf577e1233aa28123968c48f063dc942f2188768a
+to_snapshot_version: 2dc63e7b0fa38ca5d98dcc343f24f954c5f6638c03989f5bb666acf7aec1b4d5
 description: Auto-generated migration for 1 changed feature(s) + 0 downstream
 created_at: 2025-10-23 21:53:16.473975
 feature_class_overrides: {}

--- a/examples/src/examples/migration/push.py
+++ b/examples/src/examples/migration/push.py
@@ -4,6 +4,6 @@ from metaxy import MetaxyConfig
 
 config = MetaxyConfig.load(search_parents=True)
 with config.get_store() as store:
-    snapshot_id = store.record_feature_graph_snapshot()
-    print(f"📸 Recorded feature graph snapshot: {snapshot_id[:16]}...")
-    print(f"   Full ID: {snapshot_id}")
+    snapshot_version = store.record_feature_graph_snapshot()
+    print(f"📸 Recorded feature graph snapshot: {snapshot_version[:16]}...")
+    print(f"   Full ID: {snapshot_version}")

--- a/examples/src/examples/migration/setup_data.py
+++ b/examples/src/examples/migration/setup_data.py
@@ -11,7 +11,7 @@ data_dir.mkdir(exist_ok=True)
 # Create upstream data
 upstream_data = pl.DataFrame(
     {
-        "sample_id": ["video1", "video2", "video3"],
+        "sample_uid": ["video1", "video2", "video3"],
         "data_version": [
             {"frames": "upstream_v1_frames"},
             {"frames": "upstream_v2_frames"},

--- a/examples/src/examples/recompute/compute_child.py
+++ b/examples/src/examples/recompute/compute_child.py
@@ -27,15 +27,15 @@ ParentFeature = get_feature_by_key(parent_key)
 # Get metadata store from metaxy.toml config
 with MetaxyConfig.load().get_store() as store:
     # Save feature graph snapshot, normally this should be done in CI/CD before running the pipeline
-    snapshot_id, _ = store.record_feature_graph_snapshot()
+    snapshot_version, _ = store.record_feature_graph_snapshot()
 
-    print(f"Graph snapshot_id: {snapshot_id}")
+    print(f"Graph snapshot_version: {snapshot_version}")
 
     # Compute child feature (e.g., generate predictions from embeddings)
     print(f"\n📊 Computing {ChildFeature.spec.key.to_string()}...")
     print(f"  feature_version: {ChildFeature.feature_version()}")
 
-    ids_lazy = store.read_metadata(ParentFeature, columns=["sample_id"])
+    ids_lazy = store.read_metadata(ParentFeature, columns=["sample_uid"])
     # Materialize for now (sample_df parameter support pending)
     ids = ids_lazy.collect().to_polars()
 
@@ -62,4 +62,4 @@ with MetaxyConfig.load().get_store() as store:
     child_df = child_result.collect().to_polars()
     for row in child_df.iter_rows(named=True):
         dv = row["data_version"]
-        print(f"  sample_id={row['sample_id']}: {dv}")
+        print(f"  sample_uid={row['sample_uid']}: {dv}")

--- a/examples/src/examples/recompute/compute_parent.py
+++ b/examples/src/examples/recompute/compute_parent.py
@@ -27,9 +27,9 @@ ParentFeature = get_feature_by_key(parent_key)
 # Get metadata store from metaxy.toml config
 with MetaxyConfig.load().get_store() as store:
     # Save feature graph snapshot, normally this should be done in CI/CD before running the pipeline
-    snapshot_id, _ = store.record_feature_graph_snapshot()
+    snapshot_version, _ = store.record_feature_graph_snapshot()
 
-    print(f"Graph snapshot_id: {snapshot_id}")
+    print(f"Graph snapshot_version: {snapshot_version}")
 
     # Check if metadata already exists for current feature_version (avoid duplicates)
     try:
@@ -46,7 +46,7 @@ with MetaxyConfig.load().get_store() as store:
 
     parent_metadata = pl.DataFrame(
         {
-            "sample_id": [1, 2, 3],
+            "sample_uid": [1, 2, 3],
             "raw_data": ["sample_1_data", "sample_2_data", "sample_3_data"],
             "data_version": [
                 {"embeddings": "v1"},
@@ -55,7 +55,7 @@ with MetaxyConfig.load().get_store() as store:
             ],
         },
         schema={
-            "sample_id": pl.UInt32,
+            "sample_uid": pl.UInt32,
             "raw_data": pl.Utf8,
             "data_version": pl.Struct({"embeddings": pl.Utf8}),
         },

--- a/src/metaxy/cli/metadata.py
+++ b/src/metaxy/cli/metadata.py
@@ -56,7 +56,7 @@ def copy(
         str | None,
         cyclopts.Parameter(
             name=["--snapshot"],
-            help="Snapshot ID to copy (defaults to latest in source store). The snapshot_id is preserved in the destination.",
+            help="Snapshot version to copy (defaults to latest in source store). The snapshot_version is preserved in the destination.",
         ),
     ] = None,
     incremental: Annotated[
@@ -76,8 +76,8 @@ def copy(
     - Copying specific feature versions
 
     Incremental Mode (default):
-        By default, performs an anti-join on sample_id to skip rows that already exist
-        in the destination for the same snapshot_id. This prevents duplicate writes.
+        By default, performs an anti-join on sample_uid to skip rows that already exist
+        in the destination for the same snapshot_version. This prevents duplicate writes.
 
         Disabling incremental (--no-incremental) may improve performance when:
         - The destination store is empty or has no overlap with source

--- a/src/metaxy/cli/migrations.py
+++ b/src/metaxy/cli/migrations.py
@@ -28,11 +28,15 @@ def generate(
     ] = None,
     from_snapshot: Annotated[
         str | None,
-        cyclopts.Parameter(help="Compare from this historical snapshot ID (optional)"),
+        cyclopts.Parameter(
+            help="Compare from this historical snapshot version (optional)"
+        ),
     ] = None,
     to_snapshot: Annotated[
         str | None,
-        cyclopts.Parameter(help="Compare to this historical snapshot ID (optional)"),
+        cyclopts.Parameter(
+            help="Compare to this historical snapshot version (optional)"
+        ),
     ] = None,
 ):
     """Generate migration file from detected feature changes.
@@ -78,8 +82,8 @@ def generate(
         # Generate migration (returns Migration object)
         migration = generate_migration(
             metadata_store,
-            from_snapshot_id=from_snapshot,
-            to_snapshot_id=to_snapshot,
+            from_snapshot_version=from_snapshot,
+            to_snapshot_version=to_snapshot,
         )
 
         if migration is None:
@@ -128,20 +132,20 @@ def scaffold(
     from_snapshot: Annotated[
         str | None,
         cyclopts.Parameter(
-            help="Use this as from_snapshot_id (defaults to latest in store)"
+            help="Use this as from_snapshot_version (defaults to latest in store)"
         ),
     ] = None,
     to_snapshot: Annotated[
         str | None,
         cyclopts.Parameter(
-            help="Use this as to_snapshot_id (defaults to current graph)"
+            help="Use this as to_snapshot_version (defaults to current graph)"
         ),
     ] = None,
 ):
     """Create an empty migration scaffold for user-defined operations.
 
     Generates a migration file template with:
-    - Snapshot IDs from current store state
+    - Snapshot versions from current store state
     - Empty operations list for manual editing
     - Proper structure and metadata
 
@@ -174,7 +178,7 @@ def scaffold(
 
     metadata_store = get_store()
     with metadata_store:
-        # Get from_snapshot_id (use provided or default to latest in store)
+        # Get from_snapshot_version (use provided or default to latest in store)
         if from_snapshot is None:
             try:
                 feature_versions = metadata_store.read_metadata(
@@ -191,7 +195,7 @@ def scaffold(
                     # Convert to Polars for indexing
 
                     latest_native = nw.from_native(latest_snapshot).to_polars()
-                    from_snapshot_id = latest_native["snapshot_id"].item()
+                    from_snapshot_version = latest_native["snapshot_version"].item()
                 else:
                     app.error_console.print(
                         "[red]✗[/red] No feature snapshots found in store."
@@ -209,14 +213,14 @@ def scaffold(
                 )
                 raise SystemExit(1)
         else:
-            from_snapshot_id = from_snapshot
+            from_snapshot_version = from_snapshot
 
-        # Get to_snapshot_id (use provided or default to current graph)
+        # Get to_snapshot_version (use provided or default to current graph)
         if to_snapshot is None:
             graph = FeatureGraph.get_active()
-            to_snapshot_id = graph.snapshot_id
+            to_snapshot_version = graph.snapshot_version
         else:
-            to_snapshot_id = to_snapshot
+            to_snapshot_version = to_snapshot
 
         # Get parent migration ID
         parent_migration_id = None
@@ -249,8 +253,8 @@ def scaffold(
             version=1,
             id=migration_id,
             parent_migration_id=parent_migration_id,
-            from_snapshot_id=from_snapshot_id,
-            to_snapshot_id=to_snapshot_id,
+            from_snapshot_version=from_snapshot_version,
+            to_snapshot_version=to_snapshot_version,
             description=description or "User-defined migration",
             created_at=timestamp,
             operations=[],  # Empty - user will add custom operations

--- a/src/metaxy/cli/push.py
+++ b/src/metaxy/cli/push.py
@@ -9,18 +9,18 @@ def push(store: str | None = None):
     """Record all feature versions (push graph snapshot).
 
     Records all features in the active graph to the metadata store
-    with a deterministic snapshot ID. This should be run after deploying
+    with a deterministic snapshot version. This should be run after deploying
     new feature definitions.
 
     Example:
         $ metaxy push
 
         ✓ Recorded feature graph
-          Snapshot ID: abc123def456...
+          Snapshot version: abc123def456...
 
         # Or if already recorded:
         ℹ Snapshot already recorded (skipped)
-          Snapshot ID: abc123def456...
+          Snapshot version: abc123def456...
 
     Args:
         store: The metadata store to use. Defaults to the default store.
@@ -30,16 +30,16 @@ def push(store: str | None = None):
     metadata_store = get_store(store)
 
     with metadata_store:
-        snapshot_id, was_already_recorded = (
+        snapshot_version, was_already_recorded = (
             metadata_store.record_feature_graph_snapshot()
         )
 
         if was_already_recorded:
             console.print("[blue]ℹ[/blue] Snapshot already recorded (skipped)")
-            console.print(f"  Snapshot ID: {snapshot_id}")
+            console.print(f"  Snapshot version: {snapshot_version}")
         else:
             console.print("[green]✓[/green] Recorded feature graph")
-            console.print(f"  Snapshot ID: {snapshot_id}")
+            console.print(f"  Snapshot version: {snapshot_version}")
 
 
 if __name__ == "__main__":

--- a/src/metaxy/data_versioning/calculators/base.py
+++ b/src/metaxy/data_versioning/calculators/base.py
@@ -89,7 +89,7 @@ class DataVersionCalculator(ABC):
 
         Returns:
             Narwhals LazyFrame with data_version column added
-            Shape: [sample_id, __upstream_*__data_version columns, data_version (new)]
+            Shape: [sample_uid, __upstream_*__data_version columns, data_version (new)]
 
         Raises:
             ValueError: If hash_algorithm not in supported_algorithms

--- a/src/metaxy/data_versioning/diff/base.py
+++ b/src/metaxy/data_versioning/diff/base.py
@@ -27,14 +27,14 @@ class LazyDiffResult(NamedTuple):
 
     Attributes:
         added: New samples (lazy, never None - empty LazyFrame instead)
-            Columns: [sample_id, data_version, ...user columns...]
+            Columns: [sample_uid, data_version, ...user columns...]
         changed: Changed samples (lazy, never None)
-            Columns: [sample_id, data_version, ...user columns...]
+            Columns: [sample_uid, data_version, ...user columns...]
         removed: Removed samples (lazy, never None)
-            Columns: [sample_id, data_version, ...user columns...]
+            Columns: [sample_uid, data_version, ...user columns...]
 
     Note:
-        May contain additional user columns beyond sample_id and data_version,
+        May contain additional user columns beyond sample_uid and data_version,
         depending on what was passed to resolve_update() via align_upstream_metadata.
     """
 
@@ -67,14 +67,14 @@ class DiffResult(NamedTuple):
 
     Attributes:
         added: New samples (eager, never None - empty DataFrame instead)
-            Columns: [sample_id, data_version, ...user columns...]
+            Columns: [sample_uid, data_version, ...user columns...]
         changed: Changed samples (eager, never None)
-            Columns: [sample_id, data_version, ...user columns...]
+            Columns: [sample_uid, data_version, ...user columns...]
         removed: Removed samples (eager, never None)
-            Columns: [sample_id, data_version, ...user columns...]
+            Columns: [sample_uid, data_version, ...user columns...]
 
     Note:
-        May contain additional user columns beyond sample_id and data_version,
+        May contain additional user columns beyond sample_uid and data_version,
         depending on what was passed to resolve_update() via align_upstream_metadata.
     """
 
@@ -125,9 +125,9 @@ class MetadataDiffResolver(ABC):
 
         Args:
             target_versions: Narwhals LazyFrame with newly calculated data_versions
-                Shape: [sample_id, data_version (calculated), upstream columns...]
+                Shape: [sample_uid, data_version (calculated), upstream columns...]
             current_metadata: Narwhals LazyFrame with current metadata, or None
-                Shape: [sample_id, data_version (existing), feature_version, custom columns...]
+                Shape: [sample_uid, data_version (existing), feature_version, custom columns...]
                 Should be pre-filtered by feature_version at the caller level if needed.
 
         Returns:

--- a/src/metaxy/data_versioning/joiners/base.py
+++ b/src/metaxy/data_versioning/joiners/base.py
@@ -37,7 +37,7 @@ class UpstreamJoiner(ABC):
     ) -> tuple[nw.LazyFrame[Any], dict[str, str]]:
         """Join all upstream features together.
 
-        Joins upstream feature metadata on sample_id to create a unified reference
+        Joins upstream feature metadata on sample_uid to create a unified reference
         containing all upstream data_version columns needed for hash calculation.
 
         Args:
@@ -50,12 +50,12 @@ class UpstreamJoiner(ABC):
         Returns:
             Tuple of (joined_ref, upstream_column_mapping):
             - joined_ref: Narwhals LazyFrame with all upstream data joined
-                Shape: [sample_id, __upstream_video__data_version, __upstream_audio__data_version, ...]
+                Shape: [sample_uid, __upstream_video__data_version, __upstream_audio__data_version, ...]
             - upstream_column_mapping: Maps upstream feature key -> column name
                 Example: {"video": "__upstream_video__data_version"}
 
         Note:
-            Uses INNER join by default - only sample_ids present in ALL upstream features
+            Uses INNER join by default - only sample_uids present in ALL upstream features
             are included. This ensures we can compute valid data_versions.
         """
         pass

--- a/src/metaxy/graph/renderers/base.py
+++ b/src/metaxy/graph/renderers/base.py
@@ -34,9 +34,9 @@ class RenderConfig:
         metadata={"help": "Show feature and field code versions"},
     )
 
-    show_snapshot_id: bool = field(
+    show_snapshot_version: bool = field(
         default=True,
-        metadata={"help": "Show graph snapshot ID in output"},
+        metadata={"help": "Show graph snapshot version in output"},
     )
 
     # Display options
@@ -97,7 +97,7 @@ class RenderConfig:
             show_feature_versions=False,
             show_field_versions=False,
             show_code_versions=False,
-            show_snapshot_id=False,
+            show_snapshot_version=False,
         )
 
     @classmethod
@@ -108,7 +108,7 @@ class RenderConfig:
             show_feature_versions=True,
             show_field_versions=True,
             show_code_versions=False,
-            show_snapshot_id=True,
+            show_snapshot_version=True,
             hash_length=8,
         )
 
@@ -120,7 +120,7 @@ class RenderConfig:
             show_feature_versions=True,
             show_field_versions=True,
             show_code_versions=True,
-            show_snapshot_id=True,
+            show_snapshot_version=True,
             hash_length=0,  # Full hashes
         )
 

--- a/src/metaxy/graph/renderers/cards.py
+++ b/src/metaxy/graph/renderers/cards.py
@@ -37,9 +37,11 @@ class TerminalCardsRenderer(GraphRenderer):
 
         # Build edges representation
         edges_text = Text()
-        if self.config.show_snapshot_id:
-            snapshot_id = self._format_hash(self.graph.snapshot_id)
-            edges_text.append(f"📊 Graph (snapshot: {snapshot_id})\n\n", style="bold")
+        if self.config.show_snapshot_version:
+            snapshot_version = self._format_hash(self.graph.snapshot_version)
+            edges_text.append(
+                f"📊 Graph (snapshot: {snapshot_version})\n\n", style="bold"
+            )
         else:
             edges_text.append("📊 Graph\n\n", style="bold")
 

--- a/src/metaxy/graph/renderers/graphviz.py
+++ b/src/metaxy/graph/renderers/graphviz.py
@@ -28,8 +28,10 @@ class GraphvizRenderer(GraphRenderer):
         lines.append(f"    rankdir={rankdir};")
 
         # Graph attributes
-        if self.config.show_snapshot_id:
-            label = f"Graph (snapshot: {self._format_hash(self.graph.snapshot_id)})"
+        if self.config.show_snapshot_version:
+            label = (
+                f"Graph (snapshot: {self._format_hash(self.graph.snapshot_version)})"
+            )
         else:
             label = "Graph"
         lines.append(f'    label="{label}";')

--- a/src/metaxy/graph/renderers/mermaid.py
+++ b/src/metaxy/graph/renderers/mermaid.py
@@ -49,8 +49,8 @@ class MermaidRenderer(GraphRenderer):
 
         # Create flowchart
         title = ""
-        if self.config.show_snapshot_id:
-            snapshot_hash = self._format_hash(self.graph.snapshot_id)
+        if self.config.show_snapshot_version:
+            snapshot_hash = self._format_hash(self.graph.snapshot_version)
             title = f"Feature Graph (snapshot: {snapshot_hash})"
         else:
             title = "Feature Graph"

--- a/src/metaxy/graph/renderers/rich.py
+++ b/src/metaxy/graph/renderers/rich.py
@@ -25,9 +25,11 @@ class TerminalRenderer(GraphRenderer):
         console = Console()
 
         # Create root node
-        if self.config.show_snapshot_id:
-            snapshot_id = self._format_hash(self.graph.snapshot_id)
-            root = Tree(f"📊 [bold]Graph[/bold] [dim](snapshot: {snapshot_id})[/dim]")
+        if self.config.show_snapshot_version:
+            snapshot_version = self._format_hash(self.graph.snapshot_version)
+            root = Tree(
+                f"📊 [bold]Graph[/bold] [dim](snapshot: {snapshot_version})[/dim]"
+            )
         else:
             root = Tree("📊 [bold]Graph[/bold]")
 

--- a/src/metaxy/metadata_store/ibis.py
+++ b/src/metaxy/metadata_store/ibis.py
@@ -317,7 +317,7 @@ class IbisMetadataStore(MetadataStore):
         if table_name not in existing_tables:
             # Create table from DataFrame
             # Ensure NULL columns have proper types by filling with a typed value
-            # This handles cases like snapshot_id which can be NULL
+            # This handles cases like snapshot_version which can be NULL
             df_typed = df
             for col in df.columns:
                 if df[col].dtype == pl.Null:

--- a/src/metaxy/migrations/detector.py
+++ b/src/metaxy/migrations/detector.py
@@ -15,10 +15,10 @@ if TYPE_CHECKING:
 
 def detect_feature_changes(
     store: "MetadataStore",
-    from_snapshot_id: str,
-    to_snapshot_id: str,
+    from_snapshot_version: str,
+    to_snapshot_version: str,
 ) -> list[DataVersionReconciliation]:
-    """Detect feature changes by comparing snapshot_ids directly.
+    """Detect feature changes by comparing snapshot_versions directly.
 
     Pure comparison function that compares feature versions between two snapshots
     by querying their snapshot metadata from the store.
@@ -32,15 +32,15 @@ def detect_feature_changes(
 
     Args:
         store: Metadata store containing snapshot metadata
-        from_snapshot_id: Source snapshot ID (old state)
-        to_snapshot_id: Target snapshot ID (new state)
+        from_snapshot_version: Source snapshot version (old state)
+        to_snapshot_version: Target snapshot version (new state)
 
     Returns:
         List of DataVersionReconciliation operations for changed features
 
     Example:
         >>> # Compare latest snapshot in store vs current snapshot
-        >>> operations = detect_feature_changes(store, old_snapshot_id, new_snapshot_id)
+        >>> operations = detect_feature_changes(store, old_snapshot_version, new_snapshot_version)
         >>> for op in operations:
         ...     print(f"Changed: {op.feature_key} - {op.reason}")
     """
@@ -52,7 +52,7 @@ def detect_feature_changes(
             FEATURE_VERSIONS_KEY,
             current_only=False,
             allow_fallback=False,
-            filters=[nw.col("snapshot_id") == from_snapshot_id],
+            filters=[nw.col("snapshot_version") == from_snapshot_version],
         )
     except FeatureNotFoundError:
         # No from_snapshot - nothing to migrate from
@@ -63,7 +63,7 @@ def detect_feature_changes(
             FEATURE_VERSIONS_KEY,
             current_only=False,
             allow_fallback=False,
-            filters=[nw.col("snapshot_id") == to_snapshot_id],
+            filters=[nw.col("snapshot_version") == to_snapshot_version],
         )
     except FeatureNotFoundError:
         # No to_snapshot - nothing to migrate to

--- a/src/metaxy/migrations/models.py
+++ b/src/metaxy/migrations/models.py
@@ -75,10 +75,10 @@ class Migration(pydantic.BaseModel):
     parent_migration_id: str | None = (
         None  # Parent migration (None for first migration)
     )
-    from_snapshot_id: (
+    from_snapshot_version: (
         str  # Feature graph snapshot before migration (current state in store)
     )
-    to_snapshot_id: str  # Feature graph snapshot after migration (target state)
+    to_snapshot_version: str  # Feature graph snapshot after migration (target state)
     description: str
     created_at: datetime  # When migration was created
 

--- a/tests/__snapshots__/test_data_versioning_components.ambr
+++ b/tests/__snapshots__/test_data_versioning_components.ambr
@@ -39,12 +39,12 @@
     dict({
       'analysis': '2f84e757b1addd884db7365ed37557a320ab69dbd4fe09975f509c07b336a43f',
       'fusion': 'ad303eba05da467ded17cc6eaf72d16dbc40c338c802a0911a4aa229d7bdd482',
-      'sample_id': 1,
+      'sample_uid': 1,
     }),
     dict({
       'analysis': '39cd90847cb18c3f7c31a73be7f6d269364e8263dce2a9d923144489a78338c6',
       'fusion': '5dba65c3be22714cfaf969bcd63c4df6d329761b62f01e430316bde62b2ea53a',
-      'sample_id': 2,
+      'sample_uid': 2,
     }),
   ])
 # ---
@@ -53,12 +53,12 @@
     dict({
       'analysis': '13727348181400861260',
       'fusion': '370342096193421791',
-      'sample_id': 1,
+      'sample_uid': 1,
     }),
     dict({
       'analysis': '5047585375639731387',
       'fusion': '1768440773501995386',
-      'sample_id': 2,
+      'sample_uid': 2,
     }),
   ])
 # ---
@@ -67,12 +67,12 @@
     dict({
       'analysis': '11444342552948413717',
       'fusion': '3008611161107019102',
-      'sample_id': 1,
+      'sample_uid': 1,
     }),
     dict({
       'analysis': '10628887372866074486',
       'fusion': '14013057675311053626',
-      'sample_id': 2,
+      'sample_uid': 2,
     }),
   ])
 # ---

--- a/tests/cli/__snapshots__/test_cli_e2e.ambr
+++ b/tests/cli/__snapshots__/test_cli_e2e.ambr
@@ -23,7 +23,7 @@
       '3c5b4c900fdf1b7f5c08736233f70738a9ca73f94c6aa2b60aeefb5b46105085',
     ]),
     'row_count': 4,
-    'sample_ids': list([
+    'sample_uids': list([
       'video1.mp4',
       'video2.mp4',
     ]),

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -111,7 +111,7 @@ database = "{db_path}"
             TestFeature = cli_graph.features_by_key[FeatureKey(["test_cli", "feature"])]
             data = pl.DataFrame(
                 {
-                    "sample_id": [1, 2],
+                    "sample_uid": [1, 2],
                     "data_version": [{"default": "h1"}, {"default": "h2"}],
                 }
             )
@@ -154,7 +154,7 @@ config.database = "{db_path}"
 
         # Record a snapshot first so migration can load historical graph
         with store:
-            snapshot_id, _ = store.record_feature_graph_snapshot()
+            snapshot_version, _ = store.record_feature_graph_snapshot()
 
             # Verify snapshot was recorded
             from metaxy.metadata_store.base import FEATURE_VERSIONS_KEY
@@ -163,8 +163,8 @@ config.database = "{db_path}"
                 store.read_metadata(FEATURE_VERSIONS_KEY, current_only=False)
             )
             assert len(fv) > 0, "No feature versions recorded"
-            assert snapshot_id in fv["snapshot_id"].to_list(), (
-                f"Snapshot {snapshot_id} not in table"
+            assert snapshot_version in fv["snapshot_version"].to_list(), (
+                f"Snapshot {snapshot_version} not in table"
             )
 
         # Create test migration file
@@ -175,8 +175,8 @@ config.database = "{db_path}"
             version=1,
             id="test_migration",
             parent_migration_id=None,
-            from_snapshot_id=snapshot_id,
-            to_snapshot_id=snapshot_id,
+            from_snapshot_version=snapshot_version,
+            to_snapshot_version=snapshot_version,
             description="Test",
             created_at=datetime(2025, 1, 1, 0, 0, 0),
             operations=[

--- a/tests/cli/test_cli_e2e.py
+++ b/tests/cli/test_cli_e2e.py
@@ -132,7 +132,7 @@ def test_cli_e2e_duckdb_workflow(e2e_project: Path, snapshot: SnapshotAssertion)
             # Write initial metadata
             video_files_data = pl.DataFrame(
                 {
-                    "sample_id": ["video1.mp4", "video2.mp4"],
+                    "sample_uid": ["video1.mp4", "video2.mp4"],
                     "path": ["/data/video1.mp4", "/data/video2.mp4"],
                     "data_version": [{"default": "hash1"}, {"default": "hash2"}],
                 }
@@ -142,17 +142,17 @@ def test_cli_e2e_duckdb_workflow(e2e_project: Path, snapshot: SnapshotAssertion)
             # Write processing metadata
             processing_data = pl.DataFrame(
                 {
-                    "sample_id": ["video1.mp4", "video2.mp4"],
+                    "sample_uid": ["video1.mp4", "video2.mp4"],
                     "data_version": [{"frames": "proc1"}, {"frames": "proc2"}],
                 }
             )
             store.write_metadata(VideoProcessing, processing_data)
 
             # Step 2: Push (record feature versions)
-            snapshot_id_v1, _ = store.record_feature_graph_snapshot()
+            snapshot_version_v1, _ = store.record_feature_graph_snapshot()
 
-            assert snapshot_id_v1 is not None
-            assert len(snapshot_id_v1) == 64  # Full SHA256 hash
+            assert snapshot_version_v1 is not None
+            assert len(snapshot_version_v1) == 64  # Full SHA256 hash
 
         # Store is now closed, data is persisted to DuckDB
 
@@ -299,7 +299,7 @@ class VideoProcessing(Feature, spec=FeatureSpec(
             # Snapshot the final data state
             final_snapshot = {
                 "row_count": len(all_processing),
-                "sample_ids": sorted(all_processing["sample_id"].unique().to_list()),
+                "sample_uids": sorted(all_processing["sample_uid"].unique().to_list()),
                 "feature_versions": sorted(
                     all_processing["feature_version"].unique().to_list()
                 ),
@@ -361,7 +361,7 @@ def test_cli_migration_status_command(e2e_project: Path):
                 VideoFiles,
                 pl.DataFrame(
                     {
-                        "sample_id": ["v1"],
+                        "sample_uid": ["v1"],
                         "data_version": [{"default": "h1"}],
                     }
                 ),

--- a/tests/cli/test_cli_graph.py
+++ b/tests/cli/test_cli_graph.py
@@ -26,7 +26,7 @@ def test_graph_push_first_time(metaxy_project: TempMetaxyProject):
 
         assert result.returncode == 0
         assert "Recorded feature graph" in result.stdout
-        assert "Snapshot ID:" in result.stdout
+        assert "Snapshot version:" in result.stdout
 
 
 def test_graph_push_already_recorded(metaxy_project: TempMetaxyProject):
@@ -53,7 +53,7 @@ def test_graph_push_already_recorded(metaxy_project: TempMetaxyProject):
         # Second push - should skip
         result2 = metaxy_project.run_cli("graph", "push")
         assert "already recorded" in result2.stdout
-        assert "Snapshot ID:" in result2.stdout
+        assert "Snapshot version:" in result2.stdout
 
 
 def test_graph_history_empty(metaxy_project: TempMetaxyProject):
@@ -104,7 +104,7 @@ def test_graph_history_with_snapshots(metaxy_project: TempMetaxyProject):
 
         assert result.returncode == 0
         assert "Graph Snapshot History" in result.stdout
-        assert "Snapshot ID" in result.stdout
+        assert "Snapshot version" in result.stdout
         assert "Recorded At" in result.stdout
         assert "Feature Count" in result.stdout
         assert "1" in result.stdout  # 1 feature
@@ -230,7 +230,7 @@ def test_graph_describe_with_dependencies(metaxy_project: TempMetaxyProject):
 
 
 def test_graph_describe_historical_snapshot(metaxy_project: TempMetaxyProject):
-    """Test graph describe with specific snapshot ID."""
+    """Test graph describe with specific snapshot version."""
 
     def features():
         from metaxy import Feature, FeatureKey, FeatureSpec, FieldKey, FieldSpec
@@ -249,18 +249,20 @@ def test_graph_describe_historical_snapshot(metaxy_project: TempMetaxyProject):
         # Push to create snapshot
         push_result = metaxy_project.run_cli("graph", "push")
 
-        # Extract snapshot ID from output
-        match = re.search(r"Snapshot ID: ([a-f0-9]+)", push_result.stdout)
-        assert match, "Could not find snapshot ID in push output"
-        snapshot_id = match.group(1)
+        # Extract snapshot version from output
+        match = re.search(r"Snapshot version: ([a-f0-9]+)", push_result.stdout)
+        assert match, "Could not find snapshot version in push output"
+        snapshot_version = match.group(1)
 
         # Describe specific snapshot
-        result = metaxy_project.run_cli("graph", "describe", "--snapshot", snapshot_id)
+        result = metaxy_project.run_cli(
+            "graph", "describe", "--snapshot", snapshot_version
+        )
 
         assert result.returncode == 0
-        # Check that output contains "Describing snapshot" and the snapshot_id (may have newlines between them)
+        # Check that output contains "Describing snapshot" and the snapshot_version (may have newlines between them)
         assert "Describing snapshot" in result.stdout
-        assert snapshot_id in result.stdout
+        assert snapshot_version in result.stdout
         assert "Graph Snapshot:" in result.stdout
         assert "Feature Count" in result.stdout
 
@@ -320,14 +322,14 @@ def test_graph_workflow_integration(metaxy_project: TempMetaxyProject):
         push_result = metaxy_project.run_cli("graph", "push")
         assert "Recorded feature graph" in push_result.stdout
 
-        # Extract snapshot ID
-        match = re.search(r"Snapshot ID: ([a-f0-9]+)", push_result.stdout)
+        # Extract snapshot version
+        match = re.search(r"Snapshot version: ([a-f0-9]+)", push_result.stdout)
         assert match is not None
-        snapshot_id = match.group(1)
+        snapshot_version = match.group(1)
 
         # Step 2: History should show the snapshot
         history_result = metaxy_project.run_cli("graph", "history")
-        assert snapshot_id[:13] in history_result.stdout
+        assert snapshot_version[:13] in history_result.stdout
         assert "2" in history_result.stdout  # 2 features
 
         # Step 3: Describe should show current graph
@@ -337,11 +339,11 @@ def test_graph_workflow_integration(metaxy_project: TempMetaxyProject):
 
         # Step 4: Describe historical snapshot
         describe_historical = metaxy_project.run_cli(
-            "graph", "describe", "--snapshot", snapshot_id
+            "graph", "describe", "--snapshot", snapshot_version
         )
-        # Check that output contains "Describing snapshot" and the snapshot_id (may have newlines between them)
+        # Check that output contains "Describing snapshot" and the snapshot_version (may have newlines between them)
         assert "Describing snapshot" in describe_historical.stdout
-        assert snapshot_id in describe_historical.stdout
+        assert snapshot_version in describe_historical.stdout
 
 
 def test_graph_render_terminal_basic(metaxy_project: TempMetaxyProject):
@@ -704,7 +706,7 @@ def test_graph_render_custom_flags(metaxy_project: TempMetaxyProject):
     with metaxy_project.with_features(features):
         # Test with no fields shown
         result = metaxy_project.run_cli(
-            "graph", "render", "--no-show-fields", "--no-show-snapshot-id"
+            "graph", "render", "--no-show-fields", "--no-show-snapshot-version"
         )
 
         assert result.returncode == 0

--- a/tests/examples/test_migration.py
+++ b/tests/examples/test_migration.py
@@ -106,8 +106,8 @@ def test_pipeline(tmp_path, snapshot):
     snapshot_data = migration_data.copy()
     snapshot_data.pop("id", None)  # Contains timestamp
     snapshot_data.pop("created_at", None)  # Timestamp
-    snapshot_data.pop("from_snapshot_id", None)  # Hash
-    snapshot_data.pop("to_snapshot_id", None)  # Hash
+    snapshot_data.pop("from_snapshot_version", None)  # Hash
+    snapshot_data.pop("to_snapshot_version", None)  # Hash
 
     # Snapshot the deterministic parts
     assert snapshot_data == snapshot

--- a/tests/metadata_stores/__snapshots__/test_migrations_cross_store.ambr
+++ b/tests/metadata_stores/__snapshots__/test_migrations_cross_store.ambr
@@ -32,12 +32,12 @@
       dict({
         'data_version': "{'default': '6865575771891373631'}",
         'feature_version': 'fd0daab32fce8549056ee84475e18d286ad86704fb90ec622faf29ee38c3d62e',
-        'sample_id': 1,
+        'sample_uid': 1,
       }),
       dict({
         'data_version': "{'default': 'd1'}",
         'feature_version': 'fd0daab32fce8549056ee84475e18d286ad86704fb90ec622faf29ee38c3d62e',
-        'sample_id': 1,
+        'sample_uid': 1,
       }),
     ]),
   })
@@ -75,12 +75,12 @@
       dict({
         'data_version': "{'default': '6865575771891373631'}",
         'feature_version': 'fd0daab32fce8549056ee84475e18d286ad86704fb90ec622faf29ee38c3d62e',
-        'sample_id': 1,
+        'sample_uid': 1,
       }),
       dict({
         'data_version': "{'default': 'd1'}",
         'feature_version': 'fd0daab32fce8549056ee84475e18d286ad86704fb90ec622faf29ee38c3d62e',
-        'sample_id': 1,
+        'sample_uid': 1,
       }),
     ]),
   })
@@ -118,12 +118,12 @@
       dict({
         'data_version': "{'default': '6865575771891373631'}",
         'feature_version': 'fd0daab32fce8549056ee84475e18d286ad86704fb90ec622faf29ee38c3d62e',
-        'sample_id': 1,
+        'sample_uid': 1,
       }),
       dict({
         'data_version': "{'default': 'd1'}",
         'feature_version': 'fd0daab32fce8549056ee84475e18d286ad86704fb90ec622faf29ee38c3d62e',
-        'sample_id': 1,
+        'sample_uid': 1,
       }),
     ]),
   })
@@ -161,12 +161,12 @@
       dict({
         'data_version': "{'default': '5f748113fd60f0d964c320c298e759c2'}",
         'feature_version': 'fd0daab32fce8549056ee84475e18d286ad86704fb90ec622faf29ee38c3d62e',
-        'sample_id': 1,
+        'sample_uid': 1,
       }),
       dict({
         'data_version': "{'default': 'd1'}",
         'feature_version': 'fd0daab32fce8549056ee84475e18d286ad86704fb90ec622faf29ee38c3d62e',
-        'sample_id': 1,
+        'sample_uid': 1,
       }),
     ]),
   })

--- a/tests/metadata_stores/__snapshots__/test_resolve_update.ambr
+++ b/tests/metadata_stores/__snapshots__/test_resolve_update.ambr
@@ -8,7 +8,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 9,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         1,
         1,
@@ -28,7 +28,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 9,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         1,
         1,
@@ -48,7 +48,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 9,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         1,
         1,
@@ -68,7 +68,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 9,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         1,
         1,
@@ -88,7 +88,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 9,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         1,
         1,
@@ -108,7 +108,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 9,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         1,
         1,
@@ -128,7 +128,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 9,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         1,
         1,
@@ -148,7 +148,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 9,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         1,
         1,
@@ -172,7 +172,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 9,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         1,
         1,
@@ -192,7 +192,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 9,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         1,
         1,
@@ -212,7 +212,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 9,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         1,
         1,
@@ -232,7 +232,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 9,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         1,
         1,
@@ -256,7 +256,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 9,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         1,
         1,
@@ -276,7 +276,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 9,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         1,
         1,
@@ -296,7 +296,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 9,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         1,
         1,
@@ -316,7 +316,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 9,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         1,
         1,
@@ -340,7 +340,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 9,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         1,
         1,
@@ -360,7 +360,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 9,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         1,
         1,
@@ -380,7 +380,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 9,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         1,
         1,
@@ -400,7 +400,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 9,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         1,
         1,
@@ -420,7 +420,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 9,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         1,
         1,
@@ -440,7 +440,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 9,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         1,
         1,
@@ -460,7 +460,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 9,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         1,
         1,
@@ -480,7 +480,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 9,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         1,
         1,
@@ -504,7 +504,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 9,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         1,
         1,
@@ -524,7 +524,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 9,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         1,
         1,
@@ -544,7 +544,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 9,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         1,
         1,
@@ -564,7 +564,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 9,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         1,
         1,
@@ -584,7 +584,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 9,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         1,
         1,
@@ -604,7 +604,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 9,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         1,
         1,
@@ -624,7 +624,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 9,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         1,
         1,
@@ -644,7 +644,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 9,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         1,
         1,
@@ -668,7 +668,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -682,7 +682,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -696,7 +696,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -710,7 +710,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -724,7 +724,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -738,7 +738,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -752,7 +752,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -766,7 +766,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -784,7 +784,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -798,7 +798,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -812,7 +812,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -826,7 +826,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -844,7 +844,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -858,7 +858,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -872,7 +872,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -886,7 +886,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -904,7 +904,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -918,7 +918,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -932,7 +932,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -946,7 +946,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -960,7 +960,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -974,7 +974,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -988,7 +988,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -1002,7 +1002,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -1020,7 +1020,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -1034,7 +1034,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -1048,7 +1048,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -1062,7 +1062,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -1076,7 +1076,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -1090,7 +1090,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -1104,7 +1104,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -1118,7 +1118,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -1136,7 +1136,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -1150,7 +1150,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -1164,7 +1164,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -1178,7 +1178,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -1192,7 +1192,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -1206,7 +1206,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -1220,7 +1220,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -1234,7 +1234,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -1252,7 +1252,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -1266,7 +1266,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -1280,7 +1280,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -1294,7 +1294,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -1312,7 +1312,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -1326,7 +1326,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -1340,7 +1340,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -1354,7 +1354,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -1372,7 +1372,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -1386,7 +1386,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -1400,7 +1400,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -1414,7 +1414,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -1428,7 +1428,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -1442,7 +1442,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -1456,7 +1456,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -1470,7 +1470,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -1488,7 +1488,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -1502,7 +1502,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -1516,7 +1516,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -1530,7 +1530,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -1544,7 +1544,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -1558,7 +1558,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -1572,7 +1572,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,
@@ -1586,7 +1586,7 @@
       'added': 0,
       'any_version_changed': True,
       'changed': 3,
-      'changed_sample_ids': list([
+      'changed_sample_uids': list([
         1,
         2,
         3,

--- a/tests/metadata_stores/test_clickhouse.py
+++ b/tests/metadata_stores/test_clickhouse.py
@@ -31,7 +31,7 @@ def test_clickhouse_table_naming(
 
         metadata = pl.DataFrame(
             {
-                "sample_id": [1],
+                "sample_uid": [1],
                 "data_version": [{"frames": "h1", "audio": "h1"}],
             }
         )
@@ -98,7 +98,7 @@ def test_clickhouse_persistence(
     with ClickHouseMetadataStore(clickhouse_db) as store1:
         metadata = pl.DataFrame(
             {
-                "sample_id": [1, 2, 3],
+                "sample_uid": [1, 2, 3],
                 "data_version": [
                     {"frames": "h1", "audio": "h1"},
                     {"frames": "h2", "audio": "h2"},
@@ -115,7 +115,7 @@ def test_clickhouse_persistence(
         )
 
         assert len(result) == 3
-        assert set(result["sample_id"].to_list()) == {1, 2, 3}
+        assert set(result["sample_uid"].to_list()) == {1, 2, 3}
 
 
 def test_clickhouse_close_idempotent(
@@ -164,7 +164,7 @@ def test_clickhouse_hash_algorithms(
 
             metadata = pl.DataFrame(
                 {
-                    "sample_id": [1, 2],
+                    "sample_uid": [1, 2],
                     "data_version": [
                         {"frames": "h1", "audio": "h1"},
                         {"frames": "h2", "audio": "h2"},

--- a/tests/metadata_stores/test_duckdb.py
+++ b/tests/metadata_stores/test_duckdb.py
@@ -30,7 +30,7 @@ def test_duckdb_table_naming(
 
         metadata = pl.DataFrame(
             {
-                "sample_id": [1],
+                "sample_uid": [1],
                 "data_version": [{"frames": "h1", "audio": "h1"}],
             }
         )
@@ -121,7 +121,7 @@ def test_duckdb_persistence_across_instances(
     with DuckDBMetadataStore(db_path) as store1:
         metadata = pl.DataFrame(
             {
-                "sample_id": [1, 2, 3],
+                "sample_uid": [1, 2, 3],
                 "data_version": [
                     {"frames": "h1", "audio": "h1"},
                     {"frames": "h2", "audio": "h2"},
@@ -138,7 +138,7 @@ def test_duckdb_persistence_across_instances(
         )
 
         assert len(result) == 3
-        assert set(result["sample_id"].to_list()) == {1, 2, 3}
+        assert set(result["sample_uid"].to_list()) == {1, 2, 3}
 
 
 def test_duckdb_close_idempotent(

--- a/tests/metadata_stores/test_fallback_stores.py
+++ b/tests/metadata_stores/test_fallback_stores.py
@@ -172,7 +172,7 @@ def test_fallback_store_warning_issued(
     # Prepare root data
     root_data = pl.DataFrame(
         {
-            "sample_id": [1, 2, 3],
+            "sample_uid": [1, 2, 3],
             "data_version": [
                 {"default": "hash1"},
                 {"default": "hash2"},
@@ -232,7 +232,7 @@ def test_fallback_store_warning_issued(
                     result.added.to_polars()
                     if isinstance(result.added, nw.DataFrame)
                     else result.added
-                ).sort("sample_id")
+                ).sort("sample_uid")
                 versions = added_sorted["data_version"].to_list()
 
                 results[(primary_store_type, fallback_store_type, prefer_native)] = {
@@ -290,7 +290,7 @@ def test_no_fallback_warning_when_all_local(
             # Write root feature to same store
             root_data = pl.DataFrame(
                 {
-                    "sample_id": [1, 2, 3],
+                    "sample_uid": [1, 2, 3],
                     "data_version": [
                         {"default": "hash1"},
                         {"default": "hash2"},
@@ -355,7 +355,7 @@ def test_fallback_store_switches_to_polars_components(
     # Setup root feature data
     root_data = pl.DataFrame(
         {
-            "sample_id": [1, 2, 3],
+            "sample_uid": [1, 2, 3],
             "data_version": [
                 {"default": "hash1"},
                 {"default": "hash2"},
@@ -397,7 +397,7 @@ def test_fallback_store_switches_to_polars_components(
                 if isinstance(result_local.added, nw.DataFrame)
                 else result_local.added
             )
-            versions_local = added_local.sort("sample_id")["data_version"].to_list()
+            versions_local = added_local.sort("sample_uid")["data_version"].to_list()
 
             results[(primary_store_type, fallback_store_type, "all_local")] = {
                 "added": len(result_local.added),
@@ -449,7 +449,7 @@ def test_fallback_store_switches_to_polars_components(
             if isinstance(result_fallback.added, nw.DataFrame)
             else result_fallback.added
         )
-        versions_fallback = added_fallback.sort("sample_id")["data_version"].to_list()
+        versions_fallback = added_fallback.sort("sample_uid")["data_version"].to_list()
 
         results[(primary_store_type, fallback_store_type, "with_fallback")] = {
             "added": len(result_fallback.added),
@@ -503,7 +503,7 @@ def test_prefer_native_false_no_warning_even_without_fallback(
         with store, graph.use():
             root_data = pl.DataFrame(
                 {
-                    "sample_id": [1, 2, 3],
+                    "sample_uid": [1, 2, 3],
                     "data_version": [
                         {"default": "hash1"},
                         {"default": "hash2"},
@@ -566,7 +566,7 @@ def test_sqlite_no_warning_with_fallback_since_no_native(
         with fallback_store, graph.use():
             root_data = pl.DataFrame(
                 {
-                    "sample_id": [1, 2, 3],
+                    "sample_uid": [1, 2, 3],
                     "data_version": [
                         {"default": "hash1"},
                         {"default": "hash2"},

--- a/tests/metadata_stores/test_persistent_stores.py
+++ b/tests/metadata_stores/test_persistent_stores.py
@@ -26,7 +26,7 @@ def test_store_requires_context_manager(
     """Test that operations outside context manager raise error."""
     data = pl.DataFrame(
         {
-            "sample_id": [1, 2],
+            "sample_uid": [1, 2],
             "data_version": [
                 {"frames": "h1", "audio": "h1"},
                 {"frames": "h2", "audio": "h2"},
@@ -54,7 +54,7 @@ def test_store_context_manager(
         # Can perform operations
         data = pl.DataFrame(
             {
-                "sample_id": [1],
+                "sample_uid": [1],
                 "data_version": [{"frames": "h1", "audio": "h1"}],
             }
         )
@@ -74,7 +74,7 @@ def test_write_and_read_metadata(
     with persistent_store as store:
         metadata = pl.DataFrame(
             {
-                "sample_id": [1, 2, 3],
+                "sample_uid": [1, 2, 3],
                 "path": ["/data/1.mp4", "/data/2.mp4", "/data/3.mp4"],
                 "data_version": [
                     {"frames": "hash1", "audio": "hash1"},
@@ -90,7 +90,7 @@ def test_write_and_read_metadata(
         )
 
         assert len(result) == 3
-        assert "sample_id" in result.columns
+        assert "sample_uid" in result.columns
         assert "data_version" in result.columns
         assert "path" in result.columns
 
@@ -102,7 +102,7 @@ def test_write_invalid_schema(
     with persistent_store as store:
         invalid_df = pl.DataFrame(
             {
-                "sample_id": [1, 2, 3],
+                "sample_uid": [1, 2, 3],
                 "path": ["/a", "/b", "/c"],
             }
         )
@@ -118,7 +118,7 @@ def test_write_append(
     with persistent_store as store:
         df1 = pl.DataFrame(
             {
-                "sample_id": [1, 2],
+                "sample_uid": [1, 2],
                 "data_version": [
                     {"frames": "h1", "audio": "h1"},
                     {"frames": "h2", "audio": "h2"},
@@ -128,7 +128,7 @@ def test_write_append(
 
         df2 = pl.DataFrame(
             {
-                "sample_id": [3, 4],
+                "sample_uid": [3, 4],
                 "data_version": [
                     {"frames": "h3", "audio": "h3"},
                     {"frames": "h4", "audio": "h4"},
@@ -143,7 +143,7 @@ def test_write_append(
             store.read_metadata(test_features["UpstreamFeatureA"])
         )
         assert len(result) == 4
-        assert set(result["sample_id"].to_list()) == {1, 2, 3, 4}
+        assert set(result["sample_uid"].to_list()) == {1, 2, 3, 4}
 
 
 def test_read_with_filters(
@@ -153,7 +153,7 @@ def test_read_with_filters(
     with persistent_store as store:
         metadata = pl.DataFrame(
             {
-                "sample_id": [1, 2, 3],
+                "sample_uid": [1, 2, 3],
                 "data_version": [
                     {"frames": "h1", "audio": "h1"},
                     {"frames": "h2", "audio": "h2"},
@@ -165,12 +165,12 @@ def test_read_with_filters(
 
         result = collect_to_polars(
             store.read_metadata(
-                test_features["UpstreamFeatureA"], filters=[nw.col("sample_id") > 1]
+                test_features["UpstreamFeatureA"], filters=[nw.col("sample_uid") > 1]
             )
         )
 
         assert len(result) == 2
-        assert set(result["sample_id"].to_list()) == {2, 3}
+        assert set(result["sample_uid"].to_list()) == {2, 3}
 
 
 def test_read_with_column_selection(
@@ -180,7 +180,7 @@ def test_read_with_column_selection(
     with persistent_store as store:
         metadata = pl.DataFrame(
             {
-                "sample_id": [1, 2, 3],
+                "sample_uid": [1, 2, 3],
                 "path": ["/a", "/b", "/c"],
                 "data_version": [
                     {"frames": "h1", "audio": "h1"},
@@ -193,11 +193,12 @@ def test_read_with_column_selection(
 
         result = collect_to_polars(
             store.read_metadata(
-                test_features["UpstreamFeatureA"], columns=["sample_id", "data_version"]
+                test_features["UpstreamFeatureA"],
+                columns=["sample_uid", "data_version"],
             )
         )
 
-        assert set(result.columns) == {"sample_id", "data_version"}
+        assert set(result.columns) == {"sample_uid", "data_version"}
         assert "path" not in result.columns
 
 
@@ -224,7 +225,7 @@ def test_has_feature_local(
 
         metadata = pl.DataFrame(
             {
-                "sample_id": [1],
+                "sample_uid": [1],
                 "data_version": [{"frames": "h1", "audio": "h1"}],
             }
         )
@@ -255,7 +256,7 @@ def test_list_features(
         # Add features
         data_a = pl.DataFrame(
             {
-                "sample_id": [1],
+                "sample_uid": [1],
                 "data_version": [{"frames": "h1", "audio": "h1"}],
             }
         )
@@ -263,7 +264,7 @@ def test_list_features(
 
         data_b = pl.DataFrame(
             {
-                "sample_id": [1],
+                "sample_uid": [1],
                 "data_version": [{"default": "h1"}],
             }
         )
@@ -301,7 +302,7 @@ def test_system_tables(
         # Write data and record version
         data = pl.DataFrame(
             {
-                "sample_id": [1, 2],
+                "sample_uid": [1, 2],
                 "data_version": [
                     {"frames": "h1", "audio": "h1"},
                     {"frames": "h2", "audio": "h2"},
@@ -364,7 +365,7 @@ def test_nested_context_managers(
 
             metadata = pl.DataFrame(
                 {
-                    "sample_id": [1],
+                    "sample_uid": [1],
                     "data_version": [{"frames": "h1", "audio": "h1"}],
                 }
             )
@@ -397,7 +398,7 @@ def test_multiple_features(
         # Write feature A
         data_a = pl.DataFrame(
             {
-                "sample_id": [1, 2],
+                "sample_uid": [1, 2],
                 "data_version": [
                     {"frames": "h1", "audio": "h1"},
                     {"frames": "h2", "audio": "h2"},
@@ -409,7 +410,7 @@ def test_multiple_features(
         # Write feature B
         data_b = pl.DataFrame(
             {
-                "sample_id": [1, 2, 3],
+                "sample_uid": [1, 2, 3],
                 "data_version": [
                     {"default": "h1"},
                     {"default": "h2"},

--- a/tests/metadata_stores/test_resolve_update_root_features.py
+++ b/tests/metadata_stores/test_resolve_update_root_features.py
@@ -87,7 +87,7 @@ class TestResolveUpdateRootFeatures:
 
             user_samples = pl.DataFrame(
                 {
-                    "sample_id": [1, 2, 3],
+                    "sample_uid": [1, 2, 3],
                     "data_version": [
                         {"embedding": "hash1"},
                         {"embedding": "hash2"},
@@ -102,7 +102,7 @@ class TestResolveUpdateRootFeatures:
 
             # All samples should be added
             assert len(result.added) == 3
-            assert sorted(result.added["sample_id"].to_list()) == [1, 2, 3]
+            assert sorted(result.added["sample_uid"].to_list()) == [1, 2, 3]
             assert len(result.changed) == 0
             assert len(result.removed) == 0
 
@@ -125,7 +125,7 @@ class TestResolveUpdateRootFeatures:
             # Write initial metadata
             initial_metadata = pl.DataFrame(
                 {
-                    "sample_id": [1, 2, 3],
+                    "sample_uid": [1, 2, 3],
                     "data_version": [
                         {"embedding": "hash1"},
                         {"embedding": "hash2"},
@@ -140,7 +140,7 @@ class TestResolveUpdateRootFeatures:
 
             user_samples = pl.DataFrame(
                 {
-                    "sample_id": [1, 2, 4],
+                    "sample_uid": [1, 2, 4],
                     "data_version": [
                         {"embedding": "hash1"},  # unchanged
                         {"embedding": "hash2_updated"},  # changed
@@ -155,10 +155,10 @@ class TestResolveUpdateRootFeatures:
 
             # Should detect changes correctly
             assert len(result.added) == 1
-            assert result.added["sample_id"].to_list() == [4]
+            assert result.added["sample_uid"].to_list() == [4]
 
             assert len(result.changed) == 1
-            assert result.changed["sample_id"].to_list() == [2]
+            assert result.changed["sample_uid"].to_list() == [2]
 
             assert len(result.removed) == 1
-            assert result.removed["sample_id"].to_list() == [3]
+            assert result.removed["sample_uid"].to_list() == [3]

--- a/tests/metadata_stores/test_sqlite.py
+++ b/tests/metadata_stores/test_sqlite.py
@@ -30,7 +30,7 @@ def test_sqlite_table_naming(
 
         metadata = pl.DataFrame(
             {
-                "sample_id": [1],
+                "sample_uid": [1],
                 "data_version": [{"frames": "h1", "audio": "h1"}],
             }
         )
@@ -100,7 +100,7 @@ def test_sqlite_persistence_across_instances(
     with SQLiteMetadataStore(db_path) as store1:
         metadata = pl.DataFrame(
             {
-                "sample_id": [1, 2, 3],
+                "sample_uid": [1, 2, 3],
                 "data_version": [
                     {"frames": "h1", "audio": "h1"},
                     {"frames": "h2", "audio": "h2"},
@@ -117,7 +117,7 @@ def test_sqlite_persistence_across_instances(
         )
 
         assert len(result) == 3
-        assert set(result["sample_id"].to_list()) == {1, 2, 3}
+        assert set(result["sample_uid"].to_list()) == {1, 2, 3}
 
 
 def test_sqlite_in_memory(test_graph, test_features: dict[str, Any]) -> None:
@@ -132,7 +132,7 @@ def test_sqlite_in_memory(test_graph, test_features: dict[str, Any]) -> None:
     with SQLiteMetadataStore(":memory:") as store:
         metadata = pl.DataFrame(
             {
-                "sample_id": [1, 2],
+                "sample_uid": [1, 2],
                 "data_version": [
                     {"frames": "h1", "audio": "h1"},
                     {"frames": "h2", "audio": "h2"},
@@ -145,7 +145,7 @@ def test_sqlite_in_memory(test_graph, test_features: dict[str, Any]) -> None:
             store.read_metadata(test_features["UpstreamFeatureA"])
         )
         assert len(result) == 2
-        assert set(result["sample_id"].to_list()) == {1, 2}
+        assert set(result["sample_uid"].to_list()) == {1, 2}
 
 
 def test_sqlite_close_idempotent(

--- a/tests/test_data_versioning_components.py
+++ b/tests/test_data_versioning_components.py
@@ -87,7 +87,7 @@ def test_polars_joiner(features: dict[str, type[Feature]], graph: FeatureGraph):
     video_metadata = nw.from_native(
         pl.DataFrame(
             {
-                "sample_id": [1, 2, 3],
+                "sample_uid": [1, 2, 3],
                 "data_version": [
                     {"frames": "hash_v1", "audio": "hash_a1"},
                     {"frames": "hash_v2", "audio": "hash_a2"},
@@ -112,7 +112,7 @@ def test_polars_joiner(features: dict[str, type[Feature]], graph: FeatureGraph):
     # Verify result
     result = joined.collect()
     assert len(result) == 3
-    assert "sample_id" in result.columns
+    assert "sample_uid" in result.columns
     assert "video" in mapping
     assert mapping["video"] in result.columns
 
@@ -134,7 +134,7 @@ def test_polars_hash_calculator(
     joined_upstream = nw.from_native(
         pl.DataFrame(
             {
-                "sample_id": [1, 2],
+                "sample_uid": [1, 2],
                 "__upstream_video__data_version": [
                     {"frames": "hash_v1", "audio": "hash_a1"},
                     {"frames": "hash_v2", "audio": "hash_a2"},
@@ -176,7 +176,7 @@ def test_polars_hash_calculator_algorithms(
     joined_upstream = nw.from_native(
         pl.DataFrame(
             {
-                "sample_id": [1],
+                "sample_uid": [1],
                 "__upstream_video__data_version": [
                     {"frames": "hash_v1", "audio": "hash_a1"}
                 ],
@@ -221,7 +221,7 @@ def test_polars_diff_resolver_no_current() -> None:
     target_versions = nw.from_native(
         pl.DataFrame(
             {
-                "sample_id": [1, 2, 3],
+                "sample_uid": [1, 2, 3],
                 "data_version": [
                     {"default": "hash1"},
                     {"default": "hash2"},
@@ -250,7 +250,7 @@ def test_polars_diff_resolver_with_changes() -> None:
     target_versions = nw.from_native(
         pl.DataFrame(
             {
-                "sample_id": [1, 2, 3, 4],
+                "sample_uid": [1, 2, 3, 4],
                 "data_version": [
                     {"default": "hash1"},  # Unchanged
                     {"default": "hash2_new"},  # Changed
@@ -264,7 +264,7 @@ def test_polars_diff_resolver_with_changes() -> None:
     current_metadata = nw.from_native(
         pl.DataFrame(
             {
-                "sample_id": [1, 2, 3, 5],
+                "sample_uid": [1, 2, 3, 5],
                 "data_version": [
                     {"default": "hash1"},  # Same
                     {"default": "hash2_old"},  # Different
@@ -280,20 +280,20 @@ def test_polars_diff_resolver_with_changes() -> None:
         current_metadata=current_metadata,
     )
 
-    # Added: sample_id=4 - materialize to check
+    # Added: sample_uid=4 - materialize to check
     added_df = result.added.collect()
     assert len(added_df) == 1
-    assert added_df["sample_id"][0] == 4
+    assert added_df["sample_uid"][0] == 4
 
-    # Changed: sample_id=2
+    # Changed: sample_uid=2
     changed_df = result.changed.collect()
     assert len(changed_df) == 1
-    assert changed_df["sample_id"][0] == 2
+    assert changed_df["sample_uid"][0] == 2
 
-    # Removed: sample_id=5
+    # Removed: sample_uid=5
     removed_df = result.removed.collect()
     assert len(removed_df) == 1
-    assert removed_df["sample_id"][0] == 5
+    assert removed_df["sample_uid"][0] == 5
 
 
 def test_full_pipeline_integration(
@@ -306,7 +306,7 @@ def test_full_pipeline_integration(
     video_metadata = nw.from_native(
         pl.DataFrame(
             {
-                "sample_id": [1, 2, 3],
+                "sample_uid": [1, 2, 3],
                 "data_version": [
                     {"frames": "v1", "audio": "a1"},
                     {"frames": "v2", "audio": "a2"},
@@ -342,7 +342,7 @@ def test_full_pipeline_integration(
     current = nw.from_native(
         pl.DataFrame(
             {
-                "sample_id": [1, 2],
+                "sample_uid": [1, 2],
                 "data_version": [
                     {"default": "old_hash1"},
                     {"default": "old_hash2"},
@@ -356,15 +356,15 @@ def test_full_pipeline_integration(
         current_metadata=current,
     )
 
-    # Added: sample_id=3 (not in current) - materialize to check
+    # Added: sample_uid=3 (not in current) - materialize to check
     added = diff_result.added.collect()
     assert len(added) == 1
-    assert added["sample_id"][0] == 3
+    assert added["sample_uid"][0] == 3
 
-    # Changed: sample_ids 1, 2 (different hashes)
+    # Changed: sample_uids 1, 2 (different hashes)
     changed = diff_result.changed.collect()
     assert len(changed) == 2
-    assert set(changed["sample_id"].to_list()) == {1, 2}
+    assert set(changed["sample_uid"].to_list()) == {1, 2}
 
     # Removed: none (all current samples are in target)
     removed = diff_result.removed.collect()
@@ -383,7 +383,7 @@ def test_polars_joiner_multiple_upstream(
     video_metadata = nw.from_native(
         pl.DataFrame(
             {
-                "sample_id": [1, 2, 3],
+                "sample_uid": [1, 2, 3],
                 "data_version": [
                     {"frames": "v1", "audio": "a1"},
                     {"frames": "v2", "audio": "a2"},
@@ -396,7 +396,7 @@ def test_polars_joiner_multiple_upstream(
     audio_metadata = nw.from_native(
         pl.DataFrame(
             {
-                "sample_id": [1, 2, 3],
+                "sample_uid": [1, 2, 3],
                 "data_version": [
                     {"waveform": "w1"},
                     {"waveform": "w2"},
@@ -425,19 +425,19 @@ def test_polars_joiner_multiple_upstream(
     assert mapping["video"] in result.columns
     assert mapping["audio"] in result.columns
 
-    # Should have all 3 samples (inner join on matching sample_ids)
+    # Should have all 3 samples (inner join on matching sample_uids)
     assert len(result) == 3
 
 
 def test_polars_joiner_partial_overlap(graph: FeatureGraph) -> None:
-    """Test joiner with partial sample_id overlap (inner join behavior)."""
+    """Test joiner with partial sample_uid overlap (inner join behavior)."""
     joiner = NarwhalsJoiner()
 
     # Video has samples 1, 2, 3
     video_metadata = nw.from_native(
         pl.DataFrame(
             {
-                "sample_id": [1, 2, 3],
+                "sample_uid": [1, 2, 3],
                 "data_version": [{"frames": "v1"}, {"frames": "v2"}, {"frames": "v3"}],
             }
         ).lazy()
@@ -447,7 +447,7 @@ def test_polars_joiner_partial_overlap(graph: FeatureGraph) -> None:
     audio_metadata = nw.from_native(
         pl.DataFrame(
             {
-                "sample_id": [2, 3, 4],
+                "sample_uid": [2, 3, 4],
                 "data_version": [
                     {"waveform": "w2"},
                     {"waveform": "w3"},
@@ -497,7 +497,7 @@ def test_polars_joiner_partial_overlap(graph: FeatureGraph) -> None:
 
     # Inner join - only samples 2, 3 (present in BOTH)
     assert len(result) == 2
-    assert set(result["sample_id"].to_list()) == {2, 3}
+    assert set(result["sample_uid"].to_list()) == {2, 3}
 
 
 # ========== Multi-Field Calculator Tests ==========
@@ -512,7 +512,7 @@ def test_polars_calculator_multiple_fields(
     joined_upstream = nw.from_native(
         pl.DataFrame(
             {
-                "sample_id": [1, 2],
+                "sample_uid": [1, 2],
                 "__upstream_video__data_version": [
                     {"frames": "v1", "audio": "a1"},
                     {"frames": "v2", "audio": "a2"},
@@ -562,7 +562,7 @@ def test_polars_calculator_unsupported_algorithm(
 
     joined_upstream = nw.from_native(
         pl.DataFrame(
-            {"sample_id": [1], "__upstream_video__data_version": [{"frames": "v1"}]}
+            {"sample_uid": [1], "__upstream_video__data_version": [{"frames": "v1"}]}
         ).lazy()
     )
 
@@ -593,7 +593,7 @@ def test_diff_resolver_all_unchanged() -> None:
     target_versions = nw.from_native(
         pl.DataFrame(
             {
-                "sample_id": [1, 2, 3],
+                "sample_uid": [1, 2, 3],
                 "data_version": [
                     {"default": "hash1"},
                     {"default": "hash2"},
@@ -607,7 +607,7 @@ def test_diff_resolver_all_unchanged() -> None:
     current_metadata = nw.from_native(
         pl.DataFrame(
             {
-                "sample_id": [1, 2, 3],
+                "sample_uid": [1, 2, 3],
                 "data_version": [
                     {"default": "hash1"},
                     {"default": "hash2"},
@@ -636,14 +636,14 @@ def test_joiner_deterministic_order(
 
     video_metadata = nw.from_native(
         pl.DataFrame(
-            {"sample_id": [1, 2], "data_version": [{"frames": "v1"}, {"frames": "v2"}]}
+            {"sample_uid": [1, 2], "data_version": [{"frames": "v1"}, {"frames": "v2"}]}
         ).lazy()
     )
 
     audio_metadata = nw.from_native(
         pl.DataFrame(
             {
-                "sample_id": [1, 2],
+                "sample_uid": [1, 2],
                 "data_version": [{"waveform": "w1"}, {"waveform": "w2"}],
             }
         ).lazy()
@@ -669,8 +669,8 @@ def test_joiner_deterministic_order(
     assert mapping1 == mapping2
 
     # Results should be identical (order-independent)
-    result1 = joined1.collect().sort("sample_id")
-    result2 = joined2.collect().sort("sample_id")
+    result1 = joined1.collect().sort("sample_uid")
+    result2 = joined2.collect().sort("sample_uid")
 
     # Convert to Polars for comparison (Narwhals doesn't have equals method)
     assert result1.to_native().equals(result2.to_native())
@@ -715,7 +715,7 @@ def test_feature_join_upstream_override(graph: FeatureGraph):
 
     joiner = NarwhalsJoiner()
     video_metadata = nw.from_native(
-        pl.DataFrame({"sample_id": [1], "data_version": [{"frames": "v1"}]}).lazy()
+        pl.DataFrame({"sample_uid": [1], "data_version": [{"frames": "v1"}]}).lazy()
     )
 
     # Call the overridden method
@@ -771,14 +771,14 @@ def test_feature_resolve_diff_override(graph: FeatureGraph):
     target = nw.from_native(
         pl.DataFrame(
             {
-                "sample_id": [1, 2],
+                "sample_uid": [1, 2],
                 "data_version": [{"default": "new1"}, {"default": "new2"}],
             }
         ).lazy()
     )
 
     current = nw.from_native(
-        pl.DataFrame({"sample_id": [1], "data_version": [{"default": "old1"}]}).lazy()
+        pl.DataFrame({"sample_uid": [1], "data_version": [{"default": "old1"}]}).lazy()
     )
 
     # Call overridden method (this calls find_changes which needs current_feature_version=False)
@@ -812,7 +812,7 @@ def test_hash_output_snapshots(
     joined_upstream = nw.from_native(
         pl.DataFrame(
             {
-                "sample_id": [1, 2, 3],
+                "sample_uid": [1, 2, 3],
                 "__upstream_video__data_version": [
                     {"frames": "frame_hash_1", "audio": "audio_hash_1"},
                     {"frames": "frame_hash_2", "audio": "audio_hash_2"},
@@ -850,7 +850,7 @@ def test_multi_field_hash_snapshots(
     joined_upstream = nw.from_native(
         pl.DataFrame(
             {
-                "sample_id": [1],
+                "sample_uid": [1],
                 "__upstream_video__data_version": [{"frames": "v1", "audio": "a1"}],
                 "__upstream_audio__data_version": [{"waveform": "w1"}],
             }
@@ -909,7 +909,7 @@ def test_single_upstream_single_field_snapshots(
     joined_upstream = nw.from_native(
         pl.DataFrame(
             {
-                "sample_id": [1, 2, 3],
+                "sample_uid": [1, 2, 3],
                 "__upstream_video__data_version": [
                     {"frames": "v1", "audio": "a1"},
                     {"frames": "v2", "audio": "a2"},
@@ -956,7 +956,7 @@ def test_multi_upstream_multi_field_snapshots(
     joined_upstream = nw.from_native(
         pl.DataFrame(
             {
-                "sample_id": [1, 2],
+                "sample_uid": [1, 2],
                 "__upstream_video__data_version": [
                     {"frames": "frame1", "audio": "audio1"},
                     {"frames": "frame2", "audio": "audio2"},
@@ -993,7 +993,7 @@ def test_multi_upstream_multi_field_snapshots(
         dv = result["data_version"][i]
         data_versions.append(
             {
-                "sample_id": result["sample_id"][i],
+                "sample_uid": result["sample_uid"][i],
                 "fusion": dv["fusion"],
                 "analysis": dv["analysis"],
             }
@@ -1008,7 +1008,7 @@ def test_code_version_changes_snapshots(snapshot, graph: FeatureGraph):
 
     joined_upstream = nw.from_native(
         pl.DataFrame(
-            {"sample_id": [1], "__upstream_video__data_version": [{"frames": "v1"}]}
+            {"sample_uid": [1], "__upstream_video__data_version": [{"frames": "v1"}]}
         ).lazy()
     )
 
@@ -1105,7 +1105,7 @@ def test_upstream_data_changes_snapshots(snapshot):
             joined_upstream = nw.from_native(
                 pl.DataFrame(
                     {
-                        "sample_id": [1],
+                        "sample_uid": [1],
                         "__upstream_video__data_version": data_version_list,
                     }
                 ).lazy()
@@ -1137,7 +1137,7 @@ def test_diff_result_snapshots(snapshot):
     target = nw.from_native(
         pl.DataFrame(
             {
-                "sample_id": [1, 2, 3, 4, 5],
+                "sample_uid": [1, 2, 3, 4, 5],
                 "data_version": [
                     {"default": "unchanged_hash"},
                     {"default": "changed_new_hash"},
@@ -1152,7 +1152,7 @@ def test_diff_result_snapshots(snapshot):
     current = nw.from_native(
         pl.DataFrame(
             {
-                "sample_id": [1, 2, 3, 6],
+                "sample_uid": [1, 2, 3, 6],
                 "data_version": [
                     {"default": "unchanged_hash"},
                     {"default": "changed_old_hash"},
@@ -1168,11 +1168,11 @@ def test_diff_result_snapshots(snapshot):
         current_metadata=current,
     )
 
-    # Snapshot the sample_ids in each category - materialize lazy frames first
+    # Snapshot the sample_uids in each category - materialize lazy frames first
     diff_summary = {
-        "added_ids": sorted(result.added.collect()["sample_id"].to_list()),
-        "changed_ids": sorted(result.changed.collect()["sample_id"].to_list()),
-        "removed_ids": sorted(result.removed.collect()["sample_id"].to_list()),
+        "added_ids": sorted(result.added.collect()["sample_uid"].to_list()),
+        "changed_ids": sorted(result.changed.collect()["sample_uid"].to_list()),
+        "removed_ids": sorted(result.removed.collect()["sample_uid"].to_list()),
     }
 
     assert diff_summary == snapshot

--- a/tests/test_metadata_store.py
+++ b/tests/test_metadata_store.py
@@ -103,7 +103,7 @@ def populated_store(graph: FeatureGraph) -> Iterator[InMemoryMetadataStore]:
         # Add upstream feature A
         upstream_a_data = pl.DataFrame(
             {
-                "sample_id": [1, 2, 3],
+                "sample_uid": [1, 2, 3],
                 "path": ["/data/1.mp4", "/data/2.mp4", "/data/3.mp4"],
                 "data_version": [
                     {"frames": "hash_a1_frames", "audio": "hash_a1_audio"},
@@ -130,7 +130,7 @@ def multi_env_stores(
         # Populate prod with upstream data
         upstream_data = pl.DataFrame(
             {
-                "sample_id": [1, 2, 3],
+                "sample_uid": [1, 2, 3],
                 "data_version": [
                     {"frames": "prod_hash1", "audio": "prod_hash1"},
                     {"frames": "prod_hash2", "audio": "prod_hash2"},
@@ -151,7 +151,7 @@ def test_write_and_read_metadata(empty_store: InMemoryMetadataStore) -> None:
     with empty_store:
         metadata = pl.DataFrame(
             {
-                "sample_id": [1, 2, 3],
+                "sample_uid": [1, 2, 3],
                 "data_version": [
                     {"frames": "hash1", "audio": "hash1"},
                     {"frames": "hash2", "audio": "hash2"},
@@ -164,7 +164,7 @@ def test_write_and_read_metadata(empty_store: InMemoryMetadataStore) -> None:
         result = collect_to_polars(empty_store.read_metadata(UpstreamFeatureA))
 
         assert len(result) == 3
-        assert "sample_id" in result.columns
+        assert "sample_uid" in result.columns
         assert "data_version" in result.columns
 
 
@@ -173,7 +173,7 @@ def test_write_invalid_schema(empty_store: InMemoryMetadataStore) -> None:
     with empty_store:
         invalid_df = pl.DataFrame(
             {
-                "sample_id": [1, 2, 3],
+                "sample_uid": [1, 2, 3],
                 "path": ["/a", "/b", "/c"],
             }
         )
@@ -187,7 +187,7 @@ def test_write_append(empty_store: InMemoryMetadataStore) -> None:
     with empty_store:
         df1 = pl.DataFrame(
             {
-                "sample_id": [1, 2],
+                "sample_uid": [1, 2],
                 "data_version": [
                     {"frames": "h1", "audio": "h1"},
                     {"frames": "h2", "audio": "h2"},
@@ -197,7 +197,7 @@ def test_write_append(empty_store: InMemoryMetadataStore) -> None:
 
         df2 = pl.DataFrame(
             {
-                "sample_id": [3, 4],
+                "sample_uid": [3, 4],
                 "data_version": [
                     {"frames": "h3", "audio": "h3"},
                     {"frames": "h4", "audio": "h4"},
@@ -210,7 +210,7 @@ def test_write_append(empty_store: InMemoryMetadataStore) -> None:
 
         result = collect_to_polars(empty_store.read_metadata(UpstreamFeatureA))
         assert len(result) == 4
-        assert set(result["sample_id"].to_list()) == {1, 2, 3, 4}
+        assert set(result["sample_uid"].to_list()) == {1, 2, 3, 4}
 
 
 def test_read_with_filters(populated_store: InMemoryMetadataStore) -> None:
@@ -218,12 +218,12 @@ def test_read_with_filters(populated_store: InMemoryMetadataStore) -> None:
     with populated_store:
         result = collect_to_polars(
             populated_store.read_metadata(
-                UpstreamFeatureA, filters=[nw.col("sample_id") > 1]
+                UpstreamFeatureA, filters=[nw.col("sample_uid") > 1]
             )
         )
 
         assert len(result) == 2
-        assert set(result["sample_id"].to_list()) == {2, 3}
+        assert set(result["sample_uid"].to_list()) == {2, 3}
 
 
 def test_read_with_column_selection(populated_store: InMemoryMetadataStore) -> None:
@@ -231,11 +231,11 @@ def test_read_with_column_selection(populated_store: InMemoryMetadataStore) -> N
     with populated_store:
         result = collect_to_polars(
             populated_store.read_metadata(
-                UpstreamFeatureA, columns=["sample_id", "data_version"]
+                UpstreamFeatureA, columns=["sample_uid", "data_version"]
             )
         )
 
-        assert set(result.columns) == {"sample_id", "data_version"}
+        assert set(result.columns) == {"sample_uid", "data_version"}
         assert "path" not in result.columns
 
 
@@ -334,7 +334,7 @@ def test_write_to_dev_not_prod(
     with dev, prod:
         new_data = pl.DataFrame(
             {
-                "sample_id": [4, 5],
+                "sample_uid": [4, 5],
                 "data_version": [{"default": "hash4"}, {"default": "hash5"}],
             }
         )
@@ -414,7 +414,7 @@ def test_store_not_open_write_raises(empty_store: InMemoryMetadataStore) -> None
     """Test that writing to a closed store raises StoreNotOpenError."""
     metadata = pl.DataFrame(
         {
-            "sample_id": [1, 2, 3],
+            "sample_uid": [1, 2, 3],
             "data_version": [
                 {"frames": "hash1", "audio": "hash1"},
                 {"frames": "hash2", "audio": "hash2"},

--- a/tests/test_snapshot_version_stability.py
+++ b/tests/test_snapshot_version_stability.py
@@ -1,4 +1,4 @@
-"""Test that snapshot_id is stable across serialize/deserialize"""
+"""Test that snapshot_version is stable across serialize/deserialize"""
 
 # Import from conftest since it's in the same tests directory
 
@@ -7,8 +7,8 @@ from metaxy._testing import TempFeatureModule
 from metaxy.models.feature import FeatureGraph
 
 
-def test_snapshot_id_stability_with_module():
-    """Test that snapshot_id matches after serialize and reconstruct using real module"""
+def test_snapshot_version_stability_with_module():
+    """Test that snapshot_version matches after serialize and reconstruct using real module"""
 
     # Create temp module with features
     temp_module = TempFeatureModule("test_snapshot_stability")
@@ -44,26 +44,26 @@ def test_snapshot_id_stability_with_module():
         # Get the graph with features
         graph1 = temp_module.graph
 
-        # Get original snapshot_id
-        original_snapshot_id = graph1.snapshot_id
-        print(f"\nOriginal snapshot_id: {original_snapshot_id}")
+        # Get original snapshot_version
+        original_snapshot_version = graph1.snapshot_version
+        print(f"\nOriginal snapshot_version: {original_snapshot_version}")
 
         # Serialize to snapshot dict
         snapshot_dict = graph1.to_snapshot()
 
         # Reconstruct from snapshot
         graph2 = FeatureGraph.from_snapshot(snapshot_dict)
-        reconstructed_snapshot_id = graph2.snapshot_id
-        print(f"Reconstructed snapshot_id: {reconstructed_snapshot_id}")
+        reconstructed_snapshot_version = graph2.snapshot_version
+        print(f"Reconstructed snapshot_version: {reconstructed_snapshot_version}")
 
         # Verify they match
-        assert original_snapshot_id == reconstructed_snapshot_id, (
-            f"Snapshot IDs don't match!\n"
-            f"Original: {original_snapshot_id}\n"
-            f"Reconstructed: {reconstructed_snapshot_id}"
+        assert original_snapshot_version == reconstructed_snapshot_version, (
+            f"Snapshot versions don't match!\n"
+            f"Original: {original_snapshot_version}\n"
+            f"Reconstructed: {reconstructed_snapshot_version}"
         )
 
-        print("✓ Snapshot IDs match!")
+        print("✓ Snapshot versions match!")
 
     finally:
         temp_module.cleanup()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Standardized naming across the codebase by renaming sample_id to sample_uid and snapshot_id to snapshot_version. This clarifies intent, aligns APIs, and updates CLI, docs, migrations, renderers, and tests.

- **Refactors**
  - FeatureGraph.snapshot_version replaces snapshot_id.
  - System tables and constants use snapshot_version (metaxy_snapshot_version).
  - All joins, diffs, and resolve_update operate on sample_uid.
  - CLI push/history messages show “Snapshot version”; migrate generate accepts the same flags but outputs versioned fields; YAML migrations use from_snapshot_version/to_snapshot_version.
  - RenderConfig and graph renderers use show_snapshot_version and graph.snapshot_version.

- **Migration**
  - Rename metadata columns from sample_id to sample_uid in your dataframes and schemas.
  - Update any code references from snapshot_id to snapshot_version (FeatureGraph, store reads/writes, renderer config).
  - Update existing migration files to from_snapshot_version/to_snapshot_version.
  - If using copy --incremental, ensure anti-joins key on sample_uid and snapshot_version.
  - Re-record a feature graph snapshot after deploying updated feature definitions.

<!-- End of auto-generated description by cubic. -->

