### PR TITLE
make nix shell slightly impure

### DIFF
--- a/.github/workflows/QA.yml
+++ b/.github/workflows/QA.yml
@@ -37,36 +37,36 @@ jobs:
       - name: Run Ruff
         run: uv run --no-sync --with ruff ruff format --check
 
-  # typecheck:
-  #   runs-on: depot-ubuntu-latest
-  #   env:
-  #     UV_PYTHON_PREFERENCE: only-system
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v4
-  #     - name: Install Nix
-  #       uses: cachix/install-nix-action@v27
-  #       with:
-  #         nix_path: nixpkgs=channel:nixpkgs-unstable
-  #     - name: Setup Magic Nix Cache
-  #       uses: DeterminateSystems/magic-nix-cache-action@v8
-  #     - uses: nicknovitski/nix-develop@v1
-  #     - name: Sync dependencies
-  #       run: uv python pin 3.10 && uv sync --all-extras --all-groups
-  #     - name: Replace bundled Node.js with Nix Node.js
-  #       run: |
-  #         # Find the bundled node binary and replace it with Nix's node
-  #         BUNDLED_NODE=$(find .venv/lib/python3.10/site-packages/nodejs_wheel/bin -name "node" -type f 2>/dev/null || true)
-  #         if [ -n "$BUNDLED_NODE" ]; then
-  #           rm -f "$BUNDLED_NODE"
-  #           ln -s "$(which node)" "$BUNDLED_NODE"
-  #           echo "Replaced bundled node with Nix node: $(which node)"
-  #         fi
-  #     - name: Run Basedpyright
-  #       run: uv run basedpyright --level error
-  #     - name: Cleanup nix environment
-  #       if: always()
-  #       run: bash .github/scripts/cleanup-nix-env.sh
+  typecheck:
+    runs-on: depot-ubuntu-latest
+    env:
+      UV_PYTHON_PREFERENCE: only-system
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install Nix
+        uses: cachix/install-nix-action@v27
+        with:
+          nix_path: nixpkgs=channel:nixpkgs-unstable
+      - name: Setup Magic Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@v8
+      - uses: nicknovitski/nix-develop@v1
+      - name: Sync dependencies
+        run: uv python pin 3.10 && uv sync --all-extras --all-groups
+      # - name: Replace bundled Node.js with Nix Node.js
+      #   run: |
+      #     # Find the bundled node binary and replace it with Nix's node
+      #     BUNDLED_NODE=$(find .venv/lib/python3.10/site-packages/nodejs_wheel/bin -name "node" -type f 2>/dev/null || true)
+      #     if [ -n "$BUNDLED_NODE" ]; then
+      #       rm -f "$BUNDLED_NODE"
+      #       ln -s "$(which node)" "$BUNDLED_NODE"
+      #       echo "Replaced bundled node with Nix node: $(which node)"
+      #     fi
+      - name: Run Basedpyright
+        run: uv run basedpyright --level error
+      # - name: Cleanup nix environment
+      #   if: always()
+      #   run: bash .github/scripts/cleanup-nix-env.sh
 
   test:
     permissions:
@@ -101,9 +101,9 @@ jobs:
         run: uv run pytest --verbose --cov=src/metaxy --cov-report=term-missing --cov-report=xml --durations=10
 
       # without this cleanup, tools not using Nix may fail if they e.g. try to use nix-provided git
-      - name: Cleanup nix environment
-        if: always()
-        run: bash .github/scripts/cleanup-nix-env.sh
+      # - name: Cleanup nix environment
+      #   if: always()
+      #   run: bash .github/scripts/cleanup-nix-env.sh
       - name: Coverage comment
         if: matrix.python-version == '3.10' && github.event_name == 'pull_request'
         uses: MishaKav/pytest-coverage-comment@main
@@ -136,16 +136,17 @@ jobs:
       - name: Build Docs
         id: docs
         run: uv run mkdocs build --strict
-      # without this cleanup, tools not using Nix may fail if they e.g. try to use nix-provided git
-      - name: Cleanup nix environment
-        if: always()
-        run: bash .github/scripts/cleanup-nix-env.sh
+      # # without this cleanup, tools not using Nix may fail if they e.g. try to use nix-provided git
+      # - name: Cleanup nix environment
+      #   if: always()
+      #   run: bash .github/scripts/cleanup-nix-env.sh
 
   check:
     if: always()
     runs-on: depot-ubuntu-latest
     needs:
       - test
+      - typecheck
       - lint
       - format
       - docs

--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ nix develop  # enters a shell with the lowest supported Python version
 nix develop '.#"python3.11"'  # enters a shell with Python 3.11
 ```
 
+Since we are often dealing with external binaries that expect to find their dependencies in normal locations like `/usr/lib`, we also append these locations to `LD_LIBRARY_PATH`. This makes the `devShell` slightly but life much better.
+
+### GitHub Actions
+
+Metaxy is continuously tested on GitHub Actions. You can find the workflow file in `.github/workflows/QA.yml`. This workflow installs system dependencies with Nix and Python packages with `uv`.  The steps use the Nix `devShell` which is **almost** pure.
+
 ## Examples
 
 See [examples](https://github.com/anam-org/metaxy/tree/main/examples).

--- a/flake.nix
+++ b/flake.nix
@@ -41,6 +41,11 @@
           clickhouse
           graphviz
           python
+
+          # this allows external tools (normal ones like git) to still find their expected libraries
+          # Caution: This is a hack and may not work on all systems
+          "/usr"
+          "/usr/local"
         ]);
       };
     in {


### PR DESCRIPTION
Since we are often dealing with external binaries that expect to find their dependencies in normal locations like `/usr/lib`, we also append these locations to `LD_LIBRARY_PATH`. This makes the `devShell` slightly but life much better.