### PR TITLE
Support user-defined data_version_by_field

### DIFF
--- a/docs/learn/system-columns.md
+++ b/docs/learn/system-columns.md
@@ -13,6 +13,7 @@ user-defined feature fields. Only the prefixed forms are supported.
 | Canonical name                    | Description                                                             |
 | --------------------------------- | ----------------------------------------------------------------------- |
 | `metaxy_provenance_by_field`      | Struct capturing per-field provenance hashes. Sample level.             |
+| `metaxy_data_version_by_field`    | Optional struct overriding provenance exposed to downstream features.   |
 | `metaxy_feature_version`          | Version of the versioned graph upstream to the feature.                 |
 | `metaxy_snapshot_version`         | Version of the entire feature graph for the Metaxy project.             |
 | `metaxy_feature_spec_version`     | Version of the feature spec part responsible for graph topology.        |

--- a/src/metaxy/data_versioning/calculators/base.py
+++ b/src/metaxy/data_versioning/calculators/base.py
@@ -6,7 +6,10 @@ from typing import TYPE_CHECKING, Any
 import narwhals as nw
 
 from metaxy.data_versioning.hash_algorithms import HashAlgorithm
-from metaxy.models.constants import METAXY_PROVENANCE_BY_FIELD
+from metaxy.models.constants import (
+    METAXY_DATA_VERSION_BY_FIELD,
+    METAXY_PROVENANCE_BY_FIELD,
+)
 
 if TYPE_CHECKING:
     from metaxy.models.feature_spec import FeatureSpec
@@ -14,6 +17,7 @@ if TYPE_CHECKING:
 
 
 PROVENANCE_BY_FIELD_COL = METAXY_PROVENANCE_BY_FIELD
+DATA_VERSION_BY_FIELD_COL = METAXY_DATA_VERSION_BY_FIELD
 
 
 class ProvenanceByFieldCalculator(ABC):

--- a/src/metaxy/data_versioning/calculators/ibis.py
+++ b/src/metaxy/data_versioning/calculators/ibis.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, Protocol
 import narwhals as nw
 
 from metaxy.data_versioning.calculators.base import (
+    DATA_VERSION_BY_FIELD_COL,
     PROVENANCE_BY_FIELD_COL,
     ProvenanceByFieldCalculator,
 )
@@ -170,9 +171,18 @@ class IbisProvenanceByFieldCalculator(ProvenanceByFieldCalculator):
                     else "__".join(upstream_feature_key)
                 )
 
