### PR TITLE
Add claude-draft-solution command to justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -20,6 +20,19 @@ claude-resolve number prompt="":
     gt track gt-{{number}}
     claude --dangerously-skip-permissions "Resolve GitHub issue #{{number}} (do not create commits). {{prompt}}"
 
+
+# Create a GitHub issue with Claude and start working on it in an independent git worktree
+claude-draft-solution branch prompt:
+    #!/usr/bin/env bash
+    set -euxo pipefail
+    git worktree add ../worktrees/metaxy-{{branch}} origin/main
+    cd ../worktrees/metaxy-{{branch}}
+    direnv allow
+    eval "$(direnv export bash)"
+    git checkout -b {{branch}}
+    gt track {{branch}}
+    claude --dangerously-skip-permissions "{{prompt}}. create a new GitHub issue if this is a new problem -- do not ask for confirmation, I explicitly allow creating it, or search for existing one if the issue number was not mentioned. @agent-planner a plan together with @agent-python-dev. Wait for my confirmation before proceeding with the implementation. Do not create commits."
+
 docs-build:
     uv run --group docs mkdocs build --clean --strict
 


### PR DESCRIPTION
# Added `claude-draft-solution` command to streamline issue creation workflow

This PR adds a new command to the justfile that combines multiple steps into a single workflow:
1. Creates a new git worktree for the issue
2. Sets up the environment with direnv
3. Creates a new branch
4. Tracks the branch with gt
5. Invokes Claude to create a GitHub issue and develop a plan

The command allows developers to quickly start working on new features by automating the setup process and leveraging Claude to draft the initial issue and implementation plan.