### PR TITLE
[cli] add help epilogue with link to Metaxy docs

### DIFF
--- a/src/metaxy/cli/app.py
+++ b/src/metaxy/cli/app.py
@@ -18,6 +18,7 @@ app = cyclopts.App(
     config=cyclopts.config.Env(  # pyrefly: ignore[unexpected-keyword,implicit-import]
         "METAXY_",  # Every environment variable for setting the arguments will begin with this.  # pyrefly: ignore[bad-argument-count]
     ),
+    help_epilogue="Learn more in [Metaxy docs](https://anam-org.github.io/metaxy)",
 )
 
 


### PR DESCRIPTION
Added a help epilogue to the CLI app that links to the Metaxy documentation website. Users will now see a reference to the documentation when viewing help information.