### PR TITLE
Fetch and pull gh-pages branch before mike deploy

### DIFF
--- a/.github/workflows/CD-main.yml
+++ b/.github/workflows/CD-main.yml
@@ -56,6 +56,17 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
+      - name: Fetch and pull gh-pages branch
+        run: |
+          # Fetch the gh-pages branch to ensure we have the latest remote state
+          git fetch origin gh-pages:gh-pages || true
+          # If gh-pages exists remotely, ensure our local copy is up to date
+          if git show-ref --verify --quiet refs/remotes/origin/gh-pages; then
+            git checkout gh-pages
+            git pull origin gh-pages --rebase
+            git checkout -
+          fi
+
       - name: Deploy documentation with Mike
         run: uv run mike deploy --push --ignore-remote-status ${{ github.ref_name }}
 


### PR DESCRIPTION
Improved gh-pages branch handling in CD workflow

This PR enhances the CD workflow by adding a step to properly fetch and pull the gh-pages branch before deploying documentation with Mike. The new step:

1. Fetches the remote gh-pages branch
2. Checks if the branch exists remotely
3. If it exists, checks out the branch and pulls the latest changes with rebase
4. Returns to the previous branch

This prevents potential conflicts during documentation deployment and ensures we're always working with the latest state of the documentation branch.