### PR TITLE
render graph diff

### DIFF
--- a/examples/src/examples/overview/features_1.py
+++ b/examples/src/examples/overview/features_1.py
@@ -94,7 +94,7 @@ class FaceDetection(
 class SpeechToText(
     Feature,
     spec=FeatureSpec(
-        key=FeatureKey(["overview", "sst"]),
+        key=FeatureKey(["example", "stt"]),
         deps=[
             FeatureDep(
                 key=Video.spec.key,
@@ -108,28 +108,6 @@ class SpeechToText(
                     FieldDep(
                         feature_key=Video.spec.key,
                         fields=[FieldKey(["audio"])],
-                    )
-                ],
-            ),
-        ],
-    ),
-):
-    pass
-
-
-class Embeddings(
-    Feature,
-    spec=FeatureSpec(
-        key=FeatureKey(["overview", "embeddings"]),
-        deps=[FeatureDep(key=Crop.spec.key)],
-        fields=[
-            FieldSpec(
-                key=FieldKey(["embedding"]),
-                code_version=1,
-                deps=[
-                    FieldDep(
-                        feature_key=Crop.spec.key,
-                        fields=[FieldKey(["audio"]), FieldKey(["frames"])],
                     )
                 ],
             ),

--- a/examples/src/examples/overview/features_2.py
+++ b/examples/src/examples/overview/features_2.py
@@ -94,7 +94,7 @@ class FaceDetection(
 class SpeechToText(
     Feature,
     spec=FeatureSpec(
-        key=FeatureKey(["overview", "sst"]),
+        key=FeatureKey(["example", "stt"]),
         deps=[
             FeatureDep(
                 key=Video.spec.key,
@@ -108,28 +108,6 @@ class SpeechToText(
                     FieldDep(
                         feature_key=Video.spec.key,
                         fields=[FieldKey(["audio"])],
-                    )
-                ],
-            ),
-        ],
-    ),
-):
-    pass
-
-
-class Embeddings(
-    Feature,
-    spec=FeatureSpec(
-        key=FeatureKey(["overview", "embeddings"]),
-        deps=[FeatureDep(key=Crop.spec.key)],
-        fields=[
-            FieldSpec(
-                key=FieldKey(["embedding"]),
-                code_version=1,
-                deps=[
-                    FieldDep(
-                        feature_key=Crop.spec.key,
-                        fields=[FieldKey(["audio"]), FieldKey(["frames"])],
                     )
                 ],
             ),

--- a/src/metaxy/cli/graph.py
+++ b/src/metaxy/cli/graph.py
@@ -7,6 +7,7 @@ from rich.console import Console
 from rich.table import Table
 
 from metaxy.graph import RenderConfig
+from metaxy.graph_diff import GraphDiff
 
 # Rich console for formatted output
 console = Console()
@@ -273,6 +274,253 @@ def describe(
             console.print("\n[bold]Root Features:[/bold]")
             for feature_key in sorted(root_features, key=lambda k: k.to_string()):
                 console.print(f"  • {feature_key.to_string()}")
+
+
+@app.command()
+def diff(
+    snapshot1: Annotated[
+        str,
+        cyclopts.Parameter(
+            help='First snapshot to compare (can be "latest", "current", or snapshot hash)',
+        ),
+    ],
+    snapshot2: Annotated[
+        str,
+        cyclopts.Parameter(
+            help='Second snapshot to compare (can be "latest", "current", or snapshot hash)',
+        ),
+    ],
+    store: Annotated[
+        str | None,
+        cyclopts.Parameter(
+            name=["--store"],
+            help="Metadata store to use (defaults to configured default store)",
+        ),
+    ] = None,
+    format: Annotated[
+        str,
+        cyclopts.Parameter(
+            name=["--format", "-f"],
+            help="Output format: terminal, json, yaml, or mermaid",
+        ),
+    ] = "terminal",
+    output: Annotated[
+        str | None,
+        cyclopts.Parameter(
+            name=["--output", "-o"],
+            help="Output file path (default: stdout)",
+        ),
+    ] = None,
+    verbose: Annotated[
+        bool,
+        cyclopts.Parameter(
+            name=["--verbose", "-v"],
+            help="Show detailed changes",
+        ),
+    ] = False,
+    diff_only: Annotated[
+        bool,
+        cyclopts.Parameter(
+            name=["--diff-only"],
+            help="Show only the diff (list of changes) instead of merged graph visualization",
+        ),
+    ] = False,
+    feature: Annotated[
+        str | None,
+        cyclopts.Parameter(
+            name=["--feature"],
+            help="Focus on a specific feature (e.g., 'video/files' or 'video__files')",
+        ),
+    ] = None,
+    up: Annotated[
+        int | None,
+        cyclopts.Parameter(
+            name=["--up"],
+            help="Number of upstream dependency levels to include (default: all if --feature is set)",
+        ),
+    ] = None,
+    down: Annotated[
+        int | None,
+        cyclopts.Parameter(
+            name=["--down"],
+            help="Number of downstream dependent levels to include (default: all if --feature is set)",
+        ),
+    ] = None,
+    show_changed_fields_only: Annotated[
+        bool,
+        cyclopts.Parameter(
+            name=["--show-changed-fields-only"],
+            help="Show only fields that changed (hide unchanged fields)",
+        ),
+    ] = False,
+):
+    """Compare two graph snapshots and show differences.
+
+    By default, shows a merged graph visualization with all features color-coded
+    by status (added/removed/changed/unchanged). Use --diff-only to show only
+    a list of changes.
+
+    Special snapshot literals:
+    - "latest": Most recent snapshot in the store
+    - "current": Current graph state from code
+
+    Output formats:
+    - terminal: Interactive visualization (default)
+    - json: JSON representation
+    - yaml: YAML representation
+    - mermaid: Mermaid flowchart diagram
+
+    Examples:
+        # Show merged graph (default - all features with status colors)
+        $ metaxy graph diff latest current
+
+        # Show only changes (traditional diff view)
+        $ metaxy graph diff latest current --diff-only
+
+        # Compare two specific snapshots
+        $ metaxy graph diff abc123def456 def456abc123
+
+        # Show verbose details
+        $ metaxy graph diff latest current --verbose
+
+        # Focus on a specific feature and show 2 levels up and 1 level down
+        $ metaxy graph diff latest current --feature user/profile --up 2 --down 1
+
+        # Show only changed fields (hide unchanged fields)
+        $ metaxy graph diff latest current --show-changed-fields-only
+
+        # Combine slicing and field filtering
+        $ metaxy graph diff latest current --feature video/files --up 1 --down 2 --show-changed-fields-only
+
+        # Output as JSON
+        $ metaxy graph diff latest current --format json
+
+        # Save Mermaid diagram to file with graph slicing
+        $ metaxy graph diff latest current --feature user/profile --up 1 --format mermaid --output diff.mmd
+
+        # Export as YAML
+        $ metaxy graph diff latest current --format yaml --output diff.yaml
+    """
+    from metaxy.cli.context import get_store
+    from metaxy.entrypoints import load_features
+    from metaxy.formatters.graph_diff import DiffFormatter
+    from metaxy.graph_diff import GraphDiffer, SnapshotResolver
+    from metaxy.models.feature import FeatureGraph
+
+    # Validate format
+    valid_formats = ["terminal", "json", "yaml", "mermaid"]
+    if format not in valid_formats:
+        console.print(
+            f"[red]Error:[/red] Invalid format '{format}'. Must be one of: {', '.join(valid_formats)}"
+        )
+        raise SystemExit(1)
+
+    # Validate filtering options
+    if (up is not None or down is not None) and feature is None:
+        console.print(
+            "[red]Error:[/red] --up and --down require --feature to be specified"
+        )
+        raise SystemExit(1)
+
+    # Load features from entrypoints (needed for "current" literal)
+    load_features()
+    graph = FeatureGraph.get_active()
+
+    metadata_store = get_store(store)
+
+    with metadata_store:
+        # Resolve snapshot versions
+        resolver = SnapshotResolver()
+        try:
+            snapshot1_version = resolver.resolve_snapshot(
+                snapshot1, metadata_store, graph
+            )
+            snapshot2_version = resolver.resolve_snapshot(
+                snapshot2, metadata_store, graph
+            )
+        except ValueError as e:
+            console.print(f"[red]Error:[/red] {e}")
+            raise SystemExit(1)
+
+        # Load snapshot data
+        differ = GraphDiffer()
+        try:
+            snapshot1_data = differ.load_snapshot_data(
+                metadata_store, snapshot1_version
+            )
+            snapshot2_data = differ.load_snapshot_data(
+                metadata_store, snapshot2_version
+            )
+        except ValueError as e:
+            console.print(f"[red]Error:[/red] {e}")
+            raise SystemExit(1)
+
+        # Compute diff
+        graph_diff = differ.diff(snapshot1_data, snapshot2_data)
+        # Override snapshot versions in diff result
+        graph_diff = GraphDiff(
+            snapshot1=snapshot1_version,
+            snapshot2=snapshot2_version,
+            added_features=graph_diff.added_features,
+            removed_features=graph_diff.removed_features,
+            changed_features=graph_diff.changed_features,
+        )
+
+        # Format output
+        formatter = DiffFormatter(console)
+        try:
+            if diff_only:
+                # Show only diff list
+                formatted = formatter.format(
+                    diff=graph_diff,
+                    format=format,
+                    verbose=verbose,
+                    diff_only=True,
+                )
+            else:
+                # Show merged graph (default)
+                merged_data = differ.create_merged_graph_data(
+                    snapshot1_data, snapshot2_data, graph_diff
+                )
+
+                # Apply graph slicing if requested
+                if feature is not None:
+                    try:
+                        merged_data = differ.filter_merged_graph(
+                            merged_data, focus_feature=feature, up=up, down=down
+                        )
+                    except ValueError as e:
+                        console.print(f"[red]Error:[/red] {e}")
+                        raise SystemExit(1)
+
+                formatted = formatter.format(
+                    merged_data=merged_data,
+                    format=format,
+                    verbose=verbose,
+                    diff_only=False,
+                    show_all_fields=not show_changed_fields_only,
+                )
+        except ValueError as e:
+            console.print(f"[red]Error:[/red] {e}")
+            raise SystemExit(1)
+
+        # Output to file or stdout
+        if output:
+            try:
+                with open(output, "w") as f:
+                    f.write(formatted)
+                console.print(f"[green]✓[/green] Diff saved to: {output}")
+            except Exception as e:
+                console.print(f"[red]✗[/red] Failed to write to file: {e}")
+                raise SystemExit(1)
+        else:
+            # Print to stdout
+            if format == "terminal":
+                # Use Rich console for colored output
+                console.print(formatted)
+            else:
+                # Use plain print for non-terminal formats
+                print(formatted)
 
 
 @app.command()

--- a/src/metaxy/formatters/__init__.py
+++ b/src/metaxy/formatters/__init__.py
@@ -1,0 +1,1 @@
+"""Formatters for displaying metaxy data structures."""

--- a/src/metaxy/formatters/graph_diff.py
+++ b/src/metaxy/formatters/graph_diff.py
@@ -1,0 +1,791 @@
+"""Formatter for graph diff output."""
+
+import json
+from typing import Any
+
+from rich.console import Console
+
+from metaxy.graph import utils
+from metaxy.graph_diff import GraphDiff
+
+
+class DiffFormatter:
+    """Formats GraphDiff for display with colored output."""
+
+    def __init__(self, console: Console | None = None):
+        """Initialize formatter.
+
+        Args:
+            console: Rich console for output (creates new one if None)
+        """
+        self.console = console or Console()
+
+    def format(
+        self,
+        diff: GraphDiff | None = None,
+        merged_data: dict[str, Any] | None = None,
+        format: str = "terminal",
+        verbose: bool = False,
+        diff_only: bool = False,
+        show_all_fields: bool = True,
+    ) -> str:
+        """Format a GraphDiff or merged graph data in the specified format.
+
+        Args:
+            diff: GraphDiff to format (required for diff_only mode)
+            merged_data: Merged graph data (required for merged mode)
+            format: Output format ("terminal", "json", "yaml", or "mermaid")
+            verbose: If True, show more details (dependencies, code versions)
+            diff_only: If True, show only diff list; otherwise show merged graph
+            show_all_fields: If True, show all fields; if False, show only changed fields
+
+        Returns:
+            Formatted string
+
+        Raises:
+            ValueError: If format is not recognized or required data is missing
+        """
+        if diff_only:
+            if diff is None:
+                raise ValueError("diff is required for diff_only mode")
+            return self._format_diff_only(diff, format, verbose)
+        else:
+            if merged_data is None:
+                raise ValueError("merged_data is required for merged mode")
+            return self._format_merged(merged_data, format, verbose, show_all_fields)
+
+    def _format_diff_only(self, diff: GraphDiff, format: str, verbose: bool) -> str:
+        """Format diff-only output."""
+        if format == "terminal":
+            return self.format_terminal_diff_only(diff, verbose)
+        elif format == "json":
+            return self.format_json_diff_only(diff)
+        elif format == "yaml":
+            return self.format_yaml_diff_only(diff)
+        elif format == "mermaid":
+            return self.format_mermaid_diff_only(diff, verbose)
+        else:
+            raise ValueError(
+                f"Unknown format: {format}. Must be one of: terminal, json, yaml, mermaid"
+            )
+
+    def _format_merged(
+        self,
+        merged_data: dict[str, Any],
+        format: str,
+        verbose: bool,
+        show_all_fields: bool,
+    ) -> str:
+        """Format merged graph output."""
+        if format == "terminal":
+            return self.format_terminal_merged(merged_data, verbose, show_all_fields)
+        elif format == "json":
+            return self.format_json_merged(merged_data)
+        elif format == "yaml":
+            return self.format_yaml_merged(merged_data)
+        elif format == "mermaid":
+            return self.format_mermaid_merged(merged_data, verbose, show_all_fields)
+        else:
+            raise ValueError(
+                f"Unknown format: {format}. Must be one of: terminal, json, yaml, mermaid"
+            )
+
+    def format_terminal_diff_only(self, diff: GraphDiff, verbose: bool = False) -> str:
+        """Format a GraphDiff as a human-readable string with colored markup.
+
+        Args:
+            diff: GraphDiff to format
+            verbose: If True, show more details (dependencies, code versions)
+
+        Returns:
+            Formatted string with Rich markup
+        """
+        if not diff.has_changes:
+            return self._format_no_changes(diff)
+
+        lines = []
+
+        # Header
+        lines.append(
+            f"Graph Diff: {utils.format_hash(diff.snapshot1)}... → {utils.format_hash(diff.snapshot2)}..."
+        )
+        lines.append("")
+
+        # Added features
+        if diff.added_features:
+            lines.append(
+                f"[bold green]Added ({len(diff.added_features)}):[/bold green]"
+            )
+            for feature_key in diff.added_features:
+                lines.append(
+                    f"  [green]+[/green] {utils.format_feature_key(feature_key)}"
+                )
+            lines.append("")
+
+        # Removed features
+        if diff.removed_features:
+            lines.append(
+                f"[bold red]Removed ({len(diff.removed_features)}):[/bold red]"
+            )
+            for feature_key in diff.removed_features:
+                lines.append(f"  [red]-[/red] {utils.format_feature_key(feature_key)}")
+            lines.append("")
+
+        # Changed features
+        if diff.changed_features:
+            lines.append(
+                f"[bold yellow]Changed ({len(diff.changed_features)}):[/bold yellow]"
+            )
+            for feature_change in diff.changed_features:
+                # Show feature-level change
+                old_ver = (
+                    utils.format_hash(feature_change.old_version)
+                    if feature_change.old_version
+                    else "none"
+                )
+                new_ver = (
+                    utils.format_hash(feature_change.new_version)
+                    if feature_change.new_version
+                    else "none"
+                )
+                lines.append(
+                    f"  [yellow]~[/yellow] {utils.format_feature_key(feature_change.feature_key)} "
+                    f"({old_ver}... → {new_ver}...)"
+                )
+
+                # Show field changes if any
+                if feature_change.has_field_changes:
+                    lines.append("    fields:")
+                    for field_change in feature_change.field_changes:
+                        field_key_str = utils.format_field_key(field_change.field_key)
+
+                        if field_change.is_added:
+                            new_ver = (
+                                utils.format_hash(field_change.new_version)
+                                if field_change.new_version
+                                else "none"
+                            )
+                            lines.append(
+                                f"      [green]+[/green] {field_key_str} ({new_ver}...)"
+                            )
+                        elif field_change.is_removed:
+                            old_ver = (
+                                utils.format_hash(field_change.old_version)
+                                if field_change.old_version
+                                else "none"
+                            )
+                            lines.append(
+                                f"      [red]-[/red] {field_key_str} ({old_ver}...)"
+                            )
+                        elif field_change.is_changed:
+                            old_ver = (
+                                utils.format_hash(field_change.old_version)
+                                if field_change.old_version
+                                else "none"
+                            )
+                            new_ver = (
+                                utils.format_hash(field_change.new_version)
+                                if field_change.new_version
+                                else "none"
+                            )
+                            lines.append(
+                                f"      [yellow]~[/yellow] {field_key_str} "
+                                f"({old_ver}... → {new_ver}...)"
+                            )
+            lines.append("")
+
+        # Summary
+        total_changes = (
+            len(diff.added_features)
+            + len(diff.removed_features)
+            + len(diff.changed_features)
+        )
+        lines.append(f"[dim]Total changes: {total_changes}[/dim]")
+
+        return "\n".join(lines)
+
+    def _format_no_changes(self, diff: GraphDiff) -> str:
+        """Format message when there are no changes."""
+        return (
+            f"[green]No changes between snapshots[/green]\n"
+            f"  {utils.format_hash(diff.snapshot1)}... → {utils.format_hash(diff.snapshot2)}..."
+        )
+
+    def print(self, diff: GraphDiff, verbose: bool = False) -> None:
+        """Print formatted diff to console.
+
+        Args:
+            diff: GraphDiff to print
+            verbose: If True, show more details
+        """
+        formatted = self.format_terminal_diff_only(diff, verbose=verbose)
+        self.console.print(formatted)
+
+    def format_json_diff_only(self, diff: GraphDiff) -> str:
+        """Format GraphDiff as JSON.
+
+        Args:
+            diff: GraphDiff to format
+
+        Returns:
+            JSON string representation of the diff
+        """
+        data = {
+            "snapshot1": diff.snapshot1,
+            "snapshot2": diff.snapshot2,
+            "added_features": [
+                utils.format_feature_key(fk) for fk in diff.added_features
+            ],
+            "removed_features": [
+                utils.format_feature_key(fk) for fk in diff.removed_features
+            ],
+            "changed_features": [
+                {
+                    "feature_key": utils.format_feature_key(fc.feature_key),
+                    "old_version": fc.old_version,
+                    "new_version": fc.new_version,
+                    "field_changes": [
+                        {
+                            "field_key": utils.format_field_key(field.field_key),
+                            "old_version": field.old_version,
+                            "new_version": field.new_version,
+                            "is_added": field.is_added,
+                            "is_removed": field.is_removed,
+                            "is_changed": field.is_changed,
+                        }
+                        for field in fc.field_changes
+                    ],
+                }
+                for fc in diff.changed_features
+            ],
+        }
+        return json.dumps(data, indent=2)
+
+    def format_yaml_diff_only(self, diff: GraphDiff) -> str:
+        """Format GraphDiff as YAML.
+
+        Args:
+            diff: GraphDiff to format
+
+        Returns:
+            YAML string representation of the diff
+        """
+        import yaml
+
+        data = {
+            "snapshot1": diff.snapshot1,
+            "snapshot2": diff.snapshot2,
+            "added_features": [fk.to_string() for fk in diff.added_features],
+            "removed_features": [fk.to_string() for fk in diff.removed_features],
+            "changed_features": [
+                {
+                    "feature_key": fc.feature_key.to_string(),
+                    "old_version": fc.old_version,
+                    "new_version": fc.new_version,
+                    "field_changes": [
+                        {
+                            "field_key": field.field_key.to_string(),
+                            "old_version": field.old_version,
+                            "new_version": field.new_version,
+                            "is_added": field.is_added,
+                            "is_removed": field.is_removed,
+                            "is_changed": field.is_changed,
+                        }
+                        for field in fc.field_changes
+                    ],
+                }
+                for fc in diff.changed_features
+            ],
+        }
+        return yaml.safe_dump(data, default_flow_style=False, sort_keys=False)
+
+    def format_mermaid_diff_only(self, diff: GraphDiff, verbose: bool = False) -> str:
+        """Format GraphDiff as Mermaid flowchart.
+
+        Args:
+            diff: GraphDiff to format
+            verbose: If True, show more details
+
+        Returns:
+            Mermaid flowchart markup showing the diff
+        """
+        lines = []
+        lines.append("---")
+        lines.append("title: Graph Diff")
+        lines.append("---")
+        lines.append("flowchart TB")
+        lines.append(
+            "    %%{init: {'flowchart': {'htmlLabels': true, 'curve': 'basis'}, 'themeVariables': {'fontSize': '14px'}}}%%"
+        )
+        lines.append("")
+
+        # Collect all features
+        all_features = set()
+        for fk in diff.added_features:
+            all_features.add(fk.to_string())
+        for fk in diff.removed_features:
+            all_features.add(fk.to_string())
+        for fc in diff.changed_features:
+            all_features.add(fc.feature_key.to_string())
+
+        if not all_features:
+            lines.append("    Empty[No changes]")
+            lines.append("")
+            return "\n".join(lines)
+
+        # Generate node IDs (sanitized for Mermaid)
+        def sanitize_id(s: str) -> str:
+            return s.replace("/", "_").replace("-", "_")
+
+        # Define nodes with styling
+        for fk in diff.added_features:
+            node_id = sanitize_id(fk.to_string())
+            feature_str = fk.to_string()
+            lines.append(f'    {node_id}["{feature_str}"]')
+            lines.append(f"    style {node_id} fill:#90EE90,stroke:#006400")
+
+        for fk in diff.removed_features:
+            node_id = sanitize_id(fk.to_string())
+            feature_str = fk.to_string()
+            lines.append(f'    {node_id}["{feature_str}"]')
+            lines.append(f"    style {node_id} fill:#FFB6C1,stroke:#DC143C")
+
+        for fc in diff.changed_features:
+            node_id = sanitize_id(fc.feature_key.to_string())
+            feature_str = fc.feature_key.to_string()
+
+            if verbose and fc.has_field_changes:
+                # Show field changes in verbose mode
+                field_changes_str = "<br/>".join(
+                    [
+                        f"{'+ ' if field.is_added else '- ' if field.is_removed else '~ '}{field.field_key.to_string()}"
+                        for field in fc.field_changes
+                    ]
+                )
+                lines.append(f'    {node_id}["{feature_str}<br/>{field_changes_str}"]')
+            else:
+                lines.append(f'    {node_id}["{feature_str}"]')
+
+            lines.append(f"    style {node_id} fill:#FFE4B5,stroke:#FFA500")
+
+        lines.append("")
+
+        return "\n".join(lines)
+
+    # Merged graph format methods
+
+    def format_terminal_merged(
+        self,
+        merged_data: dict[str, Any],
+        verbose: bool = False,
+        show_all_fields: bool = True,
+    ) -> str:
+        """Format merged graph as terminal tree view with status annotations.
+
+        Args:
+            merged_data: Merged graph data with nodes and edges
+            verbose: If True, show more details
+            show_all_fields: If True, show all fields; if False, show only changed fields
+
+        Returns:
+            Formatted string with Rich markup
+        """
+        from metaxy.graph_diff import FieldChange
+
+        nodes = merged_data["nodes"]
+
+        if not nodes:
+            return "[yellow]Empty graph (no features)[/yellow]"
+
+        lines = []
+        lines.append("[bold]Feature Graph (merged view):[/bold]")
+        lines.append("")
+
+        # Build dependency graph for hierarchical display
+        # We'll sort features by status priority: unchanged, changed, added, removed
+        status_order = {"unchanged": 0, "changed": 1, "added": 2, "removed": 3}
+
+        sorted_features = sorted(
+            nodes.items(), key=lambda x: (status_order[x[1]["status"]], x[0])
+        )
+
+        for feature_key_str, node_data in sorted_features:
+            status = node_data["status"]
+            old_version = node_data["old_version"]
+            new_version = node_data["new_version"]
+            field_changes = node_data["field_changes"]
+            dependencies = node_data["dependencies"]
+
+            # Status symbols and colors
+            if status == "added":
+                symbol = "[green]+[/green]"
+                status_text = "[green](added)[/green]"
+            elif status == "removed":
+                symbol = "[red]-[/red]"
+                status_text = "[red](removed)[/red]"
+            elif status == "changed":
+                symbol = "[yellow]~[/yellow]"
+                status_text = "[yellow](changed)[/yellow]"
+            else:
+                symbol = " "
+                status_text = ""
+
+            # Feature line
+            lines.append(f"{symbol} [bold]{feature_key_str}[/bold] {status_text}")
+
+            # Version information
+            if status == "added":
+                lines.append(f"  version: {utils.format_hash(new_version)}...")
+            elif status == "removed":
+                lines.append(f"  version: {utils.format_hash(old_version)}...")
+            elif status == "changed":
+                old_ver_str = utils.format_hash(old_version) if old_version else "none"
+                new_ver_str = utils.format_hash(new_version) if new_version else "none"
+                lines.append(f"  version: {old_ver_str}... → {new_ver_str}...")
+            else:
+                # Unchanged
+                lines.append(f"  version: {utils.format_hash(new_version)}...")
+
+            # Dependencies
+            if dependencies:
+                lines.append(f"  depends on: {', '.join(dependencies)}")
+
+            # Fields (show fields for all features by default)
+            fields = node_data["fields"]
+            if fields:
+                lines.append("  fields:")
+
+                # Build a map of field changes for quick lookup
+                field_change_map = {
+                    fc.field_key.to_string(): fc
+                    for fc in field_changes
+                    if isinstance(fc, FieldChange)
+                }
+
+                # Collect field keys based on show_all_fields setting
+                if show_all_fields:
+                    # Show all fields (from both fields dict and field_changes for removed fields)
+                    all_field_keys = set(fields.keys())
+                    all_field_keys.update(field_change_map.keys())
+                else:
+                    # Show only changed fields
+                    all_field_keys = set(field_change_map.keys())
+
+                # Show fields
+                for field_key_str_inner in sorted(all_field_keys):
+                    if field_key_str_inner in field_change_map:
+                        # This field has a change
+                        field_change = field_change_map[field_key_str_inner]
+
+                        if field_change.is_added:
+                            new_ver = (
+                                utils.format_hash(field_change.new_version)
+                                if field_change.new_version
+                                else "none"
+                            )
+                            lines.append(
+                                f"    [green]+[/green] {field_key_str_inner} ({new_ver}...)"
+                            )
+                        elif field_change.is_removed:
+                            old_ver = (
+                                utils.format_hash(field_change.old_version)
+                                if field_change.old_version
+                                else "none"
+                            )
+                            lines.append(
+                                f"    [red]-[/red] {field_key_str_inner} ({old_ver}...)"
+                            )
+                        elif field_change.is_changed:
+                            old_ver = (
+                                utils.format_hash(field_change.old_version)
+                                if field_change.old_version
+                                else "none"
+                            )
+                            new_ver = (
+                                utils.format_hash(field_change.new_version)
+                                if field_change.new_version
+                                else "none"
+                            )
+                            lines.append(
+                                f"    [yellow]~[/yellow] {field_key_str_inner} "
+                                f"([red]{old_ver}[/red]... → [green]{new_ver}[/green]...)"
+                            )
+                    else:
+                        # Unchanged field - no color, but show with proper spacing
+                        field_version = fields[field_key_str_inner]
+                        ver = (
+                            utils.format_hash(field_version)
+                            if field_version
+                            else "none"
+                        )
+                        lines.append(f"      {field_key_str_inner} ({ver}...)")
+
+            lines.append("")
+
+        return "\n".join(lines)
+
+    def format_json_merged(self, merged_data: dict[str, Any]) -> str:
+        """Format merged graph as JSON.
+
+        Args:
+            merged_data: Merged graph data with nodes and edges
+
+        Returns:
+            JSON string representation of merged graph
+        """
+        from metaxy.graph_diff import FieldChange
+
+        # Convert to JSON-serializable format
+        nodes_json = {}
+        for feature_key, node_data in merged_data["nodes"].items():
+            field_changes_json = []
+            for field_change in node_data["field_changes"]:
+                if isinstance(field_change, FieldChange):
+                    field_changes_json.append(
+                        {
+                            "field_key": field_change.field_key.to_string(),
+                            "old_version": field_change.old_version,
+                            "new_version": field_change.new_version,
+                            "is_added": field_change.is_added,
+                            "is_removed": field_change.is_removed,
+                            "is_changed": field_change.is_changed,
+                        }
+                    )
+
+            nodes_json[feature_key] = {
+                "status": node_data["status"],
+                "old_version": node_data["old_version"],
+                "new_version": node_data["new_version"],
+                "dependencies": node_data["dependencies"],
+                "field_changes": field_changes_json,
+            }
+
+        data = {
+            "nodes": nodes_json,
+            "edges": merged_data["edges"],
+        }
+        return json.dumps(data, indent=2)
+
+    def format_yaml_merged(self, merged_data: dict[str, Any]) -> str:
+        """Format merged graph as YAML.
+
+        Args:
+            merged_data: Merged graph data with nodes and edges
+
+        Returns:
+            YAML string representation of merged graph
+        """
+        import yaml
+
+        from metaxy.graph_diff import FieldChange
+
+        # Convert to YAML-serializable format
+        nodes_yaml = {}
+        for feature_key, node_data in merged_data["nodes"].items():
+            field_changes_yaml = []
+            for field_change in node_data["field_changes"]:
+                if isinstance(field_change, FieldChange):
+                    field_changes_yaml.append(
+                        {
+                            "field_key": field_change.field_key.to_string(),
+                            "old_version": field_change.old_version,
+                            "new_version": field_change.new_version,
+                            "is_added": field_change.is_added,
+                            "is_removed": field_change.is_removed,
+                            "is_changed": field_change.is_changed,
+                        }
+                    )
+
+            nodes_yaml[feature_key] = {
+                "status": node_data["status"],
+                "old_version": node_data["old_version"],
+                "new_version": node_data["new_version"],
+                "dependencies": node_data["dependencies"],
+                "field_changes": field_changes_yaml,
+            }
+
+        data = {
+            "nodes": nodes_yaml,
+            "edges": merged_data["edges"],
+        }
+        return yaml.safe_dump(data, default_flow_style=False, sort_keys=False)
+
+    def format_mermaid_merged(
+        self,
+        merged_data: dict[str, Any],
+        verbose: bool = False,
+        show_all_fields: bool = True,
+    ) -> str:
+        """Format merged graph as Mermaid flowchart with status colors.
+
+        Args:
+            merged_data: Merged graph data with nodes and edges
+            verbose: If True, show field changes on changed nodes
+            show_all_fields: If True, show all fields; if False, show only changed fields
+
+        Returns:
+            Mermaid flowchart markup
+        """
+        from metaxy.graph_diff import FieldChange
+
+        nodes = merged_data["nodes"]
+        edges = merged_data["edges"]
+
+        lines = []
+        lines.append("---")
+        lines.append("title: Merged Graph Diff")
+        lines.append("---")
+        lines.append("flowchart TB")
+        lines.append(
+            "    %%{init: {'flowchart': {'htmlLabels': true, 'curve': 'basis'}, 'themeVariables': {'fontSize': '14px'}}}%%"
+        )
+        lines.append("")
+
+        if not nodes:
+            lines.append("    Empty[No features]")
+            return "\n".join(lines)
+
+        def sanitize_id(s: str) -> str:
+            return s.replace("/", "_").replace("-", "_")
+
+        # Define nodes with styling based on status
+        for feature_key_str, node_data in nodes.items():
+            node_id = sanitize_id(feature_key_str)
+            status = node_data["status"]
+            old_version = node_data["old_version"]
+            new_version = node_data["new_version"]
+            field_changes = node_data["field_changes"]
+
+            # Build node label
+            # Feature key in bold
+            label_parts = [f"<b>{feature_key_str}</b>"]
+            fields = node_data["fields"]
+
+            # Add version info
+            if status == "changed":
+                old_ver = (
+                    utils.format_hash(old_version, length=6) if old_version else "none"
+                )
+                new_ver = (
+                    utils.format_hash(new_version, length=6) if new_version else "none"
+                )
+                # Red for old version, green for new version
+                label_parts.append(
+                    f'<font color="#CC0000">{old_ver}</font> → '
+                    f'<font color="#00AA00">{new_ver}</font>'
+                )
+            elif status == "added":
+                ver = (
+                    utils.format_hash(new_version, length=6) if new_version else "none"
+                )
+                label_parts.append(f"{ver}")
+            elif status == "removed":
+                ver = (
+                    utils.format_hash(old_version, length=6) if old_version else "none"
+                )
+                label_parts.append(f"{ver}")
+            else:
+                # Unchanged
+                ver = (
+                    utils.format_hash(new_version, length=6) if new_version else "none"
+                )
+                label_parts.append(f"{ver}")
+
+            # Add separator line before fields
+            if fields:
+                label_parts.append('<font color="#999">---</font>')
+
+            # Show fields for all features (not just changed)
+            if fields:
+                # Build field change map (only for changed features)
+                field_change_map = {
+                    fc.field_key.to_string(): fc
+                    for fc in field_changes
+                    if isinstance(fc, FieldChange)
+                }
+
+                # Collect field keys based on show_all_fields setting
+                if show_all_fields:
+                    # Show all fields (from both fields dict and field_changes for removed fields)
+                    all_field_keys = set(fields.keys())
+                    all_field_keys.update(field_change_map.keys())
+                else:
+                    # Show only changed fields (skip if no changes for this feature)
+                    if status != "changed" or not field_change_map:
+                        all_field_keys = set()
+                    else:
+                        all_field_keys = set(field_change_map.keys())
+
+                for field_key_str_inner in sorted(all_field_keys):
+                    if field_key_str_inner in field_change_map:
+                        fc = field_change_map[field_key_str_inner]
+                        if fc.is_added:
+                            # Green for added (with version)
+                            new_ver = (
+                                utils.format_hash(fc.new_version, length=6)
+                                if fc.new_version
+                                else "none"
+                            )
+                            label_parts.append(
+                                f'<font color="#00AA00">- {field_key_str_inner} ({new_ver})</font>'
+                            )
+                        elif fc.is_removed:
+                            # Red for removed (with version)
+                            old_ver = (
+                                utils.format_hash(fc.old_version, length=6)
+                                if fc.old_version
+                                else "none"
+                            )
+                            label_parts.append(
+                                f'<font color="#CC0000">- {field_key_str_inner} ({old_ver})</font>'
+                            )
+                        elif fc.is_changed:
+                            # Yellow field name, red old version, green new version
+                            old_ver = (
+                                utils.format_hash(fc.old_version, length=6)
+                                if fc.old_version
+                                else "none"
+                            )
+                            new_ver = (
+                                utils.format_hash(fc.new_version, length=6)
+                                if fc.new_version
+                                else "none"
+                            )
+                            label_parts.append(
+                                f'- <font color="#FFAA00">{field_key_str_inner}</font> '
+                                f'(<font color="#CC0000">{old_ver}</font> → '
+                                f'<font color="#00AA00">{new_ver}</font>)'
+                            )
+                    else:
+                        # Unchanged field - no color, with dash prefix
+                        field_version = fields.get(field_key_str_inner)
+                        if field_version:
+                            ver = utils.format_hash(field_version, length=6)
+                            label_parts.append(f"- {field_key_str_inner} ({ver})")
+
+            # Wrap content in left-aligned div (like graph render does)
+            label = "<br/>".join(label_parts)
+            label = f'<div style="text-align:left">{label}</div>'
+            lines.append(f'    {node_id}["{label}"]')
+
+            # Apply styling based on status
+            if status == "added":
+                lines.append(f"    style {node_id} fill:#90EE90,stroke:#006400")
+            elif status == "removed":
+                lines.append(f"    style {node_id} fill:#FFB6C1,stroke:#DC143C")
+            elif status == "changed":
+                # Yellow border only, not filled
+                lines.append(f"    style {node_id} stroke:#FFA500,stroke-width:3px")
+            # else: unchanged - no special styling
+
+        lines.append("")
+
+        # Add edges
+        for edge in edges:
+            from_id = sanitize_id(edge["from"])
+            to_id = sanitize_id(edge["to"])
+            lines.append(f"    {from_id} --> {to_id}")
+
+        lines.append("")
+
+        return "\n".join(lines)

--- a/src/metaxy/graph/renderers/base.py
+++ b/src/metaxy/graph/renderers/base.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass, field
 
+from metaxy.graph import utils
 from metaxy.models.feature import FeatureGraph
 from metaxy.models.types import FeatureKey, FieldKey
 
@@ -144,9 +145,7 @@ class GraphRenderer:
         Returns:
             Truncated hash if hash_length > 0, otherwise full hash
         """
-        if self.config.hash_length == 0:
-            return hash_str
-        return hash_str[: self.config.hash_length]
+        return utils.format_hash(hash_str, length=self.config.hash_length)
 
     def _format_feature_key(self, key: FeatureKey) -> str:
         """Format feature key for display.
@@ -159,7 +158,7 @@ class GraphRenderer:
         Returns:
             Formatted string like "my/feature/key"
         """
-        return "/".join(key)
+        return utils.format_feature_key(key)
 
     def _format_field_key(self, key: FieldKey) -> str:
         """Format field key for display.
@@ -170,7 +169,7 @@ class GraphRenderer:
         Returns:
             Formatted string like "field_name"
         """
-        return "/".join(key)
+        return utils.format_field_key(key)
 
     def _get_filtered_features(self) -> set[FeatureKey]:
         """Get features to render based on config filters.

--- a/src/metaxy/graph/utils.py
+++ b/src/metaxy/graph/utils.py
@@ -1,0 +1,58 @@
+"""Shared utilities for graph rendering and formatting."""
+
+from metaxy.models.types import FeatureKey, FieldKey
+
+
+def sanitize_mermaid_id(s: str) -> str:
+    """Sanitize string for use as Mermaid node ID.
+
+    Replaces characters that are invalid in Mermaid identifiers.
+
+    Args:
+        s: String to sanitize
+
+    Returns:
+        Sanitized string safe for use as Mermaid node ID
+    """
+    return s.replace("/", "_").replace("-", "_").replace("__", "_")
+
+
+def format_hash(hash_str: str, length: int = 8) -> str:
+    """Format hash string with optional truncation.
+
+    Args:
+        hash_str: Full hash string
+        length: Number of characters to show (0 for full hash)
+
+    Returns:
+        Truncated or full hash string
+    """
+    if length == 0 or length >= len(hash_str):
+        return hash_str
+    return hash_str[:length]
+
+
+def format_feature_key(key: FeatureKey) -> str:
+    """Format feature key for display.
+
+    Uses / separator for better readability.
+
+    Args:
+        key: Feature key
+
+    Returns:
+        Formatted string like "my/feature/key"
+    """
+    return "/".join(key)
+
+
+def format_field_key(key: FieldKey) -> str:
+    """Format field key for display.
+
+    Args:
+        key: Field key
+
+    Returns:
+        Formatted string like "field_name"
+    """
+    return "/".join(key)

--- a/src/metaxy/graph_diff.py
+++ b/src/metaxy/graph_diff.py
@@ -1,0 +1,692 @@
+"""Core graph diff engine for comparing feature graph snapshots."""
+
+import json
+from typing import Any
+
+from pydantic import Field
+
+from metaxy.metadata_store.base import FEATURE_VERSIONS_KEY, MetadataStore
+from metaxy.models.bases import FrozenBaseModel
+from metaxy.models.feature import FeatureGraph
+from metaxy.models.types import FeatureKey, FieldKey
+
+
+class FieldChange(FrozenBaseModel):
+    """Represents a change in a field between two snapshots."""
+
+    field_key: FieldKey
+    old_version: str | None = None  # None if field was added
+    new_version: str | None = None  # None if field was removed
+
+    @property
+    def is_added(self) -> bool:
+        """Check if field was added."""
+        return self.old_version is None
+
+    @property
+    def is_removed(self) -> bool:
+        """Check if field was removed."""
+        return self.new_version is None
+
+    @property
+    def is_changed(self) -> bool:
+        """Check if field version changed."""
+        return (
+            self.old_version is not None
+            and self.new_version is not None
+            and self.old_version != self.new_version
+        )
+
+
+class FeatureChange(FrozenBaseModel):
+    """Represents a change in a feature between two snapshots."""
+
+    feature_key: FeatureKey
+    old_version: str | None = None  # None if feature was added
+    new_version: str | None = None  # None if feature was removed
+    field_changes: list[FieldChange] = Field(default_factory=list)
+
+    @property
+    def is_added(self) -> bool:
+        """Check if feature was added."""
+        return self.old_version is None
+
+    @property
+    def is_removed(self) -> bool:
+        """Check if feature was removed."""
+        return self.new_version is None
+
+    @property
+    def has_field_changes(self) -> bool:
+        """Check if feature has any field changes."""
+        return len(self.field_changes) > 0
+
+
+class GraphDiff(FrozenBaseModel):
+    """Result of comparing two graph snapshots."""
+
+    snapshot1: str
+    snapshot2: str
+    added_features: list[FeatureKey] = Field(default_factory=list)
+    removed_features: list[FeatureKey] = Field(default_factory=list)
+    changed_features: list[FeatureChange] = Field(default_factory=list)
+
+    @property
+    def has_changes(self) -> bool:
+        """Check if diff contains any changes."""
+        return bool(
+            self.added_features or self.removed_features or self.changed_features
+        )
+
+
+class SnapshotResolver:
+    """Resolves snapshot version literals to actual snapshot hashes."""
+
+    def resolve_snapshot(
+        self, literal: str, store: MetadataStore | None, graph: FeatureGraph | None
+    ) -> str:
+        """Resolve a snapshot literal to its actual version hash.
+
+        Args:
+            literal: Snapshot identifier ("latest", "current", or version hash)
+            store: Metadata store to query for snapshots (required for "latest")
+            graph: Optional active graph for "current" resolution
+
+        Returns:
+            Resolved snapshot version hash
+
+        Raises:
+            ValueError: If literal is invalid or cannot be resolved
+        """
+        if literal == "latest":
+            if store is None:
+                raise ValueError(
+                    "Cannot resolve 'latest': no metadata store provided. "
+                    "Provide a store to query for snapshots."
+                )
+            return self._resolve_latest(store)
+        elif literal == "current":
+            return self._resolve_current(graph)
+        else:
+            # Treat as explicit snapshot version
+            return literal
+
+    def _resolve_latest(self, store: MetadataStore) -> str:
+        """Resolve 'latest' to most recent snapshot in store."""
+        snapshots_df = store.read_graph_snapshots()
+
+        if snapshots_df.height == 0:
+            raise ValueError(
+                "No snapshots found in store. Cannot resolve 'latest'. "
+                "Run 'metaxy graph push' to record a snapshot."
+            )
+
+        # read_graph_snapshots() returns sorted by recorded_at descending
+        latest_snapshot = snapshots_df["snapshot_version"][0]
+        return latest_snapshot
+
+    def _resolve_current(self, graph: FeatureGraph | None) -> str:
+        """Resolve 'current' to active graph's snapshot version."""
+        if graph is None:
+            raise ValueError(
+                "Cannot resolve 'current': no active graph provided. "
+                "Ensure features are loaded before using 'current'."
+            )
+
+        if len(graph.features_by_key) == 0:
+            raise ValueError(
+                "Cannot resolve 'current': active graph is empty. "
+                "Ensure features are loaded before using 'current'."
+            )
+
+        return graph.snapshot_version
+
+
+class GraphDiffer:
+    """Compares two graph snapshots and produces a diff."""
+
+    def diff(
+        self,
+        snapshot1_data: dict[str, dict[str, Any]],
+        snapshot2_data: dict[str, dict[str, Any]],
+    ) -> GraphDiff:
+        """Compute diff between two snapshots.
+
+        Args:
+            snapshot1_data: First snapshot (feature_key -> {feature_version, fields})
+            snapshot2_data: Second snapshot (feature_key -> {feature_version, fields})
+
+        Returns:
+            GraphDiff with added, removed, and changed features
+        """
+        # Extract feature keys
+        keys1 = set(snapshot1_data.keys())
+        keys2 = set(snapshot2_data.keys())
+
+        # Identify added and removed features
+        added_keys = keys2 - keys1
+        removed_keys = keys1 - keys2
+        common_keys = keys1 & keys2
+
+        added_features = [FeatureKey(k.split("/")) for k in sorted(added_keys)]
+        removed_features = [FeatureKey(k.split("/")) for k in sorted(removed_keys)]
+
+        # Identify changed features
+        changed_features = []
+        for key_str in sorted(common_keys):
+            feature1 = snapshot1_data[key_str]
+            feature2 = snapshot2_data[key_str]
+
+            version1 = feature1["feature_version"]
+            version2 = feature2["feature_version"]
+            fields1 = feature1.get("fields", {})
+            fields2 = feature2.get("fields", {})
+
+            # Check if feature version changed or fields changed
+            if version1 != version2 or fields1 != fields2:
+                # Compute field changes
+                field_changes = self._compute_field_changes(fields1, fields2)
+
+                changed_features.append(
+                    FeatureChange(
+                        feature_key=FeatureKey(key_str.split("/")),
+                        old_version=version1,
+                        new_version=version2,
+                        field_changes=field_changes,
+                    )
+                )
+
+        # Determine snapshot versions from data
+        # For now, use placeholder - caller should provide these
+        snapshot1_version = "snapshot1"
+        snapshot2_version = "snapshot2"
+
+        return GraphDiff(
+            snapshot1=snapshot1_version,
+            snapshot2=snapshot2_version,
+            added_features=added_features,
+            removed_features=removed_features,
+            changed_features=changed_features,
+        )
+
+    def _compute_field_changes(
+        self, fields1: dict[str, str], fields2: dict[str, str]
+    ) -> list[FieldChange]:
+        """Compute changes between two field version mappings.
+
+        Args:
+            fields1: Field key (string) -> field version (hash) from snapshot1
+            fields2: Field key (string) -> field version (hash) from snapshot2
+
+        Returns:
+            List of FieldChange objects
+        """
+        field_keys1 = set(fields1.keys())
+        field_keys2 = set(fields2.keys())
+
+        added_fields = field_keys2 - field_keys1
+        removed_fields = field_keys1 - field_keys2
+        common_fields = field_keys1 & field_keys2
+
+        changes = []
+
+        # Added fields
+        for field_key_str in sorted(added_fields):
+            changes.append(
+                FieldChange(
+                    field_key=FieldKey(field_key_str.split("/")),
+                    old_version=None,
+                    new_version=fields2[field_key_str],
+                )
+            )
+
+        # Removed fields
+        for field_key_str in sorted(removed_fields):
+            changes.append(
+                FieldChange(
+                    field_key=FieldKey(field_key_str.split("/")),
+                    old_version=fields1[field_key_str],
+                    new_version=None,
+                )
+            )
+
+        # Changed fields
+        for field_key_str in sorted(common_fields):
+            version1 = fields1[field_key_str]
+            version2 = fields2[field_key_str]
+
+            if version1 != version2:
+                changes.append(
+                    FieldChange(
+                        field_key=FieldKey(field_key_str.split("/")),
+                        old_version=version1,
+                        new_version=version2,
+                    )
+                )
+
+        return changes
+
+    def create_merged_graph_data(
+        self,
+        snapshot1_data: dict[str, dict[str, Any]],
+        snapshot2_data: dict[str, dict[str, Any]],
+        diff: GraphDiff,
+    ) -> dict[str, Any]:
+        """Create merged graph data structure with status annotations.
+
+        This combines features from both snapshots into a single unified view,
+        annotating each feature with its status (added/removed/changed/unchanged).
+
+        Args:
+            snapshot1_data: First snapshot data (feature_key -> {feature_version, fields})
+            snapshot2_data: Second snapshot data (feature_key -> {feature_version, fields})
+            diff: Computed diff between snapshots
+
+        Returns:
+            Dict with structure:
+            {
+                'nodes': {
+                    feature_key_str: {
+                        'status': 'added' | 'removed' | 'changed' | 'unchanged',
+                        'old_version': str | None,
+                        'new_version': str | None,
+                        'fields': {...},  # fields from relevant snapshot
+                        'field_changes': [...],  # for changed nodes only
+                        'dependencies': [feature_key_str, ...],  # deps from relevant snapshot
+                    }
+                },
+                'edges': [
+                    {'from': feature_key_str, 'to': feature_key_str}
+                ]
+            }
+        """
+        # Create status mapping for efficient lookup
+        added_keys = {fk.to_string() for fk in diff.added_features}
+        removed_keys = {fk.to_string() for fk in diff.removed_features}
+        changed_keys = {fc.feature_key.to_string(): fc for fc in diff.changed_features}
+
+        # Get all feature keys from both snapshots
+        all_keys = set(snapshot1_data.keys()) | set(snapshot2_data.keys())
+
+        nodes = {}
+        edges = []
+
+        for feature_key_str in all_keys:
+            # Determine status
+            if feature_key_str in added_keys:
+                status = "added"
+                old_version = None
+                new_version = snapshot2_data[feature_key_str]["feature_version"]
+                fields = snapshot2_data[feature_key_str].get("fields", {})
+                field_changes = []
+                # Dependencies from snapshot2
+                deps = self._extract_dependencies(
+                    snapshot2_data[feature_key_str].get("feature_spec", {})
+                )
+            elif feature_key_str in removed_keys:
+                status = "removed"
+                old_version = snapshot1_data[feature_key_str]["feature_version"]
+                new_version = None
+                fields = snapshot1_data[feature_key_str].get("fields", {})
+                field_changes = []
+                # Dependencies from snapshot1
+                deps = self._extract_dependencies(
+                    snapshot1_data[feature_key_str].get("feature_spec", {})
+                )
+            elif feature_key_str in changed_keys:
+                status = "changed"
+                feature_change = changed_keys[feature_key_str]
+                old_version = feature_change.old_version
+                new_version = feature_change.new_version
+                fields = snapshot2_data[feature_key_str].get("fields", {})
+                field_changes = feature_change.field_changes
+                # Dependencies from snapshot2 (current version)
+                deps = self._extract_dependencies(
+                    snapshot2_data[feature_key_str].get("feature_spec", {})
+                )
+            else:
+                # Unchanged
+                status = "unchanged"
+                old_version = snapshot1_data[feature_key_str]["feature_version"]
+                new_version = snapshot2_data[feature_key_str]["feature_version"]
+                fields = snapshot2_data[feature_key_str].get("fields", {})
+                field_changes = []
+                # Dependencies from snapshot2
+                deps = self._extract_dependencies(
+                    snapshot2_data[feature_key_str].get("feature_spec", {})
+                )
+
+            nodes[feature_key_str] = {
+                "status": status,
+                "old_version": old_version,
+                "new_version": new_version,
+                "fields": fields,
+                "field_changes": field_changes,
+                "dependencies": deps,
+            }
+
+            # Create edges for dependencies (arrow points from dependency to feature)
+            for dep_key in deps:
+                edges.append({"from": dep_key, "to": feature_key_str})
+
+        return {
+            "nodes": nodes,
+            "edges": edges,
+        }
+
+    def _extract_dependencies(self, feature_spec: dict[str, Any]) -> list[str]:
+        """Extract dependency feature keys from a feature spec.
+
+        Args:
+            feature_spec: Parsed feature spec dict
+
+        Returns:
+            List of dependency feature keys as strings
+        """
+        deps = feature_spec.get("deps", [])
+        if deps is None:
+            return []
+
+        dep_keys = []
+        for dep in deps:
+            # dep is a dict with 'key' field
+            dep_key = dep.get("key", [])
+            if isinstance(dep_key, list):
+                dep_keys.append("/".join(dep_key))
+            else:
+                dep_keys.append(dep_key)
+
+        return dep_keys
+
+    def filter_merged_graph(
+        self,
+        merged_data: dict[str, Any],
+        focus_feature: str | None = None,
+        up: int | None = None,
+        down: int | None = None,
+    ) -> dict[str, Any]:
+        """Filter merged graph to show only relevant features.
+
+        Args:
+            merged_data: Merged graph data with nodes and edges
+            focus_feature: Feature key to focus on (string format with / or __)
+            up: Number of upstream levels (None = all if focus_feature is set, 0 otherwise)
+            down: Number of downstream levels (None = all if focus_feature is set, 0 otherwise)
+
+        Returns:
+            Filtered merged graph data with same structure
+
+        Raises:
+            ValueError: If focus_feature is specified but not found in graph
+        """
+        if focus_feature is None:
+            # No filtering
+            return merged_data
+
+        # Parse feature key (support both / and __ formats)
+        if "/" in focus_feature:
+            focus_key = focus_feature
+        else:
+            focus_key = focus_feature.replace("__", "/")
+
+        # Check if focus feature exists
+        if focus_key not in merged_data["nodes"]:
+            raise ValueError(f"Feature '{focus_feature}' not found in graph")
+
+        # Build dependency graph for traversal
+        # Build forward edges (feature -> dependents) and backward edges (feature -> dependencies)
+        forward_edges: dict[str, list[str]] = {}  # feature -> list of dependents
+        backward_edges: dict[str, list[str]] = {}  # feature -> list of dependencies
+
+        for edge in merged_data["edges"]:
+            dep = edge["from"]  # dependency
+            feat = edge["to"]  # dependent feature
+
+            if feat not in backward_edges:
+                backward_edges[feat] = []
+            backward_edges[feat].append(dep)
+
+            if dep not in forward_edges:
+                forward_edges[dep] = []
+            forward_edges[dep].append(feat)
+
+        # Find features to include
+        features_to_include = {focus_key}
+
+        # Add upstream (dependencies)
+        # Default behavior: if focus_feature is set but up is not specified, include all upstream
+        if up is None:
+            # Include all upstream
+            upstream = self._get_upstream_features(
+                focus_key, backward_edges, max_levels=None
+            )
+            features_to_include.update(upstream)
+        elif up > 0:
+            # Include specified number of levels
+            upstream = self._get_upstream_features(
+                focus_key, backward_edges, max_levels=up
+            )
+            features_to_include.update(upstream)
+        # else: up == 0, don't include upstream
+
+        # Add downstream (dependents)
+        # Default behavior: if focus_feature is set but down is not specified, include all downstream
+        if down is None:
+            # Include all downstream
+            downstream = self._get_downstream_features(
+                focus_key, forward_edges, max_levels=None
+            )
+            features_to_include.update(downstream)
+        elif down > 0:
+            # Include specified number of levels
+            downstream = self._get_downstream_features(
+                focus_key, forward_edges, max_levels=down
+            )
+            features_to_include.update(downstream)
+        # else: down == 0, don't include downstream
+
+        # Filter nodes and edges
+        filtered_nodes = {
+            k: v for k, v in merged_data["nodes"].items() if k in features_to_include
+        }
+        filtered_edges = [
+            e
+            for e in merged_data["edges"]
+            if e["from"] in features_to_include and e["to"] in features_to_include
+        ]
+
+        return {
+            "nodes": filtered_nodes,
+            "edges": filtered_edges,
+        }
+
+    def _get_upstream_features(
+        self,
+        start_key: str,
+        backward_edges: dict[str, list[str]],
+        max_levels: int | None = None,
+        visited: set[str] | None = None,
+        level: int = 0,
+    ) -> set[str]:
+        """Get upstream features (dependencies) recursively."""
+        if visited is None:
+            visited = set()
+
+        if start_key in visited:
+            return set()
+
+        if max_levels is not None and level >= max_levels:
+            return set()
+
+        visited.add(start_key)
+        upstream: set[str] = set()
+
+        deps = backward_edges.get(start_key, [])
+        for dep in deps:
+            if dep not in visited:
+                upstream.add(dep)
+                # Recurse
+                upstream.update(
+                    self._get_upstream_features(
+                        dep, backward_edges, max_levels, visited, level + 1
+                    )
+                )
+
+        return upstream
+
+    def _get_downstream_features(
+        self,
+        start_key: str,
+        forward_edges: dict[str, list[str]],
+        max_levels: int | None = None,
+        visited: set[str] | None = None,
+        level: int = 0,
+    ) -> set[str]:
+        """Get downstream features (dependents) recursively."""
+        if visited is None:
+            visited = set()
+
+        if start_key in visited:
+            return set()
+
+        if max_levels is not None and level >= max_levels:
+            return set()
+
+        visited.add(start_key)
+        downstream: set[str] = set()
+
+        dependents = forward_edges.get(start_key, [])
+        for dependent in dependents:
+            if dependent not in visited:
+                downstream.add(dependent)
+                # Recurse
+                downstream.update(
+                    self._get_downstream_features(
+                        dependent, forward_edges, max_levels, visited, level + 1
+                    )
+                )
+
+        return downstream
+
+    def load_snapshot_data(
+        self, store: MetadataStore, snapshot_version: str
+    ) -> dict[str, dict[str, Any]]:
+        """Load snapshot data from store.
+
+        Args:
+            store: Metadata store to query
+            snapshot_version: Snapshot version to load
+
+        Returns:
+            Dict mapping feature_key (string) -> {feature_version, fields}
+            where fields is dict mapping field_key (string) -> field_version (hash)
+
+        Raises:
+            ValueError: If snapshot not found in store
+        """
+        # Query feature_versions table for this snapshot
+        try:
+            features_lazy = store._read_metadata_native(FEATURE_VERSIONS_KEY)
+            if features_lazy is None:
+                raise ValueError(
+                    f"No feature_versions table found in store. Cannot load snapshot {snapshot_version}."
+                )
+
+            # Filter by snapshot_version
+            import narwhals as nw
+
+            features_df = (
+                features_lazy.filter(nw.col("snapshot_version") == snapshot_version)
+                .collect()
+                .to_polars()
+            )
+
+            if features_df.height == 0:
+                raise ValueError(
+                    f"Snapshot {snapshot_version} not found in store. "
+                    "Run 'metaxy graph push' to record snapshots or check the version hash."
+                )
+
+        except Exception as e:
+            raise ValueError(f"Failed to load snapshot {snapshot_version}: {e}") from e
+
+        # Build snapshot data structure for FeatureGraph.from_snapshot()
+        snapshot_dict = {}
+        for row in features_df.iter_rows(named=True):
+            feature_key_str = row["feature_key"]
+            feature_version = row["feature_version"]
+            feature_spec_json = row["feature_spec"]
+            feature_class_path = row.get("feature_class_path", "")
+
+            feature_spec_dict = json.loads(feature_spec_json)
+
+            snapshot_dict[feature_key_str] = {
+                "feature_version": feature_version,
+                "feature_spec": feature_spec_dict,
+                "feature_class_path": feature_class_path,
+            }
+
+        # Reconstruct FeatureGraph from snapshot to compute field versions
+        try:
+            graph = FeatureGraph.from_snapshot(snapshot_dict)
+        except Exception as e:
+            # If we can't reconstruct the graph (e.g., feature classes moved),
+            # fall back to using feature_version as field version (best effort)
+            import warnings
+
+            warnings.warn(
+                f"Could not reconstruct graph from snapshot {snapshot_version}: {e}. "
+                "Using feature_version as field_version (field-level diffs may be inaccurate)."
+            )
+            # Fall back to old behavior
+            snapshot_data = {}
+            for feature_key_str, data in snapshot_dict.items():
+                feature_spec_dict = data["feature_spec"]
+                fields_data = {}
+                for field_dict in feature_spec_dict.get("fields", []):
+                    field_key_list = field_dict.get("key")
+                    if isinstance(field_key_list, list):
+                        field_key_str_normalized = "/".join(field_key_list)
+                    else:
+                        field_key_str_normalized = field_key_list
+                    fields_data[field_key_str_normalized] = data["feature_version"]
+
+                snapshot_data[feature_key_str] = {
+                    "feature_version": data["feature_version"],
+                    "fields": fields_data,
+                    "feature_spec": feature_spec_dict,
+                }
+            return snapshot_data
+
+        # Now compute proper field versions using the reconstructed graph
+        from metaxy.models.plan import FQFieldKey
+
+        snapshot_data = {}
+        for feature_key_str in snapshot_dict.keys():
+            feature_version = snapshot_dict[feature_key_str]["feature_version"]
+            feature_spec = snapshot_dict[feature_key_str]["feature_spec"]
+            feature_key_obj = FeatureKey(feature_key_str.split("/"))
+
+            # Compute field versions using graph
+            fields_data = {}
+            for field_dict in feature_spec.get("fields", []):
+                field_key_list = field_dict.get("key")
+                if isinstance(field_key_list, list):
+                    field_key = FieldKey(field_key_list)
+                    field_key_str_normalized = "/".join(field_key_list)
+                else:
+                    field_key = FieldKey([field_key_list])
+                    field_key_str_normalized = field_key_list
+
+                # Compute field version using the graph
+                fq_key = FQFieldKey(feature=feature_key_obj, field=field_key)
+                field_version = graph.get_field_version(fq_key)
+                fields_data[field_key_str_normalized] = field_version
+
+            snapshot_data[feature_key_str] = {
+                "feature_version": feature_version,
+                "fields": fields_data,
+                "feature_spec": feature_spec,
+            }
+
+        return snapshot_data

--- a/tests/test_field_version_computation.py
+++ b/tests/test_field_version_computation.py
@@ -1,0 +1,151 @@
+"""Test field version computation in load_snapshot_data()."""
+
+import pytest
+
+from metaxy.graph_diff import GraphDiffer
+from metaxy.metadata_store.memory import InMemoryMetadataStore
+from metaxy.models.feature import Feature, FeatureGraph
+from metaxy.models.feature_spec import FeatureSpec
+from metaxy.models.field import FieldSpec
+from metaxy.models.plan import FQFieldKey
+from metaxy.models.types import FeatureKey, FieldKey
+
+
+def test_load_snapshot_data_computes_proper_field_versions():
+    """Test that field versions can be computed separately (when graph reconstruction works).
+
+    Note: This test validates the field version computation logic, even though
+    features defined in test functions fall back to using feature_version since
+    they can't be imported. The important validation is that:
+    1. Fields are tracked separately in the snapshot data
+    2. The fallback mechanism works when graph reconstruction fails
+    """
+    differ = GraphDiffer()
+    graph = FeatureGraph()
+
+    with graph.use():
+        # Create parent feature with two fields with different code versions
+        class ParentFeature(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["parent"]),
+                deps=None,
+                fields=[
+                    FieldSpec(key=FieldKey(["field1"]), code_version=1),
+                    FieldSpec(key=FieldKey(["field2"]), code_version=2),
+                ],
+            ),
+        ):
+            pass
+
+        # Compute expected field versions from the active graph
+        # (these would be different if we could reconstruct the graph)
+        parent_field1_version = graph.get_field_version(
+            FQFieldKey(feature=FeatureKey(["parent"]), field=FieldKey(["field1"]))
+        )
+        parent_field2_version = graph.get_field_version(
+            FQFieldKey(feature=FeatureKey(["parent"]), field=FieldKey(["field2"]))
+        )
+
+        # Field versions should be different from each other (different code versions)
+        assert parent_field1_version != parent_field2_version
+
+        with InMemoryMetadataStore() as store:
+            # Record snapshot
+            snapshot_version, _ = store.record_feature_graph_snapshot()
+
+            # Load snapshot data - will use fallback since test features can't be imported
+            with pytest.warns(
+                UserWarning,
+                match="Using feature_version as field_version",
+            ):
+                snapshot_data = differ.load_snapshot_data(store, snapshot_version)
+
+            # Verify structure is correct
+            assert "parent" in snapshot_data
+            parent_data = snapshot_data["parent"]
+            assert "feature_version" in parent_data
+            assert "fields" in parent_data
+            assert "field1" in parent_data["fields"]
+            assert "field2" in parent_data["fields"]
+
+            # In fallback mode, fields use feature_version
+            # (This is acceptable behavior when features can't be imported)
+            assert parent_data["fields"]["field1"] == parent_data["feature_version"]
+            assert parent_data["fields"]["field2"] == parent_data["feature_version"]
+
+
+def test_load_snapshot_data_fallback_when_graph_reconstruction_fails():
+    """Test fallback behavior when feature classes cannot be imported."""
+    differ = GraphDiffer()
+    graph = FeatureGraph()
+
+    with graph.use():
+        # Create a feature defined in test scope (will not be importable)
+        class TestFeature(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["test", "feature"]),
+                deps=None,
+                fields=[
+                    FieldSpec(key=FieldKey(["field1"]), code_version=1),
+                    FieldSpec(key=FieldKey(["field2"]), code_version=2),
+                ],
+            ),
+        ):
+            pass
+
+        with InMemoryMetadataStore() as store:
+            # Record snapshot
+            snapshot_version, _ = store.record_feature_graph_snapshot()
+
+            # Load snapshot data - should trigger fallback
+            with pytest.warns(
+                UserWarning,
+                match="Using feature_version as field_version",
+            ):
+                snapshot_data = differ.load_snapshot_data(store, snapshot_version)
+
+            # Verify data was loaded (even with fallback)
+            assert "test/feature" in snapshot_data
+            feature_data = snapshot_data["test/feature"]
+            assert "feature_version" in feature_data
+            assert "fields" in feature_data
+
+            # In fallback mode, all fields get the same version (feature_version)
+            assert feature_data["fields"]["field1"] == feature_data["feature_version"]
+            assert feature_data["fields"]["field2"] == feature_data["feature_version"]
+
+
+def test_field_key_normalization():
+    """Test that field keys are normalized to "/" separator format."""
+    differ = GraphDiffer()
+    graph = FeatureGraph()
+
+    with graph.use():
+
+        class TestFeature(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["test"]),
+                deps=None,
+                fields=[
+                    FieldSpec(key=FieldKey(["nested", "field"]), code_version=1),
+                ],
+            ),
+        ):
+            pass
+
+        with InMemoryMetadataStore() as store:
+            # Record snapshot
+            snapshot_version, _ = store.record_feature_graph_snapshot()
+
+            # Load snapshot data (will use fallback since feature is in test scope)
+            with pytest.warns(UserWarning):
+                snapshot_data = differ.load_snapshot_data(store, snapshot_version)
+
+            # Field key should be normalized to "/" format, not "__"
+            assert "test" in snapshot_data
+            feature_data = snapshot_data["test"]
+            assert "nested/field" in feature_data["fields"]
+            assert "nested__field" not in feature_data["fields"]

--- a/tests/test_graph_diff.py
+++ b/tests/test_graph_diff.py
@@ -1,0 +1,1692 @@
+"""Tests for graph diff functionality."""
+
+from typing import Any
+
+import pytest
+
+from metaxy.graph_diff import (
+    FeatureChange,
+    FieldChange,
+    GraphDiff,
+    GraphDiffer,
+    SnapshotResolver,
+)
+from metaxy.metadata_store.memory import InMemoryMetadataStore
+from metaxy.models.feature import Feature, FeatureGraph
+from metaxy.models.feature_spec import FeatureSpec
+from metaxy.models.field import FieldSpec
+from metaxy.models.types import FeatureKey, FieldKey
+
+
+class TestFieldChange:
+    """Test FieldChange model."""
+
+    def test_field_added(self):
+        """Test field addition detection."""
+        change = FieldChange(
+            field_key=FieldKey(["test"]), old_version=None, new_version="abc123"
+        )
+        assert change.is_added
+        assert not change.is_removed
+        assert not change.is_changed
+
+    def test_field_removed(self):
+        """Test field removal detection."""
+        change = FieldChange(
+            field_key=FieldKey(["test"]), old_version="abc123", new_version=None
+        )
+        assert change.is_removed
+        assert not change.is_added
+        assert not change.is_changed
+
+    def test_field_changed(self):
+        """Test field version change detection."""
+        change = FieldChange(
+            field_key=FieldKey(["test"]), old_version="abc123", new_version="def456"
+        )
+        assert change.is_changed
+        assert not change.is_added
+        assert not change.is_removed
+
+
+class TestFeatureChange:
+    """Test FeatureChange model."""
+
+    def test_feature_added(self):
+        """Test feature addition detection."""
+        change = FeatureChange(
+            feature_key=FeatureKey(["test"]), old_version=None, new_version="abc123"
+        )
+        assert change.is_added
+        assert not change.is_removed
+
+    def test_feature_removed(self):
+        """Test feature removal detection."""
+        change = FeatureChange(
+            feature_key=FeatureKey(["test"]), old_version="abc123", new_version=None
+        )
+        assert change.is_removed
+        assert not change.is_added
+
+    def test_feature_with_field_changes(self):
+        """Test feature with field changes."""
+        field_change = FieldChange(
+            field_key=FieldKey(["field1"]), old_version="v1", new_version="v2"
+        )
+        change = FeatureChange(
+            feature_key=FeatureKey(["test"]),
+            old_version="abc123",
+            new_version="def456",
+            field_changes=[field_change],
+        )
+        assert change.has_field_changes
+        assert len(change.field_changes) == 1
+
+
+class TestGraphDiff:
+    """Test GraphDiff model."""
+
+    def test_empty_diff(self):
+        """Test diff with no changes."""
+        diff = GraphDiff(snapshot1="s1", snapshot2="s2")
+        assert not diff.has_changes
+
+    def test_diff_with_changes(self):
+        """Test diff with various changes."""
+        diff = GraphDiff(
+            snapshot1="s1",
+            snapshot2="s2",
+            added_features=[FeatureKey(["new"])],
+            removed_features=[FeatureKey(["old"])],
+            changed_features=[
+                FeatureChange(
+                    feature_key=FeatureKey(["changed"]),
+                    old_version="v1",
+                    new_version="v2",
+                )
+            ],
+        )
+        assert diff.has_changes
+        assert len(diff.added_features) == 1
+        assert len(diff.removed_features) == 1
+        assert len(diff.changed_features) == 1
+
+
+class TestSnapshotResolver:
+    """Test SnapshotResolver."""
+
+    def test_resolve_explicit_version(self):
+        """Test resolving explicit snapshot version."""
+        resolver = SnapshotResolver()
+        result = resolver.resolve_snapshot("abc123def456", None, None)
+        assert result == "abc123def456"
+
+    def test_resolve_current_with_empty_graph(self):
+        """Test resolving 'current' with empty graph fails."""
+        resolver = SnapshotResolver()
+        graph = FeatureGraph()
+        with pytest.raises(ValueError, match="active graph is empty"):
+            resolver.resolve_snapshot("current", None, graph)
+
+    def test_resolve_current_with_graph(self):
+        """Test resolving 'current' with active graph."""
+        resolver = SnapshotResolver()
+        graph = FeatureGraph()
+
+        with graph.use():
+
+            class TestFeature(
+                Feature,
+                spec=FeatureSpec(
+                    key=FeatureKey(["test"]),
+                    deps=None,
+                    fields=[FieldSpec(key=FieldKey(["default"]), code_version=1)],
+                ),
+            ):
+                pass
+
+            result = resolver.resolve_snapshot("current", None, graph)
+            assert result == graph.snapshot_version
+            assert result != "empty"
+
+    def test_resolve_latest_empty_store(self):
+        """Test resolving 'latest' with empty store fails."""
+        resolver = SnapshotResolver()
+        with InMemoryMetadataStore() as store:
+            with pytest.raises(ValueError, match="No snapshots found"):
+                resolver.resolve_snapshot("latest", store, None)
+
+    def test_resolve_latest_with_snapshot(self):
+        """Test resolving 'latest' from store."""
+        resolver = SnapshotResolver()
+        graph = FeatureGraph()
+
+        with graph.use():
+
+            class TestFeature(
+                Feature,
+                spec=FeatureSpec(
+                    key=FeatureKey(["test"]),
+                    deps=None,
+                    fields=[FieldSpec(key=FieldKey(["default"]), code_version=1)],
+                ),
+            ):
+                pass
+
+            with InMemoryMetadataStore() as store:
+                # Record a snapshot
+                snapshot_version, _ = store.record_feature_graph_snapshot()
+
+                # Resolve latest
+                result = resolver.resolve_snapshot("latest", store, graph)
+                assert result == snapshot_version
+
+
+class TestGraphDiffer:
+    """Test GraphDiffer."""
+
+    def test_diff_empty_snapshots(self):
+        """Test diff with empty snapshots."""
+        differ = GraphDiffer()
+        snapshot1: dict[str, dict[str, Any]] = {}
+        snapshot2: dict[str, dict[str, Any]] = {}
+
+        diff = differ.diff(snapshot1, snapshot2)
+        assert not diff.has_changes
+
+    def test_diff_added_features(self):
+        """Test diff detects added features."""
+        differ = GraphDiffer()
+        snapshot1 = {}
+        snapshot2 = {
+            "feature/new": {"feature_version": "v1", "fields": {"default": "fv1"}}
+        }
+
+        diff = differ.diff(snapshot1, snapshot2)
+        assert len(diff.added_features) == 1
+        assert diff.added_features[0].to_string() == "feature/new"
+
+    def test_diff_removed_features(self):
+        """Test diff detects removed features."""
+        differ = GraphDiffer()
+        snapshot1 = {
+            "feature/old": {"feature_version": "v1", "fields": {"default": "fv1"}}
+        }
+        snapshot2 = {}
+
+        diff = differ.diff(snapshot1, snapshot2)
+        assert len(diff.removed_features) == 1
+        assert diff.removed_features[0].to_string() == "feature/old"
+
+    def test_diff_changed_feature_version(self):
+        """Test diff detects feature version changes."""
+        differ = GraphDiffer()
+        snapshot1 = {
+            "feature/changed": {"feature_version": "v1", "fields": {"default": "fv1"}}
+        }
+        snapshot2 = {
+            "feature/changed": {"feature_version": "v2", "fields": {"default": "fv1"}}
+        }
+
+        diff = differ.diff(snapshot1, snapshot2)
+        assert len(diff.changed_features) == 1
+        assert diff.changed_features[0].feature_key.to_string() == "feature/changed"
+        assert diff.changed_features[0].old_version == "v1"
+        assert diff.changed_features[0].new_version == "v2"
+
+    def test_diff_added_field(self):
+        """Test diff detects added fields."""
+        differ = GraphDiffer()
+        snapshot1 = {
+            "feature/test": {"feature_version": "v1", "fields": {"field1": "fv1"}}
+        }
+        snapshot2 = {
+            "feature/test": {
+                "feature_version": "v2",
+                "fields": {"field1": "fv1", "field2": "fv2"},
+            }
+        }
+
+        diff = differ.diff(snapshot1, snapshot2)
+        assert len(diff.changed_features) == 1
+        feature_change = diff.changed_features[0]
+        assert feature_change.has_field_changes
+        assert len(feature_change.field_changes) == 1
+        field_change = feature_change.field_changes[0]
+        assert field_change.field_key.to_string() == "field2"
+        assert field_change.is_added
+
+    def test_diff_removed_field(self):
+        """Test diff detects removed fields."""
+        differ = GraphDiffer()
+        snapshot1 = {
+            "feature/test": {
+                "feature_version": "v1",
+                "fields": {"field1": "fv1", "field2": "fv2"},
+            }
+        }
+        snapshot2 = {
+            "feature/test": {"feature_version": "v2", "fields": {"field1": "fv1"}}
+        }
+
+        diff = differ.diff(snapshot1, snapshot2)
+        assert len(diff.changed_features) == 1
+        feature_change = diff.changed_features[0]
+        assert feature_change.has_field_changes
+        field_change = feature_change.field_changes[0]
+        assert field_change.field_key.to_string() == "field2"
+        assert field_change.is_removed
+
+    def test_diff_changed_field_version(self):
+        """Test diff detects field version changes."""
+        differ = GraphDiffer()
+        snapshot1 = {
+            "feature/test": {"feature_version": "v1", "fields": {"field1": "fv1"}}
+        }
+        snapshot2 = {
+            "feature/test": {"feature_version": "v2", "fields": {"field1": "fv2"}}
+        }
+
+        diff = differ.diff(snapshot1, snapshot2)
+        assert len(diff.changed_features) == 1
+        feature_change = diff.changed_features[0]
+        assert feature_change.has_field_changes
+        field_change = feature_change.field_changes[0]
+        assert field_change.field_key.to_string() == "field1"
+        assert field_change.is_changed
+        assert field_change.old_version == "fv1"
+        assert field_change.new_version == "fv2"
+
+    def test_diff_complex_scenario(self):
+        """Test diff with multiple types of changes."""
+        differ = GraphDiffer()
+        snapshot1 = {
+            "feature/unchanged": {
+                "feature_version": "v1",
+                "fields": {"f1": "fv1"},
+            },
+            "feature/changed": {"feature_version": "v1", "fields": {"f1": "fv1"}},
+            "feature/removed": {"feature_version": "v1", "fields": {"f1": "fv1"}},
+        }
+        snapshot2 = {
+            "feature/unchanged": {
+                "feature_version": "v1",
+                "fields": {"f1": "fv1"},
+            },
+            "feature/changed": {"feature_version": "v2", "fields": {"f1": "fv2"}},
+            "feature/added": {"feature_version": "v1", "fields": {"f1": "fv1"}},
+        }
+
+        diff = differ.diff(snapshot1, snapshot2)
+        assert len(diff.added_features) == 1
+        assert len(diff.removed_features) == 1
+        assert len(diff.changed_features) == 1
+        assert diff.added_features[0].to_string() == "feature/added"
+        assert diff.removed_features[0].to_string() == "feature/removed"
+        assert diff.changed_features[0].feature_key.to_string() == "feature/changed"
+
+    def test_load_snapshot_data_from_store(self):
+        """Test loading snapshot data from store."""
+        differ = GraphDiffer()
+        graph = FeatureGraph()
+
+        with graph.use():
+
+            class TestFeature(
+                Feature,
+                spec=FeatureSpec(
+                    key=FeatureKey(["test", "feature"]),
+                    deps=None,
+                    fields=[FieldSpec(key=FieldKey(["default"]), code_version=1)],
+                ),
+            ):
+                pass
+
+            with InMemoryMetadataStore() as store:
+                # Record snapshot
+                snapshot_version, _ = store.record_feature_graph_snapshot()
+
+                # Load snapshot data
+                snapshot_data = differ.load_snapshot_data(store, snapshot_version)
+
+                assert "test/feature" in snapshot_data
+                feature_data = snapshot_data["test/feature"]
+                assert "feature_version" in feature_data
+                assert "fields" in feature_data
+
+    def test_load_snapshot_data_invalid_version(self):
+        """Test loading non-existent snapshot fails."""
+        differ = GraphDiffer()
+
+        with InMemoryMetadataStore() as store:
+            with pytest.raises(ValueError, match="Failed to load snapshot"):
+                differ.load_snapshot_data(store, "nonexistent")
+
+
+class TestDiffFormatter:
+    """Test DiffFormatter output formats."""
+
+    def test_format_dispatcher_terminal(self):
+        """Test format dispatcher routes to terminal format."""
+        from metaxy.formatters.graph_diff import DiffFormatter
+
+        diff = GraphDiff(
+            snapshot1="s1",
+            snapshot2="s2",
+            added_features=[FeatureKey(["test", "feature"])],
+        )
+        formatter = DiffFormatter()
+
+        result = formatter.format(diff=diff, format="terminal", diff_only=True)
+        assert "Added (1)" in result
+        assert "test/feature" in result
+
+    def test_format_dispatcher_invalid(self):
+        """Test format dispatcher raises error for invalid format."""
+        from metaxy.formatters.graph_diff import DiffFormatter
+
+        diff = GraphDiff(snapshot1="s1", snapshot2="s2")
+        formatter = DiffFormatter()
+
+        with pytest.raises(ValueError, match="Unknown format: invalid"):
+            formatter.format(diff=diff, format="invalid", diff_only=True)
+
+    def test_format_json_empty_diff(self):
+        """Test JSON format for empty diff."""
+        import json
+
+        from metaxy.formatters.graph_diff import DiffFormatter
+
+        diff = GraphDiff(snapshot1="snap1", snapshot2="snap2")
+        formatter = DiffFormatter()
+
+        result = formatter.format_json_diff_only(diff)
+        data = json.loads(result)
+
+        assert data["snapshot1"] == "snap1"
+        assert data["snapshot2"] == "snap2"
+        assert data["added_features"] == []
+        assert data["removed_features"] == []
+        assert data["changed_features"] == []
+
+    def test_format_json_with_changes(self):
+        """Test JSON format with various changes."""
+        import json
+
+        from metaxy.formatters.graph_diff import DiffFormatter
+
+        diff = GraphDiff(
+            snapshot1="s1",
+            snapshot2="s2",
+            added_features=[FeatureKey(["new", "feature"])],
+            removed_features=[FeatureKey(["old", "feature"])],
+            changed_features=[
+                FeatureChange(
+                    feature_key=FeatureKey(["changed", "feature"]),
+                    old_version="v1",
+                    new_version="v2",
+                    field_changes=[
+                        FieldChange(
+                            field_key=FieldKey(["field1"]),
+                            old_version="fv1",
+                            new_version="fv2",
+                        )
+                    ],
+                )
+            ],
+        )
+        formatter = DiffFormatter()
+
+        result = formatter.format_json_diff_only(diff)
+        data = json.loads(result)
+
+        assert data["added_features"] == ["new/feature"]
+        assert data["removed_features"] == ["old/feature"]
+        assert len(data["changed_features"]) == 1
+        assert data["changed_features"][0]["feature_key"] == "changed/feature"
+        assert data["changed_features"][0]["old_version"] == "v1"
+        assert data["changed_features"][0]["new_version"] == "v2"
+        assert len(data["changed_features"][0]["field_changes"]) == 1
+        assert data["changed_features"][0]["field_changes"][0]["field_key"] == "field1"
+        assert data["changed_features"][0]["field_changes"][0]["is_changed"]
+
+    def test_format_yaml_empty_diff(self):
+        """Test YAML format for empty diff."""
+        import yaml
+
+        from metaxy.formatters.graph_diff import DiffFormatter
+
+        diff = GraphDiff(snapshot1="snap1", snapshot2="snap2")
+        formatter = DiffFormatter()
+
+        result = formatter.format_yaml_diff_only(diff)
+        data = yaml.safe_load(result)
+
+        assert data["snapshot1"] == "snap1"
+        assert data["snapshot2"] == "snap2"
+        assert data["added_features"] == []
+        assert data["removed_features"] == []
+        assert data["changed_features"] == []
+
+    def test_format_yaml_with_changes(self):
+        """Test YAML format with various changes."""
+        import yaml
+
+        from metaxy.formatters.graph_diff import DiffFormatter
+
+        diff = GraphDiff(
+            snapshot1="s1",
+            snapshot2="s2",
+            added_features=[FeatureKey(["new", "feature"])],
+            removed_features=[FeatureKey(["old", "feature"])],
+            changed_features=[
+                FeatureChange(
+                    feature_key=FeatureKey(["changed", "feature"]),
+                    old_version="v1",
+                    new_version="v2",
+                )
+            ],
+        )
+        formatter = DiffFormatter()
+
+        result = formatter.format_yaml_diff_only(diff)
+        data = yaml.safe_load(result)
+
+        assert data["added_features"] == ["new/feature"]
+        assert data["removed_features"] == ["old/feature"]
+        assert len(data["changed_features"]) == 1
+        assert data["changed_features"][0]["feature_key"] == "changed/feature"
+
+    def test_format_mermaid_empty_diff(self):
+        """Test Mermaid format for empty diff."""
+        from metaxy.formatters.graph_diff import DiffFormatter
+
+        diff = GraphDiff(snapshot1="s1", snapshot2="s2")
+        formatter = DiffFormatter()
+
+        result = formatter.format_mermaid_diff_only(diff)
+
+        assert "flowchart TB" in result
+        assert "Empty[No changes]" in result
+
+    def test_format_mermaid_with_added_features(self):
+        """Test Mermaid format with added features."""
+        from metaxy.formatters.graph_diff import DiffFormatter
+
+        diff = GraphDiff(
+            snapshot1="s1",
+            snapshot2="s2",
+            added_features=[FeatureKey(["new", "feature"])],
+        )
+        formatter = DiffFormatter()
+
+        result = formatter.format_mermaid_diff_only(diff)
+
+        assert "flowchart TB" in result
+        assert "new/feature" in result
+        assert "fill:#90EE90" in result  # Green fill for added
+
+    def test_format_mermaid_with_removed_features(self):
+        """Test Mermaid format with removed features."""
+        from metaxy.formatters.graph_diff import DiffFormatter
+
+        diff = GraphDiff(
+            snapshot1="s1",
+            snapshot2="s2",
+            removed_features=[FeatureKey(["old", "feature"])],
+        )
+        formatter = DiffFormatter()
+
+        result = formatter.format_mermaid_diff_only(diff)
+
+        assert "old/feature" in result
+        assert "fill:#FFB6C1" in result  # Pink fill for removed
+
+    def test_format_mermaid_with_changed_features(self):
+        """Test Mermaid format with changed features."""
+        from metaxy.formatters.graph_diff import DiffFormatter
+
+        diff = GraphDiff(
+            snapshot1="s1",
+            snapshot2="s2",
+            changed_features=[
+                FeatureChange(
+                    feature_key=FeatureKey(["changed", "feature"]),
+                    old_version="v1",
+                    new_version="v2",
+                )
+            ],
+        )
+        formatter = DiffFormatter()
+
+        result = formatter.format_mermaid_diff_only(diff)
+
+        assert "changed/feature" in result
+        assert "fill:#FFE4B5" in result  # Tan fill for changed
+
+    def test_format_mermaid_verbose_with_field_changes(self):
+        """Test Mermaid verbose format shows field changes."""
+        from metaxy.formatters.graph_diff import DiffFormatter
+
+        diff = GraphDiff(
+            snapshot1="s1",
+            snapshot2="s2",
+            changed_features=[
+                FeatureChange(
+                    feature_key=FeatureKey(["test", "feature"]),
+                    old_version="v1",
+                    new_version="v2",
+                    field_changes=[
+                        FieldChange(
+                            field_key=FieldKey(["field1"]),
+                            old_version=None,
+                            new_version="fv1",
+                        ),
+                        FieldChange(
+                            field_key=FieldKey(["field2"]),
+                            old_version="fv2",
+                            new_version=None,
+                        ),
+                    ],
+                )
+            ],
+        )
+        formatter = DiffFormatter()
+
+        result = formatter.format_mermaid_diff_only(diff, verbose=True)
+
+        assert "test/feature" in result
+        assert "+ field1" in result  # Added field
+        assert "- field2" in result  # Removed field
+
+    def test_format_mermaid_sanitizes_node_ids(self):
+        """Test Mermaid format sanitizes node IDs."""
+        from metaxy.formatters.graph_diff import DiffFormatter
+
+        diff = GraphDiff(
+            snapshot1="s1",
+            snapshot2="s2",
+            added_features=[FeatureKey(["feature-with", "dashes"])],
+        )
+        formatter = DiffFormatter()
+
+        result = formatter.format_mermaid_diff_only(diff)
+
+        # Node ID should have slashes and dashes replaced with underscores
+        assert "feature_with_dashes" in result
+
+
+class TestMergedGraphData:
+    """Test create_merged_graph_data method."""
+
+    def test_empty_snapshots(self):
+        """Test merging empty snapshots."""
+        differ = GraphDiffer()
+        snapshot1: dict[str, dict[str, Any]] = {}
+        snapshot2: dict[str, dict[str, Any]] = {}
+        diff = differ.diff(snapshot1, snapshot2)
+
+        merged = differ.create_merged_graph_data(snapshot1, snapshot2, diff)
+
+        assert merged["nodes"] == {}
+        assert merged["edges"] == []
+
+    def test_added_features(self):
+        """Test merged graph with added features."""
+        differ = GraphDiffer()
+        snapshot1 = {}
+        snapshot2 = {
+            "feature/new": {
+                "feature_version": "v1",
+                "fields": {"default": "fv1"},
+                "feature_spec": {"deps": None},
+            }
+        }
+
+        diff = differ.diff(snapshot1, snapshot2)
+        merged = differ.create_merged_graph_data(snapshot1, snapshot2, diff)
+
+        assert "feature/new" in merged["nodes"]
+        node = merged["nodes"]["feature/new"]
+        assert node["status"] == "added"
+        assert node["old_version"] is None
+        assert node["new_version"] == "v1"
+        assert node["dependencies"] == []
+
+    def test_removed_features(self):
+        """Test merged graph with removed features."""
+        differ = GraphDiffer()
+        snapshot1 = {
+            "feature/old": {
+                "feature_version": "v1",
+                "fields": {"default": "fv1"},
+                "feature_spec": {"deps": None},
+            }
+        }
+        snapshot2 = {}
+
+        diff = differ.diff(snapshot1, snapshot2)
+        merged = differ.create_merged_graph_data(snapshot1, snapshot2, diff)
+
+        assert "feature/old" in merged["nodes"]
+        node = merged["nodes"]["feature/old"]
+        assert node["status"] == "removed"
+        assert node["old_version"] == "v1"
+        assert node["new_version"] is None
+
+    def test_changed_features(self):
+        """Test merged graph with changed features."""
+        differ = GraphDiffer()
+        snapshot1 = {
+            "feature/changed": {
+                "feature_version": "v1",
+                "fields": {"default": "fv1"},
+                "feature_spec": {"deps": None},
+            }
+        }
+        snapshot2 = {
+            "feature/changed": {
+                "feature_version": "v2",
+                "fields": {"default": "fv2"},
+                "feature_spec": {"deps": None},
+            }
+        }
+
+        diff = differ.diff(snapshot1, snapshot2)
+        merged = differ.create_merged_graph_data(snapshot1, snapshot2, diff)
+
+        assert "feature/changed" in merged["nodes"]
+        node = merged["nodes"]["feature/changed"]
+        assert node["status"] == "changed"
+        assert node["old_version"] == "v1"
+        assert node["new_version"] == "v2"
+
+    def test_unchanged_features(self):
+        """Test merged graph with unchanged features."""
+        differ = GraphDiffer()
+        snapshot1 = {
+            "feature/unchanged": {
+                "feature_version": "v1",
+                "fields": {"default": "fv1"},
+                "feature_spec": {"deps": None},
+            }
+        }
+        snapshot2 = {
+            "feature/unchanged": {
+                "feature_version": "v1",
+                "fields": {"default": "fv1"},
+                "feature_spec": {"deps": None},
+            }
+        }
+
+        diff = differ.diff(snapshot1, snapshot2)
+        merged = differ.create_merged_graph_data(snapshot1, snapshot2, diff)
+
+        assert "feature/unchanged" in merged["nodes"]
+        node = merged["nodes"]["feature/unchanged"]
+        assert node["status"] == "unchanged"
+        assert node["old_version"] == "v1"
+        assert node["new_version"] == "v1"
+
+    def test_dependencies_extraction(self):
+        """Test that dependencies are extracted correctly."""
+        differ = GraphDiffer()
+        snapshot1 = {}
+        snapshot2 = {
+            "feature/parent": {
+                "feature_version": "v1",
+                "fields": {},
+                "feature_spec": {"deps": None},
+            },
+            "feature/child": {
+                "feature_version": "v1",
+                "fields": {},
+                "feature_spec": {"deps": [{"key": ["feature", "parent"]}]},
+            },
+        }
+
+        diff = differ.diff(snapshot1, snapshot2)
+        merged = differ.create_merged_graph_data(snapshot1, snapshot2, diff)
+
+        child_node = merged["nodes"]["feature/child"]
+        assert child_node["dependencies"] == ["feature/parent"]
+
+        # Check edges (arrow points from dependency to dependent feature)
+        assert {"from": "feature/parent", "to": "feature/child"} in merged["edges"]
+
+    def test_mixed_changes(self):
+        """Test merged graph with all types of changes."""
+        differ = GraphDiffer()
+        snapshot1 = {
+            "feature/unchanged": {
+                "feature_version": "v1",
+                "fields": {},
+                "feature_spec": {"deps": None},
+            },
+            "feature/changed": {
+                "feature_version": "v1",
+                "fields": {},
+                "feature_spec": {"deps": None},
+            },
+            "feature/removed": {
+                "feature_version": "v1",
+                "fields": {},
+                "feature_spec": {"deps": None},
+            },
+        }
+        snapshot2 = {
+            "feature/unchanged": {
+                "feature_version": "v1",
+                "fields": {},
+                "feature_spec": {"deps": None},
+            },
+            "feature/changed": {
+                "feature_version": "v2",
+                "fields": {},
+                "feature_spec": {"deps": None},
+            },
+            "feature/added": {
+                "feature_version": "v1",
+                "fields": {},
+                "feature_spec": {"deps": None},
+            },
+        }
+
+        diff = differ.diff(snapshot1, snapshot2)
+        merged = differ.create_merged_graph_data(snapshot1, snapshot2, diff)
+
+        assert len(merged["nodes"]) == 4
+        assert merged["nodes"]["feature/unchanged"]["status"] == "unchanged"
+        assert merged["nodes"]["feature/changed"]["status"] == "changed"
+        assert merged["nodes"]["feature/removed"]["status"] == "removed"
+        assert merged["nodes"]["feature/added"]["status"] == "added"
+
+
+class TestMergedFormatters:
+    """Test merged graph formatters."""
+
+    def test_format_terminal_merged_empty(self):
+        """Test terminal formatting of empty merged graph."""
+        from metaxy.formatters.graph_diff import DiffFormatter
+
+        merged_data = {"nodes": {}, "edges": []}
+        formatter = DiffFormatter()
+
+        result = formatter.format_terminal_merged(merged_data)
+        assert "Empty graph" in result
+
+    def test_format_terminal_merged_with_features(self):
+        """Test terminal formatting with features."""
+        from metaxy.formatters.graph_diff import DiffFormatter
+
+        merged_data = {
+            "nodes": {
+                "feature/test": {
+                    "status": "added",
+                    "old_version": None,
+                    "new_version": "v1",
+                    "fields": {},
+                    "field_changes": [],
+                    "dependencies": [],
+                }
+            },
+            "edges": [],
+        }
+        formatter = DiffFormatter()
+
+        result = formatter.format_terminal_merged(merged_data)
+        assert "feature/test" in result
+        assert "added" in result
+
+    def test_format_json_merged(self):
+        """Test JSON formatting of merged graph."""
+        import json
+
+        from metaxy.formatters.graph_diff import DiffFormatter
+
+        merged_data = {
+            "nodes": {
+                "feature/test": {
+                    "status": "added",
+                    "old_version": None,
+                    "new_version": "v1",
+                    "fields": {},
+                    "field_changes": [],
+                    "dependencies": [],
+                }
+            },
+            "edges": [],
+        }
+        formatter = DiffFormatter()
+
+        result = formatter.format_json_merged(merged_data)
+        data = json.loads(result)
+
+        assert "nodes" in data
+        assert "feature/test" in data["nodes"]
+        assert data["nodes"]["feature/test"]["status"] == "added"
+
+    def test_format_yaml_merged(self):
+        """Test YAML formatting of merged graph."""
+        import yaml
+
+        from metaxy.formatters.graph_diff import DiffFormatter
+
+        merged_data = {
+            "nodes": {
+                "feature/test": {
+                    "status": "changed",
+                    "old_version": "v1",
+                    "new_version": "v2",
+                    "fields": {},
+                    "field_changes": [],
+                    "dependencies": [],
+                }
+            },
+            "edges": [],
+        }
+        formatter = DiffFormatter()
+
+        result = formatter.format_yaml_merged(merged_data)
+        data = yaml.safe_load(result)
+
+        assert "nodes" in data
+        assert "feature/test" in data["nodes"]
+        assert data["nodes"]["feature/test"]["status"] == "changed"
+
+    def test_format_mermaid_merged_empty(self):
+        """Test Mermaid formatting of empty merged graph."""
+        from metaxy.formatters.graph_diff import DiffFormatter
+
+        merged_data = {"nodes": {}, "edges": []}
+        formatter = DiffFormatter()
+
+        result = formatter.format_mermaid_merged(merged_data)
+        assert "flowchart TB" in result
+        assert "Empty[No features]" in result
+
+    def test_format_mermaid_merged_with_features(self):
+        """Test Mermaid formatting with features."""
+        from metaxy.formatters.graph_diff import DiffFormatter
+
+        merged_data = {
+            "nodes": {
+                "feature/added": {
+                    "status": "added",
+                    "old_version": None,
+                    "new_version": "abc123",
+                    "fields": {},
+                    "field_changes": [],
+                    "dependencies": [],
+                },
+                "feature/removed": {
+                    "status": "removed",
+                    "old_version": "def456",
+                    "new_version": None,
+                    "fields": {},
+                    "field_changes": [],
+                    "dependencies": [],
+                },
+                "feature/changed": {
+                    "status": "changed",
+                    "old_version": "old123",
+                    "new_version": "new456",
+                    "fields": {},
+                    "field_changes": [],
+                    "dependencies": [],
+                },
+            },
+            "edges": [],
+        }
+        formatter = DiffFormatter()
+
+        result = formatter.format_mermaid_merged(merged_data)
+        assert "flowchart TB" in result
+        assert "feature/added" in result
+        assert "feature/removed" in result
+        assert "feature/changed" in result
+        assert "fill:#90EE90" in result  # Green for added
+        assert "fill:#FFB6C1" in result  # Red for removed
+        assert "stroke:#FFA500" in result  # Yellow border for changed
+
+    def test_format_mermaid_merged_with_edges(self):
+        """Test Mermaid formatting includes edges."""
+        from metaxy.formatters.graph_diff import DiffFormatter
+
+        merged_data = {
+            "nodes": {
+                "feature/parent": {
+                    "status": "unchanged",
+                    "old_version": "v1",
+                    "new_version": "v1",
+                    "fields": {},
+                    "field_changes": [],
+                    "dependencies": [],
+                },
+                "feature/child": {
+                    "status": "unchanged",
+                    "old_version": "v1",
+                    "new_version": "v1",
+                    "fields": {},
+                    "field_changes": [],
+                    "dependencies": ["feature/parent"],
+                },
+            },
+            "edges": [{"from": "feature/parent", "to": "feature/child"}],
+        }
+        formatter = DiffFormatter()
+
+        result = formatter.format_mermaid_merged(merged_data)
+        assert "feature_parent --> feature_child" in result
+
+
+class TestFieldColorHighlighting:
+    """Test field-level color highlighting in formatters."""
+
+    def test_terminal_merged_shows_all_fields_with_colors(self):
+        """Test that terminal format shows all fields with color indicators for changed features."""
+        from metaxy.formatters.graph_diff import DiffFormatter
+
+        merged_data = {
+            "nodes": {
+                "feature/test": {
+                    "status": "changed",
+                    "old_version": "v1",
+                    "new_version": "v2",
+                    "fields": {"field1": "fv1", "field2": "fv2", "field3": "fv3"},
+                    "field_changes": [
+                        FieldChange(
+                            field_key=FieldKey(["field1"]),
+                            old_version=None,
+                            new_version="fv1",
+                        ),  # Added
+                        FieldChange(
+                            field_key=FieldKey(["field2"]),
+                            old_version="fv2_old",
+                            new_version="fv2",
+                        ),  # Changed
+                        # field3 is unchanged
+                    ],
+                    "dependencies": [],
+                }
+            },
+            "edges": [],
+        }
+        formatter = DiffFormatter()
+
+        result = formatter.format_terminal_merged(merged_data)
+
+        # Should show added field with green +
+        assert "[green]+[/green] field1" in result
+        # Should show changed field with yellow ~
+        assert "[yellow]~[/yellow] field2" in result
+        # Should show unchanged field with no symbol (just spaces)
+        assert "      field3" in result
+
+    def test_mermaid_merged_shows_all_fields_with_colors(self):
+        """Test that mermaid format shows all fields with color HTML for changed features."""
+        from metaxy.formatters.graph_diff import DiffFormatter
+
+        merged_data = {
+            "nodes": {
+                "feature/test": {
+                    "status": "changed",
+                    "old_version": "abc123",
+                    "new_version": "def456",
+                    "fields": {"field1": "fv1", "field2": "fv2", "field3": "fv3"},
+                    "field_changes": [
+                        FieldChange(
+                            field_key=FieldKey(["field1"]),
+                            old_version=None,
+                            new_version="fv1",
+                        ),  # Added
+                        FieldChange(
+                            field_key=FieldKey(["field2"]),
+                            old_version="fv2_old",
+                            new_version="fv2",
+                        ),  # Changed
+                        # field3 is unchanged
+                    ],
+                    "dependencies": [],
+                }
+            },
+            "edges": [],
+        }
+        formatter = DiffFormatter()
+
+        result = formatter.format_mermaid_merged(merged_data)
+
+        # Should show added field with green color and version
+        assert '<font color="#00AA00">- field1' in result and "(fv1)" in result
+        # Should show changed field: yellow name, red old version, green new version
+        assert '- <font color="#FFAA00">field2</font>' in result
+        assert '<font color="#CC0000">fv2_ol</font>' in result  # old version in red
+        assert '<font color="#00AA00">fv2</font>' in result  # new version in green
+        # Should show unchanged field with dash prefix and version
+        assert "- field3" in result and "(fv3)" in result
+
+    def test_terminal_merged_shows_removed_fields_with_color(self):
+        """Test that terminal format shows removed fields with red color."""
+        from metaxy.formatters.graph_diff import DiffFormatter
+
+        merged_data = {
+            "nodes": {
+                "feature/test": {
+                    "status": "changed",
+                    "old_version": "abc123",
+                    "new_version": "def456",
+                    "fields": {"field1": "fv1"},
+                    "field_changes": [
+                        FieldChange(
+                            field_key=FieldKey(["field2"]),
+                            old_version="fv2",
+                            new_version=None,
+                        ),  # Removed
+                    ],
+                    "dependencies": [],
+                }
+            },
+            "edges": [],
+        }
+        formatter = DiffFormatter()
+
+        result = formatter.format_terminal_merged(merged_data)
+
+        # Should show removed field with red -
+        assert "[red]-[/red] field2" in result
+
+    def test_mermaid_merged_shows_removed_fields_with_color(self):
+        """Test that mermaid format shows removed fields with red color."""
+        from metaxy.formatters.graph_diff import DiffFormatter
+
+        merged_data = {
+            "nodes": {
+                "feature/test": {
+                    "status": "changed",
+                    "old_version": "abc123",
+                    "new_version": "def456",
+                    "fields": {"field1": "fv1"},
+                    "field_changes": [
+                        FieldChange(
+                            field_key=FieldKey(["field2"]),
+                            old_version="fv2",
+                            new_version=None,
+                        ),  # Removed
+                    ],
+                    "dependencies": [],
+                }
+            },
+            "edges": [],
+        }
+        formatter = DiffFormatter()
+
+        result = formatter.format_mermaid_merged(merged_data)
+
+        # Should show removed field with red color and version
+        assert '<font color="#CC0000">- field2' in result and "(fv2)" in result
+
+
+class TestDiffFormatterDispatcher:
+    """Test the format() dispatcher method."""
+
+    def test_format_diff_only_mode(self):
+        """Test dispatcher routes to diff_only methods."""
+        from metaxy.formatters.graph_diff import DiffFormatter
+
+        diff = GraphDiff(
+            snapshot1="s1",
+            snapshot2="s2",
+            added_features=[FeatureKey(["test"])],
+        )
+        formatter = DiffFormatter()
+
+        result = formatter.format(diff=diff, format="terminal", diff_only=True)
+        assert "Added (1)" in result
+
+    def test_format_merged_mode(self):
+        """Test dispatcher routes to merged methods."""
+        from metaxy.formatters.graph_diff import DiffFormatter
+
+        merged_data = {
+            "nodes": {
+                "feature/test": {
+                    "status": "added",
+                    "old_version": None,
+                    "new_version": "v1",
+                    "fields": {},
+                    "field_changes": [],
+                    "dependencies": [],
+                }
+            },
+            "edges": [],
+        }
+        formatter = DiffFormatter()
+
+        result = formatter.format(
+            merged_data=merged_data, format="terminal", diff_only=False
+        )
+        assert "feature/test" in result
+        assert "merged view" in result.lower()
+
+    def test_format_requires_diff_for_diff_only(self):
+        """Test that diff_only mode requires diff parameter."""
+        from metaxy.formatters.graph_diff import DiffFormatter
+
+        formatter = DiffFormatter()
+
+        with pytest.raises(ValueError, match="diff is required"):
+            formatter.format(diff_only=True)
+
+    def test_format_requires_merged_data_for_merged_mode(self):
+        """Test that merged mode requires merged_data parameter."""
+        from metaxy.formatters.graph_diff import DiffFormatter
+
+        formatter = DiffFormatter()
+
+        with pytest.raises(ValueError, match="merged_data is required"):
+            formatter.format(diff_only=False)
+
+
+class TestGraphSlicing:
+    """Test graph slicing/filtering functionality."""
+
+    def test_filter_with_no_focus_returns_all(self):
+        """Test that filtering without focus feature returns all features."""
+        differ = GraphDiffer()
+        merged_data = {
+            "nodes": {
+                "feature/a": {
+                    "status": "unchanged",
+                    "old_version": "v1",
+                    "new_version": "v1",
+                    "fields": {},
+                    "field_changes": [],
+                    "dependencies": [],
+                },
+                "feature/b": {
+                    "status": "unchanged",
+                    "old_version": "v1",
+                    "new_version": "v1",
+                    "fields": {},
+                    "field_changes": [],
+                    "dependencies": [],
+                },
+            },
+            "edges": [],
+        }
+
+        result = differ.filter_merged_graph(merged_data, focus_feature=None)
+        assert len(result["nodes"]) == 2
+        assert "feature/a" in result["nodes"]
+        assert "feature/b" in result["nodes"]
+
+    def test_filter_with_focus_only(self):
+        """Test filtering with focus feature and no up/down limits."""
+        differ = GraphDiffer()
+        merged_data = {
+            "nodes": {
+                "feature/root": {
+                    "status": "unchanged",
+                    "old_version": "v1",
+                    "new_version": "v1",
+                    "fields": {},
+                    "field_changes": [],
+                    "dependencies": [],
+                },
+                "feature/parent": {
+                    "status": "unchanged",
+                    "old_version": "v1",
+                    "new_version": "v1",
+                    "fields": {},
+                    "field_changes": [],
+                    "dependencies": ["feature/root"],
+                },
+                "feature/focus": {
+                    "status": "changed",
+                    "old_version": "v1",
+                    "new_version": "v2",
+                    "fields": {},
+                    "field_changes": [],
+                    "dependencies": ["feature/parent"],
+                },
+                "feature/child": {
+                    "status": "unchanged",
+                    "old_version": "v1",
+                    "new_version": "v1",
+                    "fields": {},
+                    "field_changes": [],
+                    "dependencies": ["feature/focus"],
+                },
+                "feature/unrelated": {
+                    "status": "unchanged",
+                    "old_version": "v1",
+                    "new_version": "v1",
+                    "fields": {},
+                    "field_changes": [],
+                    "dependencies": [],
+                },
+            },
+            "edges": [
+                {"from": "feature/root", "to": "feature/parent"},
+                {"from": "feature/parent", "to": "feature/focus"},
+                {"from": "feature/focus", "to": "feature/child"},
+            ],
+        }
+
+        # Default behavior: focus with no up/down specified -> include all upstream and downstream
+        result = differ.filter_merged_graph(merged_data, focus_feature="feature/focus")
+        assert len(result["nodes"]) == 4  # focus + root + parent + child
+        assert "feature/focus" in result["nodes"]
+        assert "feature/root" in result["nodes"]
+        assert "feature/parent" in result["nodes"]
+        assert "feature/child" in result["nodes"]
+        assert "feature/unrelated" not in result["nodes"]
+
+    def test_filter_with_focus_and_up_limit(self):
+        """Test filtering with focus feature and upstream limit."""
+        differ = GraphDiffer()
+        merged_data = {
+            "nodes": {
+                "feature/root": {
+                    "status": "unchanged",
+                    "old_version": "v1",
+                    "new_version": "v1",
+                    "fields": {},
+                    "field_changes": [],
+                    "dependencies": [],
+                },
+                "feature/parent": {
+                    "status": "unchanged",
+                    "old_version": "v1",
+                    "new_version": "v1",
+                    "fields": {},
+                    "field_changes": [],
+                    "dependencies": ["feature/root"],
+                },
+                "feature/focus": {
+                    "status": "changed",
+                    "old_version": "v1",
+                    "new_version": "v2",
+                    "fields": {},
+                    "field_changes": [],
+                    "dependencies": ["feature/parent"],
+                },
+            },
+            "edges": [
+                {"from": "feature/root", "to": "feature/parent"},
+                {"from": "feature/parent", "to": "feature/focus"},
+            ],
+        }
+
+        # up=1 means only direct dependencies
+        result = differ.filter_merged_graph(
+            merged_data, focus_feature="feature/focus", up=1, down=0
+        )
+        assert len(result["nodes"]) == 2  # focus + parent only
+        assert "feature/focus" in result["nodes"]
+        assert "feature/parent" in result["nodes"]
+        assert "feature/root" not in result["nodes"]
+
+    def test_filter_with_focus_and_down_limit(self):
+        """Test filtering with focus feature and downstream limit."""
+        differ = GraphDiffer()
+        merged_data = {
+            "nodes": {
+                "feature/focus": {
+                    "status": "changed",
+                    "old_version": "v1",
+                    "new_version": "v2",
+                    "fields": {},
+                    "field_changes": [],
+                    "dependencies": [],
+                },
+                "feature/child": {
+                    "status": "unchanged",
+                    "old_version": "v1",
+                    "new_version": "v1",
+                    "fields": {},
+                    "field_changes": [],
+                    "dependencies": ["feature/focus"],
+                },
+                "feature/grandchild": {
+                    "status": "unchanged",
+                    "old_version": "v1",
+                    "new_version": "v1",
+                    "fields": {},
+                    "field_changes": [],
+                    "dependencies": ["feature/child"],
+                },
+            },
+            "edges": [
+                {"from": "feature/focus", "to": "feature/child"},
+                {"from": "feature/child", "to": "feature/grandchild"},
+            ],
+        }
+
+        # down=1 means only direct dependents
+        result = differ.filter_merged_graph(
+            merged_data, focus_feature="feature/focus", up=0, down=1
+        )
+        assert len(result["nodes"]) == 2  # focus + child only
+        assert "feature/focus" in result["nodes"]
+        assert "feature/child" in result["nodes"]
+        assert "feature/grandchild" not in result["nodes"]
+
+    def test_filter_with_up_down_zero(self):
+        """Test filtering with up=0 and down=0 shows only focus feature."""
+        differ = GraphDiffer()
+        merged_data = {
+            "nodes": {
+                "feature/parent": {
+                    "status": "unchanged",
+                    "old_version": "v1",
+                    "new_version": "v1",
+                    "fields": {},
+                    "field_changes": [],
+                    "dependencies": [],
+                },
+                "feature/focus": {
+                    "status": "changed",
+                    "old_version": "v1",
+                    "new_version": "v2",
+                    "fields": {},
+                    "field_changes": [],
+                    "dependencies": ["feature/parent"],
+                },
+                "feature/child": {
+                    "status": "unchanged",
+                    "old_version": "v1",
+                    "new_version": "v1",
+                    "fields": {},
+                    "field_changes": [],
+                    "dependencies": ["feature/focus"],
+                },
+            },
+            "edges": [
+                {"from": "feature/parent", "to": "feature/focus"},
+                {"from": "feature/focus", "to": "feature/child"},
+            ],
+        }
+
+        result = differ.filter_merged_graph(
+            merged_data, focus_feature="feature/focus", up=0, down=0
+        )
+        assert len(result["nodes"]) == 1  # only focus feature
+        assert "feature/focus" in result["nodes"]
+        assert "feature/parent" not in result["nodes"]
+        assert "feature/child" not in result["nodes"]
+
+    def test_filter_with_invalid_feature_raises_error(self):
+        """Test that filtering with non-existent feature raises ValueError."""
+        differ = GraphDiffer()
+        merged_data = {
+            "nodes": {"feature/a": {"status": "unchanged"}},
+            "edges": [],
+        }
+
+        with pytest.raises(ValueError, match="not found in graph"):
+            differ.filter_merged_graph(merged_data, focus_feature="feature/nonexistent")
+
+    def test_filter_supports_both_key_formats(self):
+        """Test that filtering supports both / and __ in feature keys."""
+        differ = GraphDiffer()
+        merged_data = {
+            "nodes": {
+                "feature/test": {
+                    "status": "unchanged",
+                    "old_version": "v1",
+                    "new_version": "v1",
+                    "fields": {},
+                    "field_changes": [],
+                    "dependencies": [],
+                }
+            },
+            "edges": [],
+        }
+
+        # Test with / format
+        result1 = differ.filter_merged_graph(
+            merged_data, focus_feature="feature/test", up=0, down=0
+        )
+        assert "feature/test" in result1["nodes"]
+
+        # Test with __ format
+        result2 = differ.filter_merged_graph(
+            merged_data, focus_feature="feature__test", up=0, down=0
+        )
+        assert "feature/test" in result2["nodes"]
+
+    def test_filter_preserves_edges(self):
+        """Test that filtering preserves edges between included nodes."""
+        differ = GraphDiffer()
+        merged_data = {
+            "nodes": {
+                "feature/a": {
+                    "status": "unchanged",
+                    "old_version": "v1",
+                    "new_version": "v1",
+                    "fields": {},
+                    "field_changes": [],
+                    "dependencies": [],
+                },
+                "feature/b": {
+                    "status": "unchanged",
+                    "old_version": "v1",
+                    "new_version": "v1",
+                    "fields": {},
+                    "field_changes": [],
+                    "dependencies": ["feature/a"],
+                },
+                "feature/c": {
+                    "status": "unchanged",
+                    "old_version": "v1",
+                    "new_version": "v1",
+                    "fields": {},
+                    "field_changes": [],
+                    "dependencies": ["feature/a"],
+                },
+            },
+            "edges": [
+                {"from": "feature/a", "to": "feature/b"},
+                {"from": "feature/a", "to": "feature/c"},
+            ],
+        }
+
+        result = differ.filter_merged_graph(
+            merged_data, focus_feature="feature/b", up=1, down=0
+        )
+        # Should include feature/a and feature/b
+        assert len(result["nodes"]) == 2
+        # Should include edge from a to b, but not a to c
+        assert len(result["edges"]) == 1
+        assert {"from": "feature/a", "to": "feature/b"} in result["edges"]
+        assert {"from": "feature/a", "to": "feature/c"} not in result["edges"]
+
+
+class TestShowAllFieldsParameter:
+    """Test show_all_fields parameter in formatters."""
+
+    def test_format_terminal_shows_all_fields_by_default(self):
+        """Test that terminal format shows all fields by default."""
+        from metaxy.formatters.graph_diff import DiffFormatter
+
+        merged_data = {
+            "nodes": {
+                "feature/test": {
+                    "status": "changed",
+                    "old_version": "v1",
+                    "new_version": "v2",
+                    "fields": {
+                        "field1": "fv1",
+                        "field2": "fv2",
+                        "field3": "fv3",
+                    },
+                    "field_changes": [
+                        FieldChange(
+                            field_key=FieldKey(["field1"]),
+                            old_version="fv1_old",
+                            new_version="fv1",
+                        ),
+                    ],
+                    "dependencies": [],
+                }
+            },
+            "edges": [],
+        }
+        formatter = DiffFormatter()
+
+        result = formatter.format_terminal_merged(merged_data, show_all_fields=True)
+
+        # Should show changed field
+        assert "field1" in result
+        # Should also show unchanged fields
+        assert "field2" in result
+        assert "field3" in result
+
+    def test_format_terminal_shows_only_changed_fields_when_requested(self):
+        """Test that terminal format can show only changed fields."""
+        from metaxy.formatters.graph_diff import DiffFormatter
+
+        merged_data = {
+            "nodes": {
+                "feature/test": {
+                    "status": "changed",
+                    "old_version": "v1",
+                    "new_version": "v2",
+                    "fields": {
+                        "field1": "fv1",
+                        "field2": "fv2",
+                        "field3": "fv3",
+                    },
+                    "field_changes": [
+                        FieldChange(
+                            field_key=FieldKey(["field1"]),
+                            old_version="fv1_old",
+                            new_version="fv1",
+                        ),
+                    ],
+                    "dependencies": [],
+                }
+            },
+            "edges": [],
+        }
+        formatter = DiffFormatter()
+
+        result = formatter.format_terminal_merged(merged_data, show_all_fields=False)
+
+        # Should show changed field
+        assert "field1" in result
+        # Should NOT show unchanged fields
+        assert "field2" not in result
+        assert "field3" not in result
+
+    def test_format_mermaid_shows_all_fields_by_default(self):
+        """Test that mermaid format shows all fields by default."""
+        from metaxy.formatters.graph_diff import DiffFormatter
+
+        merged_data = {
+            "nodes": {
+                "feature/test": {
+                    "status": "changed",
+                    "old_version": "abc123",
+                    "new_version": "def456",
+                    "fields": {
+                        "field1": "fv1",
+                        "field2": "fv2",
+                        "field3": "fv3",
+                    },
+                    "field_changes": [
+                        FieldChange(
+                            field_key=FieldKey(["field1"]),
+                            old_version="fv1_old",
+                            new_version="fv1",
+                        ),
+                    ],
+                    "dependencies": [],
+                }
+            },
+            "edges": [],
+        }
+        formatter = DiffFormatter()
+
+        result = formatter.format_mermaid_merged(merged_data, show_all_fields=True)
+
+        # Should show changed field
+        assert "field1" in result
+        # Should also show unchanged fields
+        assert "field2" in result
+        assert "field3" in result
+
+    def test_format_mermaid_shows_only_changed_fields_when_requested(self):
+        """Test that mermaid format can show only changed fields."""
+        from metaxy.formatters.graph_diff import DiffFormatter
+
+        merged_data = {
+            "nodes": {
+                "feature/test": {
+                    "status": "changed",
+                    "old_version": "abc123",
+                    "new_version": "def456",
+                    "fields": {
+                        "field1": "fv1",
+                        "field2": "fv2",
+                        "field3": "fv3",
+                    },
+                    "field_changes": [
+                        FieldChange(
+                            field_key=FieldKey(["field1"]),
+                            old_version="fv1_old",
+                            new_version="fv1",
+                        ),
+                    ],
+                    "dependencies": [],
+                }
+            },
+            "edges": [],
+        }
+        formatter = DiffFormatter()
+
+        result = formatter.format_mermaid_merged(merged_data, show_all_fields=False)
+
+        # Should show changed field
+        assert "field1" in result
+        # Should NOT show unchanged fields
+        assert "field2" not in result
+        assert "field3" not in result
+
+    def test_format_dispatcher_passes_show_all_fields(self):
+        """Test that format() dispatcher passes show_all_fields to formatters."""
+        from metaxy.formatters.graph_diff import DiffFormatter
+
+        merged_data = {
+            "nodes": {
+                "feature/test": {
+                    "status": "changed",
+                    "old_version": "v1",
+                    "new_version": "v2",
+                    "fields": {"field1": "fv1", "field2": "fv2"},
+                    "field_changes": [
+                        FieldChange(
+                            field_key=FieldKey(["field1"]),
+                            old_version="fv1_old",
+                            new_version="fv1",
+                        ),
+                    ],
+                    "dependencies": [],
+                }
+            },
+            "edges": [],
+        }
+        formatter = DiffFormatter()
+
+        result = formatter.format(
+            merged_data=merged_data,
+            format="terminal",
+            diff_only=False,
+            show_all_fields=False,
+        )
+
+        # Should show changed field
+        assert "field1" in result
+        # Should NOT show unchanged field
+        assert "field2" not in result


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a graph diff engine and CLI command to compare feature graph snapshots and render changes. This makes it easy to see added, removed, and version-changed features and fields between snapshots.

- **New Features**
  - GraphDiffer/GraphDiff to compute snapshot differences at feature and field level.
  - CLI: metaxy graph diff <snapshot1> <snapshot2> with support for "latest", "current", or a hash; outputs terminal or JSON; flags for verbose and diff-only.
  - DiffFormatter for clear, colorized terminal output and structured JSON; includes merged view and focused diffs.
  - Shared utils for hash truncation, key formatting, and safe Mermaid IDs.

- **Refactors**
  - Renderers use shared formatting utils for consistent output.
  - README and examples: renamed sst → stt; removed Embeddings from overview examples.

<!-- End of auto-generated description by cubic. -->

