### PR TITLE
accept mapping of feature_key->filter in some APIs

### DIFF
--- a/.claude/agents/python-dev.md
+++ b/.claude/agents/python-dev.md
@@ -26,7 +26,7 @@ You religiously follow these principles in all code you write or review:
 
 **Type Safety**:
 - Use comprehensive type annotations for all functions, methods, and class attributes
-- Leverage modern Python typing features: `TypeVar`, `Generic`, `Protocol`, `Literal`, `TypedDict`, etc.
+- Leverage modern Python typing features: `TypeVar`, `Generic`, `Protocol`, `Literal`, `TypedDict`, `Mapping`, `Sequence`, etc.
 - Use `typing.cast()` sparingly and only when necessary
 - Ensure type annotations are accurate and meaningful, not just for compliance
 - Consider using `typing.overload` for functions with multiple signatures

--- a/src/metaxy/cli/metadata.py
+++ b/src/metaxy/cli/metadata.py
@@ -8,7 +8,6 @@ from rich.console import Console
 from metaxy.models.types import FeatureKey
 
 if TYPE_CHECKING:
-    from metaxy.metadata_store import FilteredFeature
     from metaxy.models.feature import Feature
 
 # Rich console for formatted output
@@ -119,7 +118,7 @@ def copy(
         raise SystemExit(1)
 
     # Parse feature keys
-    feature_keys: list[FeatureKey | type[Feature] | FilteredFeature] | None = None
+    feature_keys: list[FeatureKey | type[Feature]] | None = None
     if features:
         feature_keys = []
         for feature_str in features:

--- a/src/metaxy/metadata_store/__init__.py
+++ b/src/metaxy/metadata_store/__init__.py
@@ -3,7 +3,6 @@
 from metaxy.metadata_store.base import (
     FEATURE_VERSIONS_KEY,
     MIGRATION_HISTORY_KEY,
-    FilteredFeature,
     MetadataStore,
     allow_feature_version_override,
 )
@@ -21,7 +20,6 @@ from metaxy.metadata_store.memory import InMemoryMetadataStore
 __all__ = [
     "MetadataStore",
     "InMemoryMetadataStore",
-    "FilteredFeature",
     "MetadataStoreError",
     "FeatureNotFoundError",
     "FieldNotFoundError",

--- a/src/metaxy/metadata_store/ibis.py
+++ b/src/metaxy/metadata_store/ibis.py
@@ -6,6 +6,7 @@ Supports any SQL database that Ibis supports:
 - And 20+ other backends
 """
 
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
 import narwhals as nw
@@ -346,8 +347,8 @@ class IbisMetadataStore(MetadataStore):
         feature: FeatureKey | type[Feature],
         *,
         feature_version: str | None = None,
-        filters: list[nw.Expr] | None = None,
-        columns: list[str] | None = None,
+        filters: Sequence[nw.Expr] | None = None,
+        columns: Sequence[str] | None = None,
     ) -> nw.LazyFrame[Any] | None:
         """
         Read metadata from this store only (no fallback).

--- a/src/metaxy/metadata_store/memory.py
+++ b/src/metaxy/metadata_store/memory.py
@@ -1,5 +1,6 @@
 """In-memory metadata store implementation."""
 
+from collections.abc import Sequence
 from typing import Any
 
 import narwhals as nw
@@ -117,8 +118,8 @@ class InMemoryMetadataStore(MetadataStore):
         feature: FeatureKey | type[Feature],
         *,
         feature_version: str | None = None,
-        filters: list[nw.Expr] | None = None,
-        columns: list[str] | None = None,
+        filters: Sequence[nw.Expr] | None = None,
+        columns: Sequence[str] | None = None,
     ) -> nw.LazyFrame[Any] | None:
         """
         Read metadata from this store only (no fallback).

--- a/tests/metadata_stores/test_persistent_stores.py
+++ b/tests/metadata_stores/test_persistent_stores.py
@@ -165,7 +165,8 @@ def test_read_with_filters(
 
         result = collect_to_polars(
             store.read_metadata(
-                test_features["UpstreamFeatureA"], filters=[nw.col("sample_uid") > 1]
+                test_features["UpstreamFeatureA"],
+                filters=[nw.col("sample_uid") > 1],
             )
         )
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enables per-feature filtering by accepting a mapping of feature_key -> [filters] across core APIs. Replaces FilteredFeature with a simpler, consistent filters API for reads, copies, and updates.

- **New Features**
  - copy_metadata now takes filters: Mapping[str, Sequence[nw.Expr]] and applies them per feature during source reads.
  - read_upstream_metadata supports filters mapping; resolve_update forwards filters through native and polars paths.
  - read_metadata/_read_metadata_native accept Sequence[nw.Expr] for filters and columns (memory and ibis stores updated).

- **Migration**
  - Removed FilteredFeature; features now only accept FeatureKey or Feature types.
  - Pass filters as a dict keyed by FeatureKey.to_string(), e.g. {"ns/feature_a": [nw.col("x") > 0]}.
  - FilteredFeature is no longer exported from metaxy.metadata_store; CLI and tests updated accordingly.

<!-- End of auto-generated description by cubic. -->