-                provenance_col_name = upstream_column_mapping.get(
+                override_col_name = upstream_column_mapping.get(
                     upstream_key_str, PROVENANCE_BY_FIELD_COL
                 )
+
+                data_version_col_name: str | None = None
+                provenance_col_name = override_col_name
+                if override_col_name.endswith(DATA_VERSION_BY_FIELD_COL):
+                    data_version_col_name = override_col_name
+                    # Remove the data_version suffix and replace with provenance suffix
+                    # More robust than .replace() which could affect feature key names
+                    prefix = override_col_name[: -len(DATA_VERSION_BY_FIELD_COL)]
+                    provenance_col_name = prefix + PROVENANCE_BY_FIELD_COL
 
                 for upstream_field in sorted(upstream_fields):
                     upstream_field_str = (
@@ -185,9 +195,16 @@ class IbisProvenanceByFieldCalculator(ProvenanceByFieldCalculator):
                         ibis.literal(f"{upstream_key_str}/{upstream_field_str}")
                     )
                     # Access struct field for upstream field's hash
-                    components.append(
-                        ibis_table[provenance_col_name][upstream_field_str]
-                    )
+                    provenance_expr = ibis_table[provenance_col_name][
+                        upstream_field_str
+                    ]
+                    if data_version_col_name:
+                        override_expr = ibis_table[data_version_col_name][
+                            upstream_field_str
+                        ]
+                        components.append(override_expr.fillna(provenance_expr))
+                    else:
+                        components.append(provenance_expr)
 
             # Concatenate all components with separator
             concat_expr = components[0]

--- a/src/metaxy/data_versioning/joiners/base.py
+++ b/src/metaxy/data_versioning/joiners/base.py
@@ -57,8 +57,11 @@ class UpstreamJoiner(ABC):
         Returns:
             Tuple of (joined_ref, upstream_column_mapping):
             - joined_ref: Narwhals LazyFrame with all upstream data joined
-                Contains: ID columns, metaxy_provenance_by_field columns, and any user columns
-            - upstream_column_mapping: Maps upstream feature key -> metaxy_provenance_by_field column name
+                Contains: ID columns, metaxy_provenance_by_field columns, optional
+                metaxy_data_version_by_field columns, and any user columns
+            - upstream_column_mapping: Maps upstream feature key -> column name containing
+                the effective provenance struct (prefers metaxy_data_version_by_field when present,
+                otherwise metaxy_provenance_by_field).
                 Example: {"video": "__upstream_video__metaxy_provenance_by_field"}
 
         Note:
@@ -66,7 +69,8 @@ class UpstreamJoiner(ABC):
               features are included. This ensures we can compute valid field_provenance.
             - ID columns come from feature_spec.id_columns (default: ["sample_uid"])
             - Supports composite keys (multiple ID columns) for complex join scenarios
-            - System columns (ID columns, metaxy_provenance_by_field) are always preserved
+            - System columns (ID columns, metaxy_provenance_by_field, metaxy_data_version_by_field)
+              are always preserved
             - User columns are preserved based on columns parameter (default: all)
         """
         pass

--- a/src/metaxy/ext/sqlmodel.py
+++ b/src/metaxy/ext/sqlmodel.py
@@ -13,6 +13,7 @@ from sqlmodel.main import SQLModelMetaclass
 from metaxy.config import MetaxyConfig
 from metaxy.models.constants import (
     ALL_SYSTEM_COLUMNS,
+    METAXY_DATA_VERSION_BY_FIELD,
     METAXY_FEATURE_SPEC_VERSION,
     METAXY_FEATURE_VERSION,
     METAXY_PROVENANCE_BY_FIELD,
@@ -259,6 +260,15 @@ class BaseSQLModelFeature(  # pyright: ignore[reportIncompatibleMethodOverride]
         sa_type=JSON,
         sa_column_kwargs={
             "name": METAXY_PROVENANCE_BY_FIELD,
+            "nullable": True,
+        },
+    )
+
+    metaxy_data_version_by_field: str | None = Field(
+        default=None,
+        sa_type=JSON,
+        sa_column_kwargs={
+            "name": METAXY_DATA_VERSION_BY_FIELD,
             "nullable": True,
         },
     )

--- a/src/metaxy/metadata_store/base.py
+++ b/src/metaxy/metadata_store/base.py
@@ -36,6 +36,7 @@ from metaxy.metadata_store.system_tables import (
     allow_feature_version_override,
 )
 from metaxy.models.constants import (
+    METAXY_DATA_VERSION_BY_FIELD,
     METAXY_FEATURE_SPEC_VERSION,
     METAXY_FEATURE_TRACKING_VERSION,
     METAXY_FEATURE_VERSION,
@@ -73,6 +74,7 @@ def _is_using_polars_components(
 
 
 PROVENANCE_BY_FIELD_COL = METAXY_PROVENANCE_BY_FIELD
+DATA_VERSION_BY_FIELD_COL = METAXY_DATA_VERSION_BY_FIELD
 FEATURE_VERSION_COL = METAXY_FEATURE_VERSION
 SNAPSHOT_VERSION_COL = METAXY_SNAPSHOT_VERSION
 FEATURE_SPEC_VERSION_COL = METAXY_FEATURE_SPEC_VERSION
@@ -586,6 +588,13 @@ class MetadataStore(ABC):
             raise MetadataSchemaError(
                 f"'{PROVENANCE_BY_FIELD_COL}' column must be pl.Struct, got {provenance_type}"
             )
+
+        if DATA_VERSION_BY_FIELD_COL in df.columns:
+            data_version_type = df.schema[DATA_VERSION_BY_FIELD_COL]
+            if not isinstance(data_version_type, pl.Struct):
+                raise MetadataSchemaError(
+                    f"'{DATA_VERSION_BY_FIELD_COL}' column must be pl.Struct when provided, got {data_version_type}"
+                )
 
         # Check for feature_version column
         if FEATURE_VERSION_COL not in df.columns:

--- a/src/metaxy/models/constants.py
+++ b/src/metaxy/models/constants.py
@@ -18,6 +18,9 @@ SYSTEM_COLUMN_PREFIX = "metaxy_"
 METAXY_PROVENANCE_BY_FIELD = f"{SYSTEM_COLUMN_PREFIX}provenance_by_field"
 """Field-level provenance hashes (struct column mapping field names to hashes)."""
 
+METAXY_DATA_VERSION_BY_FIELD = f"{SYSTEM_COLUMN_PREFIX}data_version_by_field"
+"""Optional user-defined field-level version overrides."""
+
 METAXY_FEATURE_VERSION = f"{SYSTEM_COLUMN_PREFIX}feature_version"
 """Hash of the feature definition (dependencies + fields + code_versions)."""
 
@@ -35,6 +38,7 @@ METAXY_FEATURE_TRACKING_VERSION = f"{SYSTEM_COLUMN_PREFIX}feature_tracking_versi
 ALL_SYSTEM_COLUMNS = frozenset(
     {
         METAXY_PROVENANCE_BY_FIELD,
+        METAXY_DATA_VERSION_BY_FIELD,
         METAXY_FEATURE_VERSION,
         METAXY_SNAPSHOT_VERSION,
     }


### PR DESCRIPTION
resolves #47 

### TL;DR

Added support for `metaxy_data_version_by_field` to decouple change detection from downstream propagation.

### What changed?

- Added a new system column `metaxy_data_version_by_field` that allows users to override the version exposed to downstream features
- Updated the versioning system to use `data_version_by_field` (when present) for downstream computation, while still using `provenance_by_field` for change detection
- Modified joiners to preserve both columns and prefer `data_version_by_field` in mappings when available
- Updated calculators to use override values from `data_version_by_field` when computing downstream provenance
- Added comprehensive documentation explaining the purpose and use cases
- Added tests to verify the behavior works as expected

### How to test?

1. Create a feature with both `metaxy_provenance_by_field` and `metaxy_data_version_by_field`
2. Verify downstream features use the values from `data_version_by_field`
3. Change `provenance_by_field` but keep `data_version_by_field` the same
4. Verify the feature is recomputed (due to provenance change) but downstream features don't see the change

### Why make this change?

This change enables several important use cases:

1. **Version Pinning**: Pin downstream features to a stable version while iterating on improvements
2. **Gradual Rollout**: Release new versions to downstream features gradually
3. **Breaking Change Management**: Make breaking changes without forcing immediate downstream updates

The separation of change detection from downstream propagation gives users more control over how changes flow through their feature graph, enabling safer deployments and more flexible development workflows.