### PR TITLE
[cli] move feature discovery documentation link from push to launcher docstring

### DIFF
--- a/src/metaxy/cli/app.py
+++ b/src/metaxy/cli/app.py
@@ -58,7 +58,7 @@ def launcher(
     """Metaxy CLI.
 
     Auto-discovers configuration (`metaxy.toml` or `pyproject.toml`) in current or parent directories.
-    The configuration file must be present.
+    Feature definitions are collected via [feature discovery](https://anam-org.github.io/metaxy/main/learn/feature-discovery/).
     """
     import logging
     import os

--- a/src/metaxy/cli/graph.py
+++ b/src/metaxy/cli/graph.py
@@ -38,7 +38,6 @@ def push(
     """Serialize all Metaxy features to the metadata store.
 
     This is intended to be invoked in a CD pipeline **before** running Metaxy code in production.
-    Feature definitions are collected via the [feature discovery](https://anam-org.github.io/metaxy/main/learn/feature-discovery/) mechanism.
     """
     from metaxy.cli.context import AppContext
     from metaxy.metadata_store.system.models import METAXY_TAG


### PR DESCRIPTION
Updated CLI documentation to clarify feature discovery process. Moved the feature discovery link from the `push` command documentation to the main launcher docstring, making it more visible and accessible at the top level of the CLI interface.