### PR TITLE
[docs] remove CLI examples and simplify help text

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -8,37 +8,3 @@ This section provides a comprehensive reference for all Metaxy CLI commands.
     recursive: true
     flatten-commands: false
     generate-toc: true
-
-## Examples
-
-### Recording a graph snapshot
-
-```bash
-# Push the current feature graph to the metadata store
-metaxy graph push
-```
-
-The recommendation is to run this command in your CD pipeline.
-
-### Generating and applying migrations
-
-```bash
-# Generate a migration for detected changes
-metaxy migrations generate --op metaxy.migrations.ops.DataVersionReconciliation
-
-# Apply pending migrations
-metaxy migrations apply
-```
-
-### Visualizing the feature graph
-
-```bash
-# Render as terminal tree view
-metaxy graph render
-
-# Render as Mermaid diagram
-metaxy graph render --format mermaid
-
-# Compare two snapshots
-metaxy graph-diff render <snapshot-id> current --format mermaid
-```

--- a/src/metaxy/cli/app.py
+++ b/src/metaxy/cli/app.py
@@ -12,7 +12,6 @@ from metaxy.cli.console import console, error_console
 # Main app
 app = cyclopts.App(
     name="metaxy",  # pyrefly: ignore[unexpected-keyword]
-    help="Metaxy - Feature Metadata Management",  # pyrefly: ignore[unexpected-keyword]
     version=__version__,  # pyrefly: ignore[unexpected-keyword]
     console=console,  # pyrefly: ignore[unexpected-keyword]
     error_console=error_console,  # pyrefly: ignore[unexpected-keyword]
@@ -58,10 +57,8 @@ def launcher(
 ):
     """Metaxy CLI.
 
-    Auto-discovers config file (metaxy.toml or pyproject.toml) by searching
-    current directory and parent directories.
-
-    Environment variables can override config (METAXY_STORE, METAXY_MIGRATIONS_DIR, etc).
+    Auto-discovers configuration (`metaxy.toml` or `pyproject.toml`) in current or parent directories.
+    The configuration file must be present.
     """
     import logging
     import os

--- a/src/metaxy/cli/graph.py
+++ b/src/metaxy/cli/graph.py
@@ -35,9 +35,10 @@ def push(
         ),
     ] = None,
 ):
-    """Serialize all Metaxy feature definitions (identified via feature discovery) to the metadata store.
+    """Serialize all Metaxy features to the metadata store.
 
     This is intended to be invoked in a CD pipeline **before** running Metaxy code in production.
+    Feature definitions are collected via the [feature discovery](https://anam-org.github.io/metaxy/main/learn/feature-discovery/) mechanism.
     """
     from metaxy.cli.context import AppContext
     from metaxy.metadata_store.system.models import METAXY_TAG


### PR DESCRIPTION
# Remove CLI examples and simplify documentation

This PR removes the CLI examples section from the documentation and simplifies the CLI help text. The changes include:

1. Removing the "Examples" section from the CLI reference documentation
2. Removing the redundant help text from the main CLI app
3. Simplifying the CLI launcher description to focus on configuration discovery
4. Enhancing the `graph push` command description with a link to the feature discovery documentation

These changes make the documentation more concise while still providing the necessary information for users.