### PR TITLE
[core] allow passing a new FieldsMapping object to FeatureDep

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -6854,14 +6854,6 @@
             {
                 "code": "reportUnnecessaryIsInstance",
                 "range": {
-                    "startColumn": 13,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnnecessaryIsInstance",
-                "range": {
                     "startColumn": 19,
                     "endColumn": 44,
                     "lineCount": 1
@@ -8358,6 +8350,14 @@
                 }
             },
             {
+                "code": "reportImportCycles",
+                "range": {
+                    "startColumn": 0,
+                    "endColumn": 0,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportImplicitStringConcatenation",
                 "range": {
                     "startColumn": 16,
@@ -8872,6 +8872,14 @@
                 }
             },
             {
+                "code": "reportImportCycles",
+                "range": {
+                    "startColumn": 0,
+                    "endColumn": 0,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportImplicitStringConcatenation",
                 "range": {
                     "startColumn": 20,
@@ -8990,14 +8998,6 @@
             {
                 "code": "reportUnnecessaryIsInstance",
                 "range": {
-                    "startColumn": 13,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnnecessaryIsInstance",
-                "range": {
                     "startColumn": 21,
                     "endColumn": 52,
                     "lineCount": 1
@@ -9008,14 +9008,6 @@
                 "range": {
                     "startColumn": 15,
                     "endColumn": 18,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnnecessaryIsInstance",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 45,
                     "lineCount": 1
                 }
             },
@@ -18468,6 +18460,378 @@
                 "range": {
                     "startColumn": 15,
                     "endColumn": 75,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./tests/models/test_field_mapping_improvements.py": [
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedParameter",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 43,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 43,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownVariableType",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 86,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownVariableType",
+                "range": {
+                    "startColumn": 34,
+                    "endColumn": 36,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownVariableType",
+                "range": {
+                    "startColumn": 38,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 71,
+                    "endColumn": 83,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownArgumentType",
+                "range": {
+                    "startColumn": 63,
+                    "endColumn": 82,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 27,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedParameter",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 46,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 46,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownVariableType",
+                "range": {
+                    "startColumn": 23,
+                    "endColumn": 30,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownVariableType",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 25,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownVariableType",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 18,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownVariableType",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownArgumentType",
+                "range": {
+                    "startColumn": 38,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 35,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownVariableType",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 27,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownArgumentType",
+                "range": {
+                    "startColumn": 41,
+                    "endColumn": 56,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 27,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedParameter",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 46,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 46,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedParameter",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 46,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownVariableType",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 21,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownArgumentType",
+                "range": {
+                    "startColumn": 63,
+                    "endColumn": 78,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./tests/models/test_field_mapping_serialization.py": [
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 19,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedParameter",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 38,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 38,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownVariableType",
+                "range": {
+                    "startColumn": 15,
+                    "endColumn": 22,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownArgumentType",
+                "range": {
+                    "startColumn": 48,
+                    "endColumn": 59,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownVariableType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 16,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownVariableType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownVariableType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 14,
                     "lineCount": 1
                 }
             }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,8 @@ Metaxy is a feature metadata management system for multimodal ML pipelines that 
 
 Never create git commits unless asked for explicitly by the user.
 
+You can check GitHub Actions for your PR to see if tests pass.
+
 ### Environment Setup
 
 ```bash

--- a/src/metaxy/__init__.py
+++ b/src/metaxy/__init__.py
@@ -41,7 +41,17 @@ from metaxy.models.feature_spec import (
     IDColumnsT,
     TestingFeatureSpec,
 )
-from metaxy.models.field import FieldDep, FieldSpec, SpecialFieldDep
+from metaxy.models.field import (
+    FieldDep,
+    FieldSpec,
+    SpecialFieldDep,
+)
+from metaxy.models.fields_mapping import (
+    AllFieldsMapping,
+    DefaultFieldsMapping,
+    FieldsMapping,
+    FieldsMappingType,
+)
 from metaxy.models.types import FeatureDepMetadata, FeatureKey, FieldKey
 
 
@@ -81,6 +91,10 @@ __all__ = [
     "FeatureDepMetadata",
     "BaseFeatureSpec",
     "BaseFeatureSpecWithIDColumns",
+    "AllFieldsMapping",
+    "DefaultFieldsMapping",
+    "FieldsMapping",
+    "FieldsMappingType",
     "FieldDep",
     "FieldSpec",
     "SpecialFieldDep",

--- a/src/metaxy/models/feature.py
+++ b/src/metaxy/models/feature.py
@@ -283,6 +283,7 @@ class FeatureGraph:
             feature=feature,
             deps=[self.feature_specs_by_key[dep.feature] for dep in feature.deps or []]
             or None,
+            feature_deps=feature.deps,  # Pass the actual FeatureDep objects with field mappings
         )
 
     def get_field_version(self, key: "FQFieldKey") -> str:

--- a/src/metaxy/models/fields_mapping.py
+++ b/src/metaxy/models/fields_mapping.py
@@ -1,0 +1,333 @@
+"""Field mapping system for automatic field dependency resolution.
+
+This module provides a flexible system for defining how fields map to upstream
+dependencies, supporting both automatic mapping patterns and explicit configurations.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from enum import Enum
+from typing import TYPE_CHECKING, Literal
+
+from pydantic import BaseModel, ConfigDict, TypeAdapter
+from pydantic import Field as PydanticField
+from typing_extensions import Self
+
+from metaxy.models.types import FeatureKey, FieldKey
+
+if TYPE_CHECKING:
+    from metaxy.models.feature_spec import BaseFeatureSpecWithIDColumns
+
+
+class FieldsMappingType(str, Enum):
+    """Type of fields mapping between a field key and the upstream field keys."""
+
+    DEFAULT = "default"
+    SPECIFIC = "specific"
+    ALL = "all"
+    NONE = "none"
+
+
+class FieldsMappingResolutionContext(BaseModel):
+    """Context for resolving field mappings.
+
+    This contains all the information needed to resolve field dependencies
+    including the upstream feature being mapped against.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    field_key: FieldKey
+    """The downstream field key being resolved."""
+
+    upstream_feature: BaseFeatureSpecWithIDColumns
+    """The upstream feature spec being resolved against."""
+
+    @property
+    def upstream_feature_key(self) -> FeatureKey:
+        """Get the upstream feature key."""
+        return self.upstream_feature.key
+
+    @property
+    def upstream_feature_fields(self) -> set[FieldKey]:
+        """Get the set of field keys from the upstream feature."""
+        return {field.key for field in self.upstream_feature.fields}
+
+
+class BaseFieldsMapping(BaseModel, ABC):  # pyright: ignore[reportUnsafeMultipleInheritance]
+    """Base class for field mapping configurations.
+
+    Field mappings define how a field automatically resolves its dependencies
+    based on upstream feature fields.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    @abstractmethod
+    def resolve_field_deps(
+        self,
+        context: FieldsMappingResolutionContext,
+    ) -> set[FieldKey]:
+        """Resolve automatic field mapping to explicit FieldDep list.
+
+        This method should be overridden by concrete implementations.
+
+        Args:
+            context: The resolution context containing field key and upstream feature.
+
+        Returns:
+            Set of [FieldKey][metaxy.models.types.FieldKey] instances for matching fields
+        """
+        raise NotImplementedError
+
+
+class SpecificFieldsMapping(BaseFieldsMapping):
+    """Field mapping that explicitly depends on specific upstream fields.
+
+    Arguments:
+        type: Always "SPECIFIC" for discriminated union serialization
+        mapping: Mapping of downstream field keys to their corresponding upstream field keys.
+
+    Examples:
+        >>> # Explicitly depend on specific upstream fields
+        >>> SpecificFieldsMapping({""downstream": {"upstream_1", "upstream_2"}})
+
+        >>> # Or use the classmethod
+        >>> FieldsMapping.specific({"field1", "field2"})
+    """
+
+    type: Literal[FieldsMappingType.SPECIFIC] = FieldsMappingType.SPECIFIC
+    mapping: dict[FieldKey, set[FieldKey]]
+
+    def resolve_field_deps(
+        self,
+        context: FieldsMappingResolutionContext,
+    ) -> set[FieldKey]:
+        desired_upstream_fields = self.mapping.get(context.field_key, set())
+        return desired_upstream_fields & context.upstream_feature_fields
+
+
+class AllFieldsMapping(BaseFieldsMapping):
+    """Field mapping that explicitly depends on all upstream features and all their fields.
+
+    Examples:
+        >>> # Explicitly depend on all upstream fields
+        >>> AllFieldsMapping()
+
+        >>> # Or use the classmethod
+        >>> FieldsMapping.all()
+    """
+
+    type: Literal[FieldsMappingType.ALL] = FieldsMappingType.ALL
+
+    def resolve_field_deps(
+        self,
+        context: FieldsMappingResolutionContext,
+    ) -> set[FieldKey]:
+        return context.upstream_feature_fields
+
+
+class NoneFieldsMapping(BaseFieldsMapping):
+    """Field mapping that never matches any upstream fields."""
+
+    type: Literal[FieldsMappingType.NONE] = FieldsMappingType.NONE
+
+    def resolve_field_deps(
+        self,
+        context: FieldsMappingResolutionContext,
+    ) -> set[FieldKey]:
+        return set()
+
+
+class DefaultFieldsMapping(BaseFieldsMapping):
+    """Default automatic field mapping configuration.
+
+    When used, automatically maps fields to matching upstream fields based on field keys.
+
+    Attributes:
+        type: Always "DEFAULT" for discriminated union serialization
+        match_suffix: If True, allows suffix matching (e.g., "french" matches "audio/french")
+        exclude_features: List of feature keys to exclude from auto-mapping
+        exclude_fields: List of field keys to exclude from auto-mapping
+
+    Examples:
+        >>> # Exact match only (default)
+        >>> DefaultFieldsMapping()
+
+        >>> # Enable suffix matching
+        >>> DefaultFieldsMapping(match_suffix=True)
+
+        >>> # Exclude specific upstream features
+        >>> DefaultFieldsMapping(exclude_features=[FeatureKey(["some", "feature"])])
+
+        >>> # Exclude specific fields from being auto-mapped
+        >>> DefaultFieldsMapping(exclude_fields=[FieldKey(["metadata"])])
+    """
+
+    type: Literal[FieldsMappingType.DEFAULT] = FieldsMappingType.DEFAULT
+    match_suffix: bool = False
+    exclude_features: list[FeatureKey] = PydanticField(default_factory=list)
+    exclude_fields: list[FieldKey] = PydanticField(default_factory=list)
+
+    def resolve_field_deps(
+        self,
+        context: FieldsMappingResolutionContext,
+    ) -> set[FieldKey]:
+        # Check if this feature is excluded
+        if context.upstream_feature_key in self.exclude_features:
+            return set()
+
+        res = set()
+
+        for upstream_field_key in context.upstream_feature_fields:
+            # Skip excluded fields
+            if upstream_field_key in self.exclude_fields:
+                continue
+
+            # Check for exact match
+            if upstream_field_key == context.field_key:
+                res.add(upstream_field_key)
+            # Check for suffix match if enabled
+            elif self.match_suffix and self._is_suffix_match(
+                context.field_key, upstream_field_key
+            ):
+                res.add(upstream_field_key)
+
+        # If no fields matched, return ALL fields from this upstream feature
+        # (excluding any explicitly excluded fields)
+        if not res:
+            for upstream_field_key in context.upstream_feature_fields:
+                if upstream_field_key not in self.exclude_fields:
+                    res.add(upstream_field_key)
+
+        return res
+
+    def _is_suffix_match(
+        self, field_key: FieldKey, upstream_field_key: FieldKey
+    ) -> bool:
+        """Check if field_key is a suffix of upstream_field_key.
+
+        For hierarchical keys like "audio/french", this checks if "french"
+        matches the suffix.
+
+        Args:
+            field_key: The field key for which to resolve dependencies.
+            upstream_fields_by_feature_key: Mapping of upstream feature keys to their fields.
+
+        Returns:
+            True if field_key is a suffix of upstream_field_key
+        """
+        # For single-part keys, check if it's the last part of a multi-part key
+        if len(field_key.parts) == 1 and len(upstream_field_key.parts) > 1:
+            return field_key.parts[0] == upstream_field_key.parts[-1]
+
+        # For multi-part keys, check if all parts match as suffix
+        if len(field_key.parts) <= len(upstream_field_key.parts):
+            return upstream_field_key.parts[-len(field_key.parts) :] == field_key.parts
+
+        return False
+
+
+class FieldsMapping(BaseModel):
+    """Base class for field mapping configurations.
+
+    Field mappings define how a field automatically resolves its dependencies
+    based on upstream feature fields. This is separate from explicit field
+    dependencies which are defined directly.
+    """
+
+    model_config = ConfigDict(frozen=True)
+    # mapping: BaseFieldsMapping
+    mapping: (
+        AllFieldsMapping
+        | SpecificFieldsMapping
+        | NoneFieldsMapping
+        | DefaultFieldsMapping
+    ) = PydanticField(..., discriminator="type")
+
+    def resolve_field_deps(
+        self,
+        context: FieldsMappingResolutionContext,
+    ) -> set[FieldKey]:
+        """Resolve field dependencies based on upstream feature fields.
+
+        Invokes the provided mapping to resolve dependencies.
+
+        Args:
+            context: The resolution context containing field key and upstream feature.
+
+        Returns:
+            Set of [FieldKey][metaxy.models.types.FieldKey] instances for matching fields
+        """
+        return self.mapping.resolve_field_deps(context)
+
+    @classmethod
+    def default(
+        cls,
+        *,
+        match_suffix: bool = False,
+        exclude_features: list[FeatureKey] | None = None,
+        exclude_fields: list[FieldKey] | None = None,
+    ) -> Self:
+        """Create a default field mapping configuration.
+
+        Args:
+            match_suffix: If True, allows suffix matching (e.g., "french" matches "audio/french")
+            exclude_features: List of feature keys to exclude from auto-mapping
+            exclude_fields: List of field keys to exclude from auto-mapping
+
+        Returns:
+            Configured FieldsMapping instance.
+        """
+        return cls(
+            mapping=DefaultFieldsMapping(
+                match_suffix=match_suffix,
+                exclude_features=exclude_features or [],
+                exclude_fields=exclude_fields or [],
+            )
+        )
+
+    @classmethod
+    def specific(cls, mapping: dict[FieldKey, set[FieldKey]]) -> Self:
+        """Create a field mapping that maps downstream field keys into specific upstream field keys.
+
+        Args:
+            mapping: Mapping of downstream field keys to sets of upstream field keys
+
+        Returns:
+            Configured FieldsMapping instance.
+        """
+        return cls(mapping=SpecificFieldsMapping(mapping=mapping))
+
+    @classmethod
+    def all(cls) -> Self:
+        """Create a field mapping that explicitly depends on all upstream fields.
+
+        Returns:
+            Configured FieldsMapping instance.
+
+        Examples:
+            >>> # Use in field specifications
+            >>> FieldSpec(
+            ...     key="combined",
+            ...     fields_mapping=FieldsMapping.all()
+            ... )
+        """
+        return cls(mapping=AllFieldsMapping())
+
+    @classmethod
+    def none(cls) -> Self:
+        """Create a field mapping that explicitly depends on no upstream fields.
+
+        This is typically useful when explicitly defining [FieldSpec.deps][metaxy.models.field.FieldSpec.deps] instead.
+
+        Returns:
+            Configured FieldsMapping instance.
+        """
+        return cls(mapping=NoneFieldsMapping())
+
+
+FieldsMappingAdapter = TypeAdapter(
+    AllFieldsMapping | SpecificFieldsMapping | NoneFieldsMapping | DefaultFieldsMapping
+)

--- a/tests/__snapshots__/test_feature_project_detection.ambr
+++ b/tests/__snapshots__/test_feature_project_detection.ambr
@@ -11,7 +11,7 @@
 # name: test_feature_project_persists_across_graph_operations
   dict({
     'project': 'persist_project',
-    'tracking_version': 'fa71a02f',
+    'tracking_version': 'd37e965a',
   })
 # ---
 # name: test_multiple_features_same_project

--- a/tests/__snapshots__/test_feature_tracking_version.ambr
+++ b/tests/__snapshots__/test_feature_tracking_version.ambr
@@ -1,10 +1,4 @@
 # serializer version: 1
-# name: test_provenance_by_field_unchanged_by_project
-  dict({
-    'field1': '9cb9f5bd9b380278e273033d16f07feabda7bdf5b813e9941b0f29e63b20efdb',
-    'field2': '0b485f68befbb7abb029b43a698161745c63259b8ad0bc00260b7da4b9830243',
-  })
-# ---
 # name: test_feature_tracking_version_includes_project
   dict({
     'feature_version_a': '3731d5aef6d53cfda612433171c52401406f94fd1c3482e7754ef2b24d85d170',
@@ -12,8 +6,8 @@
     'feature_versions_same': True,
     'project_a': 'project_a',
     'project_b': 'project_b',
-    'tracking_version_a': '8656b5e5187bca8fc46909f736ac8958e60ea90b86bc7a0a3cd360647420d0bb',
-    'tracking_version_b': '97a3c65bff35f71c84d07b087b280f9ee8e05063047179ffaa82fa2a3087533d',
+    'tracking_version_a': 'b39ec2794ba7a734d9c75b92623ff6eb4f44c225891a1826e3f006555ce43b2b',
+    'tracking_version_b': 'abca64dcf3063fda7712f43e371da79b0d4493a00360f0fc15e51de5da3f9497',
     'tracking_versions_differ': True,
   })
 # ---
@@ -42,6 +36,12 @@
     ]),
   })
 # ---
+# name: test_provenance_by_field_unchanged_by_project
+  dict({
+    'field1': '9cb9f5bd9b380278e273033d16f07feabda7bdf5b813e9941b0f29e63b20efdb',
+    'field2': '0b485f68befbb7abb029b43a698161745c63259b8ad0bc00260b7da4b9830243',
+  })
+# ---
 # name: test_tracking_version_deterministic
-  '8ef407e1e203fb40eb2101935b76138f794607fdabd81e5211b91508f5abb222'
+  '5b5f6eb2940ab3cceb11fb370a5582a8269387c3845b61c9dc6a8fe114cb97cf'
 # ---

--- a/tests/__snapshots__/test_id_columns.ambr
+++ b/tests/__snapshots__/test_id_columns.ambr
@@ -1,8 +1,8 @@
 # serializer version: 1
 # name: test_snapshot_stability_with_id_columns
   dict({
-    'composite': '8b141d16d5265d987e0396369f297e23999ecff82b318f33861e1d5ab15bb0bc',
-    'default': '7177cd540e383ab3459d4442a7c093be25c0fd0c5a72eee32a58345218accb9b',
-    'single_custom': '26007d9fa684afd7387b38b52ed198eaa52e97437e307c183d5e34c643ea64ce',
+    'composite': 'ad22abb84e68b72de23a59cb66874ac765112ee0827986913c545405d5b5f0d3',
+    'default': '70355417b488e802efc936cb92846de6e9d4547542ca5b43a7cdd28aa58d932f',
+    'single_custom': 'ac36afab9b97997131dd920d334a6076690e4d1990a345007280a74c07495ded',
   })
 # ---

--- a/tests/__snapshots__/test_spec_version.ambr
+++ b/tests/__snapshots__/test_spec_version.ambr
@@ -1,14 +1,14 @@
 # serializer version: 1
 # name: test_feature_spec_version_deterministic
-  '8f172f2cbfbdb47d3436805744df4fdc5c9d01d807fad215e1e20c4d1979f638'
+  '473c860ef72ef30b5c2d6aa6601a3342d816512536b03cd61808e0dd93b2db40'
 # ---
 # name: test_feature_spec_version_includes_all_properties
-  'd064fcf34eeae2421b1f5ea49a3c6129de81b2dfe6134f55f62193feb761d877'
+  '285db9ad24660f445c4f394e1ed4c1e90f9270ff81ecaaf715bbbe00e8ec97d7'
 # ---
 # name: test_feature_spec_version_recorded_in_metadata_store
   dict({
     'feature_key': 'recorded/feature',
-    'feature_spec_version': 'c2789d844c9d45db84de5e807dcda8e6a1e82db996315120c13649018e0c28bf',
+    'feature_spec_version': 'c19bf840ba81c8e03f3eb0516a042157623def5df12cf1c92f453d943f0ad9b7',
     'feature_version': '0c7b2d83252fbf2f689bec7d37c4f7ffb103755d11eafabc1e000a372f415d83',
     'snapshot_version': '14d4294da40f4ab27ca85eb739fffd70e92c92522dbcba995cfa2aa343988bf3',
   })
@@ -21,7 +21,8 @@
       'fields': list([
         dict({
           'code_version': '1',
-          'deps': '__METAXY_ALL_DEP__',
+          'deps': list([
+          ]),
           'key': list([
             'data',
           ]),
@@ -37,15 +38,15 @@
       'metadata': dict({
       }),
     }),
-    'feature_spec_version': '4e4360e5ed4599f1a073f442fed25260423dbad28ea351e3e58d7e27fa8676df',
-    'feature_tracking_version': 'f9122c9cb65202ea7d3b1e07b937e4b7461c6e97f8fa348df4cf778465a29174',
+    'feature_spec_version': 'ffac5337d8ef946b5ebc04f54629037e5c7fc1affa56b9de24be7861bb70aa4a',
+    'feature_tracking_version': 'e94e07a211ecbb8852ad5b50eeff420370af84fc24ec39c511b2ca32ac9c6bb7',
     'feature_version': '7cfde77960e3cf10327e9cb97f311418b101fc5ee2c146922a997306e318edaf',
     'project': 'test',
   })
 # ---
 # name: test_feature_spec_version_with_column_selection_and_rename
-  '69f1e1fd95746476d014639e56fdbe7518c03b8f0113996138f9a86e1352bfea'
+  'ec274b4e2098124803f88d79b26b381da28140987bec4dc70369915e01e69567'
 # ---
 # name: test_feature_spec_version_with_multiple_complex_deps
-  '1bbfdb3e9bd1acaca7f56d798ca7dcdb42dbf647ac5403139dc57f5216db4584'
+  'bc98ef44e7b4b35f290d7e9edde7e90b7a0d2042c24c6dca68c7cadf98c97073'
 # ---

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+import random
+
 import pytest
 
 from metaxy.config import MetaxyConfig
@@ -95,3 +97,21 @@ def metaxy_project(tmp_path):
     from metaxy._testing import TempMetaxyProject
 
     return TempMetaxyProject(tmp_path)
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--random-selection",
+        metavar="N",
+        action="store",
+        default=-1,
+        type=int,
+        help="Only run random selected subset of N tests.",
+    )
+
+
+def pytest_collection_modifyitems(session, config, items):
+    random_sample_size = config.getoption("--random-selection")
+
+    if random_sample_size >= 0:
+        items[:] = random.sample(items, k=random_sample_size)

--- a/tests/examples/__snapshots__/test_recompute.ambr
+++ b/tests/examples/__snapshots__/test_recompute.ambr
@@ -11,7 +11,10 @@
   examples/child (version
   440ffb028aaa5cb21b155c4ef21debd81f283f99aa91ef58cbe541d71164b44f)
     Feature Dependencies:
-      feature=examples/parent columns=None rename=None
+      feature=examples/parent columns=None rename=None 
+  fields_mapping=FieldsMapping(mapping=DefaultFieldsMapping(type=<FieldsMappingTyp
+  e.DEFAULT: 'default'>, match_suffix=False, exclude_features=[], 
+  exclude_fields=[]))
     Fields:
       predictions (code_version 1, version
   1905d9e85ceb58b0361e863c7fbfbf5843582f8ed135ea5ce6c24ee2c68c6bb4)
@@ -30,7 +33,10 @@
   examples/child (version
   7251e21c32d2d8e35a8ba389a8ce1b597663f206dee0ff55e542a3af1f1665cd)
     Feature Dependencies:
-      feature=examples/parent columns=None rename=None
+      feature=examples/parent columns=None rename=None 
+  fields_mapping=FieldsMapping(mapping=DefaultFieldsMapping(type=<FieldsMappingTyp
+  e.DEFAULT: 'default'>, match_suffix=False, exclude_features=[], 
+  exclude_fields=[]))
     Fields:
       predictions (code_version 1, version
   bcb950543ea50ba3e19aef4846cbc3d36725e2548040c4327219eb2e75e6d997)

--- a/tests/metadata_stores/__snapshots__/test_snapshot_push.ambr
+++ b/tests/metadata_stores/__snapshots__/test_snapshot_push.ambr
@@ -29,19 +29,19 @@
     'versions': list([
       dict({
         'feature_key': 'downstream',
-        'feature_spec_version': '31c4f51ae046775fda2715619d8eebbd18b1a3af22eb0c593bd7f5b2beecea3c',
+        'feature_spec_version': '7c7d179fbd4ea208b038149fe1ccf3cf85eb69fb1b6c8b24380e87ac3d5262c2',
         'feature_version': '7b8e38a11f800fb93c18c0e04c4609d7b52ec12b62177ba8355531d363f01751',
         'snapshot_version': '1ab4ecd9d7af535b843dc22416dd99d5e430317c0a2bcd01fe83ffc2d7392da8',
       }),
       dict({
         'feature_key': 'upstream',
-        'feature_spec_version': '4b4b37d99f4e052c0e0ac10bd6216d715f68c0a0dad7750495a9ec6b310aae46',
+        'feature_spec_version': '8d13977172cfa9d37b0cd5e23e03496e9c94c27762af5678766b86d0fd3f4a42',
         'feature_version': '8a2ffeab8da447095c5ee7a77e5635a1e16e7f3605021732f50f7002fa258398',
         'snapshot_version': '1ab4ecd9d7af535b843dc22416dd99d5e430317c0a2bcd01fe83ffc2d7392da8',
       }),
       dict({
         'feature_key': 'downstream',
-        'feature_spec_version': '67f822a2f2bd3be1e63f60e81b835c43e7ec6ed331d0e409d6181c1ae1077abd',
+        'feature_spec_version': '0591bf12d95f8cb662f4397e52e845b2a693c08003ec31b26ae6ef8a82053a30',
         'feature_version': '7b8e38a11f800fb93c18c0e04c4609d7b52ec12b62177ba8355531d363f01751',
         'snapshot_version': '1ab4ecd9d7af535b843dc22416dd99d5e430317c0a2bcd01fe83ffc2d7392da8',
       }),

--- a/tests/models/test_all_fields_mapping.py
+++ b/tests/models/test_all_fields_mapping.py
@@ -1,0 +1,281 @@
+"""Tests for AllFieldsMapping functionality."""
+
+from metaxy import (
+    Feature,
+    FeatureDep,
+    FeatureGraph,
+    FeatureKey,
+    FeatureSpec,
+    FieldKey,
+    FieldSpec,
+)
+from metaxy.models.field import SpecialFieldDep
+from metaxy.models.fields_mapping import AllFieldsMapping, FieldsMapping
+
+
+def test_all_fields_mapping_returns_all():
+    """Test that AllFieldsMapping always returns SpecialFieldDep.ALL."""
+    graph = FeatureGraph()
+
+    with graph.use():
+        # Define upstream feature
+        class UpstreamFeature(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["test", "upstream"]),
+                deps=None,
+                fields=[
+                    FieldSpec(key=FieldKey(["audio"]), code_version="1"),
+                    FieldSpec(key=FieldKey(["video"]), code_version="1"),
+                ],
+            ),
+        ):
+            pass
+
+        # Define downstream feature with AllFieldsMapping
+        class DownstreamFeature(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["test", "downstream"]),
+                deps=[
+                    FeatureDep(
+                        feature=UpstreamFeature, fields_mapping=FieldsMapping.all()
+                    )
+                ],
+                fields=[
+                    FieldSpec(
+                        key=FieldKey(["combined"]),
+                        code_version="1",
+                        deps=SpecialFieldDep.ALL,  # Explicitly set to ALL
+                    ),
+                ],
+            ),
+        ):
+            pass
+
+        # Check that field deps is SpecialFieldDep.ALL
+        combined_field = DownstreamFeature.spec().fields_by_key[FieldKey(["combined"])]
+        assert combined_field.deps == SpecialFieldDep.ALL
+
+
+def test_fields_mapping_all_classmethod():
+    """Test the FieldsMapping.all() classmethod."""
+    graph = FeatureGraph()
+
+    with graph.use():
+        # Define upstream feature
+        class UpstreamFeature(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["test", "upstream"]),
+                deps=None,
+                fields=[
+                    FieldSpec(key=FieldKey(["audio"]), code_version="1"),
+                    FieldSpec(key=FieldKey(["video"]), code_version="1"),
+                ],
+            ),
+        ):
+            pass
+
+        # Use FieldsMapping.all() classmethod
+        class DownstreamFeature(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["test", "downstream"]),
+                deps=[
+                    FeatureDep(
+                        feature=UpstreamFeature, fields_mapping=FieldsMapping.all()
+                    )
+                ],
+                fields=[
+                    FieldSpec(
+                        key=FieldKey(["combined"]),
+                        code_version="1",
+                        deps=SpecialFieldDep.ALL,  # Explicitly ALL
+                    ),
+                ],
+            ),
+        ):
+            pass
+
+        # Check that field deps is SpecialFieldDep.ALL
+        combined_field = DownstreamFeature.spec().fields_by_key[FieldKey(["combined"])]
+        assert combined_field.deps == SpecialFieldDep.ALL
+
+        # Verify that FieldsMapping.all() returns FieldsMapping with inner AllFieldsMapping
+        all_mapping = FieldsMapping.all()
+        assert isinstance(all_mapping.mapping, AllFieldsMapping)
+        from metaxy.models.fields_mapping import FieldsMappingType
+
+        assert all_mapping.mapping.type == FieldsMappingType.ALL
+
+
+def test_all_fields_mapping_with_multiple_upstreams():
+    """Test AllFieldsMapping with multiple upstream features."""
+    graph = FeatureGraph()
+
+    with graph.use():
+        # Define first upstream feature
+        class Upstream1(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["test", "upstream1"]),
+                deps=None,
+                fields=[
+                    FieldSpec(key=FieldKey(["audio"]), code_version="1"),
+                ],
+            ),
+        ):
+            pass
+
+        # Define second upstream feature
+        class Upstream2(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["test", "upstream2"]),
+                deps=None,
+                fields=[
+                    FieldSpec(key=FieldKey(["video"]), code_version="1"),
+                ],
+            ),
+        ):
+            pass
+
+        # Use AllFieldsMapping to depend on all fields from both upstreams
+        class Downstream(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["test", "downstream"]),
+                deps=[
+                    FeatureDep(feature=Upstream1, fields_mapping=FieldsMapping.all()),
+                    FeatureDep(feature=Upstream2, fields_mapping=FieldsMapping.all()),
+                ],
+                fields=[
+                    FieldSpec(
+                        key=FieldKey(["aggregated"]),
+                        code_version="1",
+                        deps=SpecialFieldDep.ALL,  # Explicitly ALL
+                    ),
+                ],
+            ),
+        ):
+            pass
+
+        # Should be ALL (depends on everything)
+        field = Downstream.spec().fields_by_key[FieldKey(["aggregated"])]
+        assert field.deps == SpecialFieldDep.ALL
+
+
+def test_all_fields_mapping_serialization():
+    """Test that AllFieldsMapping serializes and deserializes correctly."""
+    from metaxy.models.fields_mapping import FieldsMappingAdapter, FieldsMappingType
+
+    # Create an AllFieldsMapping instance
+    all_mapping = AllFieldsMapping()
+
+    # Serialize to dict (for JSON serialization)
+    serialized = all_mapping.model_dump(mode="json")
+    assert serialized == {"type": "all"}  # Enum serializes to string value
+
+    # Deserialize back
+    deserialized = FieldsMappingAdapter.validate_python(serialized)
+    assert isinstance(deserialized, AllFieldsMapping)
+    assert deserialized.type == FieldsMappingType.ALL
+
+    # Also test with FieldsMapping.all()
+    all_mapping_2 = FieldsMapping.all()
+    serialized_2 = all_mapping_2.model_dump(mode="json")
+    assert serialized_2 == {"mapping": {"type": "all"}}  # Wrapped in mapping field
+
+
+def test_all_fields_mapping_vs_explicit_all():
+    """Test that AllFieldsMapping is equivalent to explicit SpecialFieldDep.ALL."""
+    graph = FeatureGraph()
+
+    with graph.use():
+        # Define upstream feature
+        class UpstreamFeature(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["test", "upstream"]),
+                deps=None,
+                fields=[
+                    FieldSpec(key=FieldKey(["data"]), code_version="1"),
+                ],
+            ),
+        ):
+            pass
+
+        # One field with AllFieldsMapping on FeatureDep
+        class WithMapping(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["test", "with_mapping"]),
+                deps=[
+                    FeatureDep(
+                        feature=UpstreamFeature, fields_mapping=FieldsMapping.all()
+                    )
+                ],
+                fields=[
+                    FieldSpec(
+                        key=FieldKey(["field1"]),
+                        code_version="1",
+                        # Will be resolved to ALL via fields_mapping
+                    ),
+                ],
+            ),
+        ):
+            pass
+
+        # Another field with explicit SpecialFieldDep.ALL
+        class WithExplicit(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["test", "with_explicit"]),
+                deps=[FeatureDep(feature=UpstreamFeature)],
+                fields=[
+                    FieldSpec(
+                        key=FieldKey(["field1"]),
+                        code_version="1",
+                        deps=SpecialFieldDep.ALL,  # Explicit
+                    ),
+                ],
+            ),
+        ):
+            pass
+
+        # Both should result in ALL dependencies
+        mapping_field = WithMapping.spec().fields_by_key[FieldKey(["field1"])]
+        explicit_field = WithExplicit.spec().fields_by_key[FieldKey(["field1"])]
+
+        # Note: The field with fields_mapping will have deps=[] at definition time
+        # but will be resolved to ALL at runtime based on the AllFieldsMapping
+        assert mapping_field.deps == []  # No explicit deps (empty list, not None)
+        assert explicit_field.deps == SpecialFieldDep.ALL  # Explicit ALL
+
+
+def test_all_fields_mapping_with_no_upstreams():
+    """Test AllFieldsMapping on a root feature (no upstreams)."""
+    graph = FeatureGraph()
+
+    with graph.use():
+        # Root feature with no dependencies
+        class RootFeature(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["test", "root"]),
+                deps=None,  # No dependencies
+                fields=[
+                    FieldSpec(
+                        key=FieldKey(["data"]),
+                        code_version="1",
+                        deps=SpecialFieldDep.ALL,  # Explicitly ALL for root feature
+                    ),
+                ],
+            ),
+        ):
+            pass
+
+        # Should still be ALL (even with no upstreams)
+        field = RootFeature.spec().fields_by_key[FieldKey(["data"])]
+        assert field.deps == SpecialFieldDep.ALL

--- a/tests/models/test_field_mapping.py
+++ b/tests/models/test_field_mapping.py
@@ -1,0 +1,487 @@
+"""Tests for automatic field mapping functionality."""
+
+from metaxy import (
+    Feature,
+    FeatureDep,
+    FeatureGraph,
+    FeatureKey,
+    FeatureSpec,
+    FieldKey,
+    FieldSpec,
+)
+from metaxy.models.field import FieldDep
+
+
+def test_default_fields_mapping_exact_match():
+    """Test exact field name matching."""
+    graph = FeatureGraph()
+
+    with graph.use():
+        # Define upstream feature with fields
+        class UpstreamFeature(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["test", "upstream"]),
+                deps=None,
+                fields=[
+                    FieldSpec(key=FieldKey(["audio"]), code_version="1"),
+                    FieldSpec(key=FieldKey(["video"]), code_version="1"),
+                ],
+            ),
+        ):
+            pass
+
+        # Define downstream feature with auto-mapped fields
+        class DownstreamFeature(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["test", "downstream"]),
+                deps=[FeatureDep(feature=UpstreamFeature)],
+                fields=[
+                    FieldSpec(
+                        key=FieldKey(["audio"]),
+                        code_version="1",
+                        # deps will be resolved from FeatureDep.fields_mapping,  # Should map to upstream audio
+                    ),
+                    FieldSpec(
+                        key=FieldKey(["video"]),
+                        code_version="1",
+                        # deps will be resolved from FeatureDep.fields_mapping,  # Should map to upstream video
+                    ),
+                ],
+            ),
+        ):
+            pass
+
+        # Check that fields have no explicit deps (will be resolved via FeatureDep.fields_mapping)
+        audio_field = DownstreamFeature.spec().fields_by_key[FieldKey(["audio"])]
+        assert audio_field.deps == []  # Uses default mapping from FeatureDep
+
+        video_field = DownstreamFeature.spec().fields_by_key[FieldKey(["video"])]
+        assert video_field.deps == []  # Uses default mapping from FeatureDep
+
+
+def test_default_fields_mapping_suffix_match():
+    """Test suffix matching for hierarchical field keys."""
+    graph = FeatureGraph()
+
+    with graph.use():
+        # Define upstream feature with hierarchical fields
+        class UpstreamFeature(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["test", "upstream"]),
+                deps=None,
+                fields=[
+                    FieldSpec(key=FieldKey(["audio", "french"]), code_version="1"),
+                    FieldSpec(key=FieldKey(["audio", "english"]), code_version="1"),
+                    FieldSpec(key=FieldKey(["video", "frames"]), code_version="1"),
+                ],
+            ),
+        ):
+            pass
+
+        # Define downstream feature with suffix matching
+        class DownstreamFeature(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["test", "downstream"]),
+                deps=[FeatureDep(feature=UpstreamFeature)],
+                fields=[
+                    FieldSpec(
+                        key=FieldKey(["french"]),
+                        code_version="1",
+                        # deps will be resolved from FeatureDep.fields_mapping,  # Should match audio/french
+                    ),
+                    FieldSpec(
+                        key=FieldKey(["frames"]),
+                        code_version="1",
+                        # deps will be resolved from FeatureDep.fields_mapping,  # Should match video/frames
+                    ),
+                ],
+            ),
+        ):
+            pass
+
+        # Check fields have no explicit deps (will be resolved via FeatureDep.fields_mapping with suffix matching)
+        french_field = DownstreamFeature.spec().fields_by_key[FieldKey(["french"])]
+        assert (
+            french_field.deps == []
+        )  # Uses default mapping with suffix matching from FeatureDep
+
+        frames_field = DownstreamFeature.spec().fields_by_key[FieldKey(["frames"])]
+        assert (
+            frames_field.deps == []
+        )  # Uses default mapping with suffix matching from FeatureDep
+
+
+def test_default_fields_mapping_no_match():
+    """Test behavior when no matching fields are found."""
+    graph = FeatureGraph()
+
+    with graph.use():
+        # Define upstream feature
+        class UpstreamFeature(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["test", "upstream"]),
+                deps=None,
+                fields=[
+                    FieldSpec(key=FieldKey(["audio"]), code_version="1"),
+                ],
+            ),
+        ):
+            pass
+
+        # Define downstream feature with non-matching field
+        class DownstreamFeature(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["test", "downstream"]),
+                deps=[FeatureDep(feature=UpstreamFeature)],
+                fields=[
+                    FieldSpec(
+                        key=FieldKey(["video"]),  # No match in upstream
+                        code_version="1",
+                        # deps will be resolved from FeatureDep.fields_mapping,
+                    ),
+                ],
+            ),
+        ):
+            pass
+
+        # Field should have no explicit deps (will be resolved at runtime)
+        video_field = DownstreamFeature.spec().fields_by_key[FieldKey(["video"])]
+        assert (
+            video_field.deps == []
+        )  # Will fall back to ALL at runtime when no matches found
+
+
+def test_default_fields_mapping_multiple_upstreams():
+    """Test auto-mapping with multiple upstream features."""
+    graph = FeatureGraph()
+
+    with graph.use():
+        # Define first upstream feature
+        class Upstream1(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["test", "upstream1"]),
+                deps=None,
+                fields=[
+                    FieldSpec(key=FieldKey(["audio"]), code_version="1"),
+                    FieldSpec(key=FieldKey(["metadata"]), code_version="1"),
+                ],
+            ),
+        ):
+            pass
+
+        # Define second upstream feature
+        class Upstream2(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["test", "upstream2"]),
+                deps=None,
+                fields=[
+                    FieldSpec(key=FieldKey(["video"]), code_version="1"),
+                    FieldSpec(key=FieldKey(["timestamp"]), code_version="1"),
+                ],
+            ),
+        ):
+            pass
+
+        # Define downstream with deps on both
+        class Downstream(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["test", "downstream"]),
+                deps=[
+                    FeatureDep(feature=Upstream1),
+                    FeatureDep(feature=Upstream2),
+                ],
+                fields=[
+                    FieldSpec(
+                        key=FieldKey(["audio"]),
+                        code_version="1",
+                        # deps will be resolved from FeatureDep.fields_mapping,  # From Upstream1
+                    ),
+                    FieldSpec(
+                        key=FieldKey(["video"]),
+                        code_version="1",
+                        # deps will be resolved from FeatureDep.fields_mapping,  # From Upstream2
+                    ),
+                ],
+            ),
+        ):
+            pass
+
+        # Check fields have no explicit deps (will be resolved at runtime)
+        audio_field = Downstream.spec().fields_by_key[FieldKey(["audio"])]
+        assert audio_field.deps == []  # Will map to Upstream1 at runtime
+
+        video_field = Downstream.spec().fields_by_key[FieldKey(["video"])]
+        assert video_field.deps == []  # Will map to Upstream2 at runtime
+
+
+def test_default_fields_mapping_multiple_matches():
+    """Test that fields can map to multiple upstream features naturally."""
+    graph = FeatureGraph()
+
+    with graph.use():
+        # Define two upstream features with same field name
+        class Upstream1(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["test", "upstream1"]),
+                deps=None,
+                fields=[
+                    FieldSpec(key=FieldKey(["audio"]), code_version="1"),
+                ],
+            ),
+        ):
+            pass
+
+        class Upstream2(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["test", "upstream2"]),
+                deps=None,
+                fields=[
+                    FieldSpec(key=FieldKey(["audio"]), code_version="1"),  # Same name!
+                ],
+            ),
+        ):
+            pass
+
+        # This should map to both upstream features
+        class Downstream(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["test", "downstream"]),
+                deps=[
+                    FeatureDep(feature=Upstream1),
+                    FeatureDep(feature=Upstream2),
+                ],
+                fields=[
+                    FieldSpec(
+                        key=FieldKey(["audio"]),
+                        code_version="1",
+                        # deps will be resolved from FeatureDep.fields_mapping,  # Maps to both!
+                    ),
+                ],
+            ),
+        ):
+            pass
+
+        # Field should have no explicit deps (will map to both at runtime)
+        audio_field = Downstream.spec().fields_by_key[FieldKey(["audio"])]
+        assert audio_field.deps == []  # Will map to both upstream features at runtime
+
+
+def test_default_fields_mapping_exclude_features():
+    """Test excluding specific features from auto-mapping."""
+    graph = FeatureGraph()
+
+    with graph.use():
+        # Define two upstream features with same field
+        class Upstream1(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["test", "upstream1"]),
+                deps=None,
+                fields=[
+                    FieldSpec(key=FieldKey(["audio"]), code_version="1"),
+                ],
+            ),
+        ):
+            pass
+
+        class Upstream2(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["test", "upstream2"]),
+                deps=None,
+                fields=[
+                    FieldSpec(key=FieldKey(["audio"]), code_version="2"),
+                ],
+            ),
+        ):
+            pass
+
+        # Use exclude to avoid ambiguity
+        class Downstream(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["test", "downstream"]),
+                deps=[
+                    FeatureDep(feature=Upstream1),
+                    FeatureDep(feature=Upstream2),
+                ],
+                fields=[
+                    FieldSpec(
+                        key=FieldKey(["audio"]),
+                        code_version="1",
+                        # deps will be resolved from FeatureDep.fields_mapping
+                    ),
+                ],
+            ),
+        ):
+            pass
+
+        # Field should have no explicit deps (will map to Upstream2 only at runtime due to exclude)
+        audio_field = Downstream.spec().fields_by_key[FieldKey(["audio"])]
+        assert audio_field.deps == []  # Will map to Upstream2 only at runtime
+
+
+def test_default_fields_mapping_mixed_deps():
+    """Test mixing auto-mapped and explicit field deps."""
+    graph = FeatureGraph()
+
+    with graph.use():
+        # Define upstream features
+        class Upstream1(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["test", "upstream1"]),
+                deps=None,
+                fields=[
+                    FieldSpec(key=FieldKey(["audio"]), code_version="1"),
+                    FieldSpec(key=FieldKey(["video"]), code_version="1"),
+                ],
+            ),
+        ):
+            pass
+
+        class Upstream2(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["test", "upstream2"]),
+                deps=None,
+                fields=[
+                    FieldSpec(key=FieldKey(["metadata"]), code_version="1"),
+                ],
+            ),
+        ):
+            pass
+
+        # Mix auto and explicit deps
+        class Downstream(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["test", "downstream"]),
+                deps=[
+                    FeatureDep(feature=Upstream1),
+                    FeatureDep(feature=Upstream2),
+                ],
+                fields=[
+                    FieldSpec(
+                        key=FieldKey(["audio"]),
+                        code_version="1",
+                        # deps will be resolved from FeatureDep.fields_mapping,  # Auto-mapped
+                    ),
+                    FieldSpec(
+                        key=FieldKey(["custom"]),
+                        code_version="1",
+                        deps=[  # Explicit deps
+                            FieldDep(
+                                feature=Upstream1.spec().key,
+                                fields=[FieldKey(["video"])],
+                            ),
+                            FieldDep(
+                                feature=Upstream2.spec().key,
+                                fields=[FieldKey(["metadata"])],
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ):
+            pass
+
+        # Check auto-mapped field has no explicit deps
+        audio_field = Downstream.spec().fields_by_key[FieldKey(["audio"])]
+        assert audio_field.deps == []  # Will auto-map at runtime
+
+        # Check explicit deps field has the specified deps
+        custom_field = Downstream.spec().fields_by_key[FieldKey(["custom"])]
+        assert isinstance(custom_field.deps, list)
+        assert len(custom_field.deps) == 2
+        assert custom_field.deps[0].feature == Upstream1.spec().key
+        assert custom_field.deps[1].feature == Upstream2.spec().key
+
+
+def test_default_fields_mapping_no_feature_deps_fallback():
+    """Test that DefaultFieldsMapping falls back to ALL when no feature deps exist."""
+    graph = FeatureGraph()
+
+    with graph.use():
+        # No longer raises an error - instead falls back to ALL for backward compatibility
+        class RootFeature(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["test", "root"]),
+                deps=None,  # No dependencies!
+                fields=[
+                    FieldSpec(
+                        key=FieldKey(["audio"]),
+                        code_version="1",
+                        # deps will be resolved from FeatureDep.fields_mapping,  # Will fallback to ALL
+                    ),
+                ],
+            ),
+        ):
+            pass
+
+        # Field should have no explicit deps (will fallback to ALL at runtime when no feature deps)
+        audio_field = RootFeature.spec().fields_by_key[FieldKey(["audio"])]
+        assert audio_field.deps == []  # Will fallback to ALL at runtime
+
+
+def test_backward_compatibility():
+    """Test that existing code with explicit deps still works."""
+    graph = FeatureGraph()
+
+    with graph.use():
+        # Define upstream
+        class Upstream(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["test", "upstream"]),
+                deps=None,
+                fields=[
+                    FieldSpec(key=FieldKey(["audio"]), code_version="1"),
+                    FieldSpec(key=FieldKey(["video"]), code_version="1"),
+                ],
+            ),
+        ):
+            pass
+
+        # Old-style explicit deps should still work
+        class Downstream(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["test", "downstream"]),
+                deps=[FeatureDep(feature=Upstream)],
+                fields=[
+                    FieldSpec(
+                        key=FieldKey(["processed"]),
+                        code_version="1",
+                        deps=[
+                            FieldDep(
+                                feature=Upstream.spec().key,
+                                fields=[FieldKey(["audio"]), FieldKey(["video"])],
+                            )
+                        ],
+                    ),
+                ],
+            ),
+        ):
+            pass
+
+        # Check explicit deps still work
+        field = Downstream.spec().fields_by_key[FieldKey(["processed"])]
+        assert isinstance(field.deps, list)
+        assert field.deps[0].feature == Upstream.spec().key
+        # Type guard: fields should be a list after explicit declaration
+        assert isinstance(field.deps[0].fields, list), "Expected fields to be a list"
+        assert len(field.deps[0].fields) == 2

--- a/tests/models/test_field_mapping_improvements.py
+++ b/tests/models/test_field_mapping_improvements.py
@@ -1,0 +1,232 @@
+"""Tests for improved DefaultFieldsMapping functionality."""
+
+from metaxy import (
+    Feature,
+    FeatureDep,
+    FeatureGraph,
+    FeatureKey,
+    FeatureSpec,
+    FieldKey,
+    FieldSpec,
+)
+from metaxy.models.fields_mapping import FieldsMapping
+
+
+def test_default_fields_mapping_is_default():
+    """Test that DefaultFieldsMapping is now the default for FieldSpec.deps."""
+    graph = FeatureGraph()
+
+    with graph.use():
+        # Define upstream feature
+        class UpstreamFeature(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["test", "upstream"]),
+                deps=None,
+                fields=[
+                    FieldSpec(key=FieldKey(["audio"]), code_version="1"),
+                    FieldSpec(key=FieldKey(["video"]), code_version="1"),
+                ],
+            ),
+        ):
+            pass
+
+        # Define downstream feature without explicitly specifying deps
+        # Should use DefaultFieldsMapping by default
+        class DownstreamFeature(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["test", "downstream"]),
+                deps=[FeatureDep(feature=UpstreamFeature)],
+                fields=[
+                    FieldSpec(
+                        key=FieldKey(["audio"]),
+                        code_version="1",
+                        # No deps specified - should use DefaultFieldsMapping
+                    ),
+                    FieldSpec(
+                        key=FieldKey(["video"]),
+                        code_version="1",
+                        # No deps specified - should use DefaultFieldsMapping
+                    ),
+                ],
+            ),
+        ):
+            pass
+
+        # Check that fields have no explicit deps (auto-mapped via FeatureDep)
+        audio_field = DownstreamFeature.spec().fields_by_key[FieldKey(["audio"])]
+        assert audio_field.deps == []  # Uses default mapping from FeatureDep
+
+        video_field = DownstreamFeature.spec().fields_by_key[FieldKey(["video"])]
+        assert video_field.deps == []  # Uses default mapping from FeatureDep
+
+
+def test_exclude_fields():
+    """Test excluding specific fields from auto-mapping."""
+    graph = FeatureGraph()
+
+    with graph.use():
+        # Define upstream features with same field names
+        class Upstream1(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["test", "upstream1"]),
+                deps=None,
+                fields=[
+                    FieldSpec(key=FieldKey(["data"]), code_version="1"),
+                    FieldSpec(key=FieldKey(["metadata"]), code_version="1"),
+                ],
+            ),
+        ):
+            pass
+
+        class Upstream2(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["test", "upstream2"]),
+                deps=None,
+                fields=[
+                    FieldSpec(key=FieldKey(["data"]), code_version="2"),
+                    FieldSpec(key=FieldKey(["metadata"]), code_version="2"),
+                ],
+            ),
+        ):
+            pass
+
+        # Use exclude_fields to prevent metadata from being mapped
+        class Downstream(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["test", "downstream"]),
+                deps=[
+                    FeatureDep(feature=Upstream1),
+                    FeatureDep(feature=Upstream2),
+                ],
+                fields=[
+                    FieldSpec(
+                        key=FieldKey(["metadata"]),
+                        code_version="1",
+                        # deps will be resolved from FeatureDep.fields_mapping
+                    ),
+                ],
+            ),
+        ):
+            pass
+
+        # metadata field should have no explicit deps (will resolve at runtime)
+        metadata_field = Downstream.spec().fields_by_key[FieldKey(["metadata"])]
+        assert metadata_field.deps == []  # Will be resolved at runtime
+
+
+def test_backward_compat_with_explicit_all():
+    """Test that explicitly using FieldsMapping.all() works as expected."""
+    graph = FeatureGraph()
+
+    with graph.use():
+
+        class Upstream(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["test", "upstream"]),
+                deps=None,
+                fields=[
+                    FieldSpec(key=FieldKey(["data"]), code_version="1"),
+                ],
+            ),
+        ):
+            pass
+
+        # Explicitly use FieldsMapping.all()
+        class Downstream(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["test", "downstream"]),
+                deps=[FeatureDep(feature=Upstream, fields_mapping=FieldsMapping.all())],
+                fields=[
+                    FieldSpec(
+                        key=FieldKey(["processed"]),
+                        code_version="1",
+                        # Will depend on ALL fields from upstream via the FeatureDep
+                    ),
+                ],
+            ),
+        ):
+            pass
+
+        # Field should have no explicit deps (resolved via FeatureDep.fields_mapping)
+        field = Downstream.spec().fields_by_key[FieldKey(["processed"])]
+        assert field.deps == []  # Uses FieldsMapping.all() from FeatureDep
+
+
+def test_default_mapping_with_no_upstream_deps():
+    """Test that DefaultFieldsMapping handles features with no dependencies gracefully."""
+    graph = FeatureGraph()
+
+    with graph.use():
+        # Root feature with no dependencies
+        # DefaultFieldsMapping should fallback to ALL behavior
+        class RootFeature(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["test", "root"]),
+                deps=None,  # No dependencies
+                fields=[
+                    FieldSpec(
+                        key=FieldKey(["data"]),
+                        code_version="1",
+                        # Uses default DefaultFieldsMapping, should fallback to ALL
+                    ),
+                ],
+            ),
+        ):
+            pass
+
+        # Should work without errors
+        field = RootFeature.spec().fields_by_key[FieldKey(["data"])]
+        # Field has no explicit deps (will resolve to ALL at runtime with no feature deps)
+        assert field.deps == []
+
+
+def test_exclude_fields_with_suffix_matching():
+    """Test that exclude_fields works with suffix matching."""
+    graph = FeatureGraph()
+
+    with graph.use():
+
+        class Upstream(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["test", "upstream"]),
+                deps=None,
+                fields=[
+                    FieldSpec(key=FieldKey(["audio", "french"]), code_version="1"),
+                    FieldSpec(key=FieldKey(["audio", "english"]), code_version="1"),
+                    FieldSpec(key=FieldKey(["video", "french"]), code_version="1"),
+                ],
+            ),
+        ):
+            pass
+
+        # Exclude audio/french but allow video/french with suffix matching
+        class Downstream(
+            Feature,
+            spec=FeatureSpec(
+                key=FeatureKey(["test", "downstream"]),
+                deps=[FeatureDep(feature=Upstream)],
+                fields=[
+                    FieldSpec(
+                        key=FieldKey(["french"]),
+                        code_version="1",
+                        # deps will be resolved from FeatureDep.fields_mapping
+                    ),
+                ],
+            ),
+        ):
+            pass
+
+        # Field should have no explicit deps (will resolve at runtime with exclusions)
+        french_field = Downstream.spec().fields_by_key[FieldKey(["french"])]
+        assert (
+            french_field.deps == []
+        )  # Will match video/french at runtime (audio/french excluded)

--- a/tests/models/test_field_mapping_integration.py
+++ b/tests/models/test_field_mapping_integration.py
@@ -1,0 +1,390 @@
+"""Test field mapping integration with FeatureDep."""
+
+from metaxy.models.feature import Feature, FeatureGraph
+from metaxy.models.feature_spec import FeatureDep, FeatureSpec
+from metaxy.models.field import FieldDep, FieldKey, FieldSpec
+from metaxy.models.fields_mapping import FieldsMapping
+from metaxy.models.types import FeatureKey
+
+
+def test_field_mapping_on_feature_dep():
+    """Test that field mapping on FeatureDep resolves correctly."""
+    test_graph = FeatureGraph()
+
+    with test_graph.use():
+        # Create upstream features with various fields
+        class UpstreamA(
+            Feature,
+            spec=FeatureSpec(
+                key="upstream_a",
+                fields=[
+                    FieldSpec(key="audio", code_version="1"),
+                    FieldSpec(key="video", code_version="1"),
+                    FieldSpec(key="metadata", code_version="1"),
+                ],
+            ),
+        ):
+            pass
+
+        class UpstreamB(
+            Feature,
+            spec=FeatureSpec(
+                key="upstream_b",
+                fields=[
+                    FieldSpec(key="audio/french", code_version="1"),
+                    FieldSpec(key="text", code_version="1"),
+                ],
+            ),
+        ):
+            pass
+
+        # Test 1: Default field mapping (exact match)
+        class DownstreamDefault(
+            Feature,
+            spec=FeatureSpec(
+                key="downstream_default",
+                deps=[
+                    FeatureDep(
+                        feature="upstream_a"
+                    ),  # Uses DefaultFieldsMapping() by default
+                    FeatureDep(feature="upstream_b"),
+                ],
+                fields=[
+                    FieldSpec(key="audio"),  # Should match upstream_a.audio
+                    FieldSpec(key="text"),  # Should match upstream_b.text
+                    FieldSpec(key="other"),  # No match, should get ALL
+                ],
+            ),
+        ):
+            pass
+
+        # Get the feature plan
+        plan_default = test_graph.get_feature_plan(FeatureKey(["downstream_default"]))
+
+        # Check field dependencies
+        field_deps = plan_default.field_dependencies
+
+        # Debug output
+        print(f"field_deps keys: {list(field_deps.keys())}")
+        print(f"field_deps: {field_deps}")
+
+        # "audio" field should map to upstream_a
+        assert FieldKey(["audio"]) in field_deps
+        audio_deps = field_deps[FieldKey(["audio"])]
+        assert FeatureKey(["upstream_a"]) in audio_deps
+        assert FieldKey(["audio"]) in audio_deps[FeatureKey(["upstream_a"])]
+
+        # "text" field should map to upstream_b
+        assert FieldKey(["text"]) in field_deps
+        text_deps = field_deps[FieldKey(["text"])]
+        assert FeatureKey(["upstream_b"]) in text_deps
+        assert FieldKey(["text"]) in text_deps[FeatureKey(["upstream_b"])]
+
+        # "other" field has no match, should get ALL
+        assert FieldKey(["other"]) in field_deps
+        other_deps = field_deps[FieldKey(["other"])]
+        # Should have all fields from all upstreams
+        assert FeatureKey(["upstream_a"]) in other_deps
+        assert len(other_deps[FeatureKey(["upstream_a"])]) == 3  # All 3 fields
+        assert FeatureKey(["upstream_b"]) in other_deps
+        assert len(other_deps[FeatureKey(["upstream_b"])]) == 2  # All 2 fields
+
+
+def test_field_mapping_with_suffix_matching():
+    """Test field mapping with suffix matching enabled."""
+    test_graph = FeatureGraph()
+
+    with test_graph.use():
+
+        class UpstreamAudio(
+            Feature,
+            spec=FeatureSpec(
+                key="upstream_audio",
+                fields=[
+                    FieldSpec(key="audio/english", code_version="1"),
+                    FieldSpec(key="audio/french", code_version="1"),
+                    FieldSpec(key="metadata", code_version="1"),
+                ],
+            ),
+        ):
+            pass
+
+        # Use suffix matching to match "french" to "audio/french"
+        class DownstreamSuffix(
+            Feature,
+            spec=FeatureSpec(
+                key="downstream_suffix",
+                deps=[
+                    FeatureDep(
+                        feature="upstream_audio",
+                        fields_mapping=FieldsMapping.default(match_suffix=True),
+                    ),
+                ],
+                fields=[
+                    FieldSpec(
+                        key="french"
+                    ),  # Should match audio/french with suffix matching
+                    FieldSpec(
+                        key="english"
+                    ),  # Should match audio/english with suffix matching
+                ],
+            ),
+        ):
+            pass
+
+        plan = test_graph.get_feature_plan(FeatureKey(["downstream_suffix"]))
+        field_deps = plan.field_dependencies
+
+        # "french" should map to audio/french
+        assert FieldKey(["french"]) in field_deps
+        french_deps = field_deps[FieldKey(["french"])]
+        assert FeatureKey(["upstream_audio"]) in french_deps
+        assert (
+            FieldKey(["audio", "french"]) in french_deps[FeatureKey(["upstream_audio"])]
+        )
+
+        # "english" should map to audio/english
+        assert FieldKey(["english"]) in field_deps
+        english_deps = field_deps[FieldKey(["english"])]
+        assert FeatureKey(["upstream_audio"]) in english_deps
+        assert (
+            FieldKey(["audio", "english"])
+            in english_deps[FeatureKey(["upstream_audio"])]
+        )
+
+
+def test_field_mapping_with_explicit_all():
+    """Test field mapping with explicit ALL mapping."""
+    test_graph = FeatureGraph()
+
+    with test_graph.use():
+
+        class UpstreamData(
+            Feature,
+            spec=FeatureSpec(
+                key="upstream_data",
+                fields=[
+                    FieldSpec(key="field1", code_version="1"),
+                    FieldSpec(key="field2", code_version="1"),
+                ],
+            ),
+        ):
+            pass
+
+        # Use FieldsMapping.all() to explicitly depend on all upstream fields
+        class DownstreamAll(
+            Feature,
+            spec=FeatureSpec(
+                key="downstream_all",
+                deps=[
+                    FeatureDep(
+                        feature="upstream_data", fields_mapping=FieldsMapping.all()
+                    ),
+                ],
+                fields=[
+                    FieldSpec(key="combined"),  # Will depend on ALL upstream fields
+                ],
+            ),
+        ):
+            pass
+
+        plan = test_graph.get_feature_plan(FeatureKey(["downstream_all"]))
+        field_deps = plan.field_dependencies
+
+        # "combined" should depend on all fields from upstream
+        assert FieldKey(["combined"]) in field_deps
+        combined_deps = field_deps[FieldKey(["combined"])]
+        assert FeatureKey(["upstream_data"]) in combined_deps
+        assert len(combined_deps[FeatureKey(["upstream_data"])]) == 2  # All fields
+
+
+def test_explicit_deps_override_field_mapping():
+    """Test that explicit field deps are preserved alongside automatic mapping."""
+    test_graph = FeatureGraph()
+
+    with test_graph.use():
+
+        class UpstreamX(
+            Feature,
+            spec=FeatureSpec(
+                key="upstream_x",
+                fields=[
+                    FieldSpec(key="data", code_version="1"),
+                    FieldSpec(key="metadata", code_version="1"),
+                ],
+            ),
+        ):
+            pass
+
+        class UpstreamY(
+            Feature,
+            spec=FeatureSpec(
+                key="upstream_y",
+                fields=[
+                    FieldSpec(key="data", code_version="1"),
+                    FieldSpec(key="other", code_version="1"),
+                ],
+            ),
+        ):
+            pass
+
+        class DownstreamExplicit(
+            Feature,
+            spec=FeatureSpec(
+                key="downstream_explicit",
+                deps=[
+                    FeatureDep(feature="upstream_x"),  # Default mapping
+                    FeatureDep(feature="upstream_y"),  # Default mapping
+                ],
+                fields=[
+                    # Explicit deps - should be used directly
+                    FieldSpec(
+                        key="data",
+                        deps=[
+                            FieldDep(
+                                feature="upstream_x", fields=[FieldKey(["metadata"])]
+                            ),
+                            # Explicitly depend on metadata from X, not data
+                        ],
+                    ),
+                ],
+            ),
+        ):
+            pass
+
+        plan = test_graph.get_feature_plan(FeatureKey(["downstream_explicit"]))
+        field_deps = plan.field_dependencies
+
+        # "data" field should use explicit deps, not automatic mapping
+        assert FieldKey(["data"]) in field_deps
+        data_deps = field_deps[FieldKey(["data"])]
+        assert FeatureKey(["upstream_x"]) in data_deps
+        # Should only have metadata field, not data field
+        assert data_deps[FeatureKey(["upstream_x"])] == [FieldKey(["metadata"])]
+        # Should not have upstream_y since not in explicit deps
+        assert FeatureKey(["upstream_y"]) not in data_deps
+
+
+def test_field_mapping_with_exclusions():
+    """Test field mapping with exclusions."""
+    test_graph = FeatureGraph()
+
+    with test_graph.use():
+
+        class UpstreamMulti(
+            Feature,
+            spec=FeatureSpec(
+                key="upstream_multi",
+                fields=[
+                    FieldSpec(key="data", code_version="1"),
+                    FieldSpec(key="metadata", code_version="1"),
+                    FieldSpec(key="debug", code_version="1"),
+                ],
+            ),
+        ):
+            pass
+
+        class UpstreamExcluded(
+            Feature,
+            spec=FeatureSpec(
+                key="upstream_excluded",
+                fields=[
+                    FieldSpec(key="data", code_version="1"),
+                ],
+            ),
+        ):
+            pass
+
+        # Exclude certain fields and features from auto-mapping
+        class DownstreamExclusions(
+            Feature,
+            spec=FeatureSpec(
+                key="downstream_exclusions",
+                deps=[
+                    FeatureDep(
+                        feature="upstream_multi",
+                        fields_mapping=FieldsMapping.default(
+                            exclude_fields=[
+                                FieldKey(["debug"])
+                            ],  # Don't auto-map debug field
+                        ),
+                    ),
+                    FeatureDep(
+                        feature="upstream_excluded",
+                        fields_mapping=FieldsMapping.default(
+                            exclude_features=[
+                                FeatureKey(["upstream_excluded"])
+                            ],  # Exclude this entire feature
+                        ),
+                    ),
+                ],
+                fields=[
+                    FieldSpec(key="data"),  # Should only match upstream_multi.data
+                    FieldSpec(key="debug"),  # Won't match due to exclusion
+                ],
+            ),
+        ):
+            pass
+
+        plan = test_graph.get_feature_plan(FeatureKey(["downstream_exclusions"]))
+        field_deps = plan.field_dependencies
+
+        # "data" should only map to upstream_multi (upstream_excluded is excluded)
+        data_deps = field_deps[FieldKey(["data"])]
+        assert FeatureKey(["upstream_multi"]) in data_deps
+        assert FieldKey(["data"]) in data_deps[FeatureKey(["upstream_multi"])]
+        # upstream_excluded should not be in deps even though it has matching field
+        assert FeatureKey(["upstream_excluded"]) not in data_deps
+
+        # "debug" field doesn't match due to exclusion, falls back to ALL except excluded
+        debug_deps = field_deps[FieldKey(["debug"])]
+        # Should have all fields from upstream_multi except the excluded "debug" field
+        assert FeatureKey(["upstream_multi"]) in debug_deps
+        assert (
+            len(debug_deps[FeatureKey(["upstream_multi"])]) == 2
+        )  # All fields except debug
+        # upstream_excluded should not contribute since the entire feature is excluded
+        assert FeatureKey(["upstream_excluded"]) not in debug_deps
+
+
+def test_no_field_mapping_specified():
+    """Test behavior when no field mapping is specified (should still use default)."""
+    test_graph = FeatureGraph()
+
+    with test_graph.use():
+
+        class SimpleUpstream(
+            Feature,
+            spec=FeatureSpec(
+                key="simple_upstream",
+                fields=[
+                    FieldSpec(key="value", code_version="1"),
+                ],
+            ),
+        ):
+            pass
+
+        # No fields_mapping specified - should use DefaultFieldsMapping()
+        class SimpleDownstream(
+            Feature,
+            spec=FeatureSpec(
+                key="simple_downstream",
+                deps=[
+                    FeatureDep(
+                        feature="simple_upstream"
+                    ),  # fields_mapping=None, defaults to DefaultFieldsMapping()
+                ],
+                fields=[
+                    FieldSpec(key="value"),  # Should match simple_upstream.value
+                ],
+            ),
+        ):
+            pass
+
+        plan = test_graph.get_feature_plan(FeatureKey(["simple_downstream"]))
+        field_deps = plan.field_dependencies
+
+        # Should still work with default mapping
+        value_deps = field_deps[FieldKey(["value"])]
+        assert FeatureKey(["simple_upstream"]) in value_deps
+        assert FieldKey(["value"]) in value_deps[FeatureKey(["simple_upstream"])]

--- a/tests/models/test_field_mapping_serialization.py
+++ b/tests/models/test_field_mapping_serialization.py
@@ -1,0 +1,246 @@
+"""Tests for field mapping serialization and deserialization."""
+
+import json
+
+from metaxy import FeatureKey, FieldKey
+from metaxy.models.fields_mapping import (
+    AllFieldsMapping,
+    DefaultFieldsMapping,
+    FieldsMapping,
+    FieldsMappingAdapter,
+    FieldsMappingType,
+)
+
+
+def test_default_fields_mapping_serialization_basic():
+    """Test basic DefaultFieldsMapping serialization."""
+    mapping = DefaultFieldsMapping()
+
+    # Serialize to dict
+    serialized = mapping.model_dump(mode="json")
+    assert serialized == {
+        "type": "default",
+        "match_suffix": False,
+        "exclude_features": [],
+        "exclude_fields": [],
+    }
+
+    # Deserialize back
+    deserialized = FieldsMappingAdapter.validate_python(serialized)
+    assert isinstance(deserialized, DefaultFieldsMapping)
+    assert deserialized.match_suffix is False
+    assert deserialized.exclude_features == []
+    assert deserialized.exclude_fields == []
+
+
+def test_default_fields_mapping_serialization_with_config():
+    """Test DefaultFieldsMapping serialization with configuration."""
+    feature_key = FeatureKey(["test", "feature"])
+    field_key = FieldKey(["test_field"])
+
+    mapping = DefaultFieldsMapping(
+        match_suffix=True,
+        exclude_features=[feature_key],
+        exclude_fields=[field_key],
+    )
+
+    # Serialize to dict
+    serialized = mapping.model_dump(mode="json")
+    assert serialized == {
+        "type": "default",
+        "match_suffix": True,
+        "exclude_features": [feature_key.model_dump()],
+        "exclude_fields": [field_key.model_dump()],
+    }
+
+    # Deserialize back
+    deserialized = FieldsMappingAdapter.validate_python(serialized)
+    assert isinstance(deserialized, DefaultFieldsMapping)
+    assert deserialized.match_suffix is True
+    assert deserialized.exclude_features == [feature_key]
+    assert deserialized.exclude_fields == [field_key]
+
+
+def test_default_fields_mapping_json_serialization():
+    """Test DefaultFieldsMapping JSON serialization."""
+    mapping = DefaultFieldsMapping(match_suffix=True)
+
+    # Serialize to JSON string
+    json_str = mapping.model_dump_json()
+    parsed = json.loads(json_str)
+
+    assert parsed == {
+        "type": "default",
+        "match_suffix": True,
+        "exclude_features": [],
+        "exclude_fields": [],
+    }
+
+    # Deserialize from JSON
+    deserialized = FieldsMappingAdapter.validate_python(parsed)
+    assert isinstance(deserialized, DefaultFieldsMapping)
+    assert deserialized.match_suffix is True
+
+
+def test_all_fields_mapping_serialization():
+    """Test AllFieldsMapping serialization."""
+    mapping = AllFieldsMapping()
+
+    # Serialize to dict
+    serialized = mapping.model_dump(mode="json")
+    assert serialized == {"type": "all"}
+
+    # Deserialize back
+    deserialized = FieldsMappingAdapter.validate_python(serialized)
+    assert isinstance(deserialized, AllFieldsMapping)
+    assert deserialized.type == FieldsMappingType.ALL
+
+
+def test_all_fields_mapping_json_serialization():
+    """Test AllFieldsMapping JSON serialization."""
+    mapping = AllFieldsMapping()
+
+    # Serialize to JSON string
+    json_str = mapping.model_dump_json()
+    parsed = json.loads(json_str)
+
+    assert parsed == {"type": "all"}
+
+    # Deserialize from JSON
+    deserialized = FieldsMappingAdapter.validate_python(parsed)
+    assert isinstance(deserialized, AllFieldsMapping)
+
+
+def test_fields_mapping_classmethod_serialization():
+    """Test serialization of mappings created via classmethods."""
+    # Test FieldsMapping.default()
+    default_mapping = FieldsMapping.default(
+        match_suffix=True, exclude_fields=[FieldKey(["metadata"])]
+    )
+
+    serialized = default_mapping.model_dump(mode="json")
+    # The mapping field contains the actual DefaultFieldsMapping
+    assert serialized == {
+        "mapping": {
+            "type": "default",
+            "match_suffix": True,
+            "exclude_features": [],
+            "exclude_fields": [["metadata"]],  # FieldKey serializes as list
+        }
+    }
+
+    # Test FieldsMapping.all()
+    all_mapping = FieldsMapping.all()
+    serialized = all_mapping.model_dump(mode="json")
+    assert serialized == {"mapping": {"type": "all"}}
+
+
+def test_backward_compatibility_direct_instantiation():
+    """Test backward compatibility for direct DefaultFieldsMapping instantiation."""
+    # Old-style direct dict without discriminated union structure
+    old_style = {
+        "match_suffix": True,
+        "exclude_features": [],
+        "exclude_fields": [["metadata"]],  # FieldKey as list
+    }
+
+    # Should still validate properly
+    mapping = DefaultFieldsMapping.model_validate(old_style)
+    assert isinstance(mapping, DefaultFieldsMapping)
+    assert mapping.match_suffix is True
+    assert mapping.exclude_fields == [FieldKey(["metadata"])]
+
+
+def test_discriminated_union_validation():
+    """Test that discriminated union validation works correctly."""
+    # DefaultFieldsMapping with discriminated union
+    default_data = {
+        "type": "default",
+        "match_suffix": False,
+        "exclude_features": [],
+        "exclude_fields": [],
+    }
+    mapping = FieldsMappingAdapter.validate_python(default_data)
+    assert isinstance(mapping, DefaultFieldsMapping)
+
+    # AllFieldsMapping with discriminated union
+    all_data = {"type": "all"}
+    mapping = FieldsMappingAdapter.validate_python(all_data)
+    assert isinstance(mapping, AllFieldsMapping)
+
+
+def test_round_trip_serialization():
+    """Test round-trip serialization for all mapping types."""
+    # Test individual mapping types (not FieldsMapping wrapper)
+    mappings = [
+        DefaultFieldsMapping(),
+        DefaultFieldsMapping(match_suffix=True),
+        DefaultFieldsMapping(
+            exclude_features=[FeatureKey(["test"])],
+            exclude_fields=[FieldKey(["field1"]), FieldKey(["field2"])],
+        ),
+        AllFieldsMapping(),
+    ]
+
+    for original in mappings:
+        # Serialize to dict
+        serialized = original.model_dump()
+
+        # Deserialize back
+        deserialized = FieldsMappingAdapter.validate_python(serialized)
+
+        # Check type matches
+        assert type(deserialized) is type(original)
+
+        # For DefaultFieldsMapping, check config
+        if isinstance(original, DefaultFieldsMapping):
+            assert isinstance(deserialized, DefaultFieldsMapping)
+            assert deserialized.match_suffix == original.match_suffix
+            assert deserialized.exclude_features == original.exclude_features
+            assert deserialized.exclude_fields == original.exclude_fields
+
+        # Test JSON round-trip too
+        json_str = original.model_dump_json()
+        json_data = json.loads(json_str)
+        from_json = FieldsMappingAdapter.validate_python(json_data)
+        assert type(from_json) is type(original)
+
+    # Test FieldsMapping wrapper separately
+    wrapped_mappings = [
+        FieldsMapping.default(match_suffix=True),
+        FieldsMapping.all(),
+    ]
+
+    for original in wrapped_mappings:
+        # Serialize to dict
+        serialized = original.model_dump()
+
+        # Check that mapping field exists
+        assert "mapping" in serialized
+
+        # The inner mapping can be deserialized
+        inner = FieldsMappingAdapter.validate_python(serialized["mapping"])
+        assert isinstance(inner, (DefaultFieldsMapping, AllFieldsMapping))
+
+
+def test_mixed_serialization_formats():
+    """Test that both old and new serialization formats work."""
+    # New discriminated union format
+    new_format = {
+        "type": "default",
+        "match_suffix": True,
+        "exclude_features": [],
+        "exclude_fields": [],
+    }
+
+    # Old direct format (backward compatibility)
+    old_format = {"match_suffix": True, "exclude_features": [], "exclude_fields": []}
+
+    # Both should work
+    from_new = DefaultFieldsMapping.model_validate(new_format)
+    from_old = DefaultFieldsMapping.model_validate(old_format)
+
+    assert from_new.match_suffix is True
+    assert from_old.match_suffix is True
+    assert from_new.exclude_features == []
+    assert from_old.exclude_features == []


### PR DESCRIPTION
Resolve #76

Implemented `FieldsMapping`​ variants:

- `FieldsMapping.default()` - by default matches on names and prefixes, can be configured
- `FieldsMapping.all()` - matches to all fields
- `FieldsMapping.none()` - matches to none
- `FieldsMapping.specific()` - matches using a mapping (haha) which is user-provided