### PR TITLE
[core] remove variadic format from FeatureKey and FieldKey

### DIFF
--- a/docs/learn/syntactic-sugar.md
+++ b/docs/learn/syntactic-sugar.md
@@ -15,7 +15,6 @@ from metaxy import FeatureKey
 
 key = FeatureKey("prefix/feature")
 key = FeatureKey(["prefix", "feature"])
-key = FeatureKey("prefix", "feature")
 same_key = FeatureKey(key)
 ```
 
@@ -27,7 +26,6 @@ Both `FeatureKey` and `FieldKey` accept:
 
 - **String format**: `FeatureKey("prefix/feature")`
 - **Sequence format**: `FeatureKey(["prefix", "feature"])`
-- **Variadic format**: `FeatureKey("prefix", "feature")`
 - **Same type**: `FeatureKey(another_feature_key)` -- for full Inception mode
 
 All formats produce equivalent keys, internally represented as a sequence of parts.

--- a/src/metaxy/models/types.py
+++ b/src/metaxy/models/types.py
@@ -60,22 +60,20 @@ class _Key(BaseModel):
         Initialize from various input types.
 
         Args:
-            *args: Variadic positional arguments:
-                - Single str: Split on "/" separator ("a/b/c" -> ["a", "b", "c"])
-                - Single Sequence[str]: Use as parts (["a", "b", "c"])
-                - Single Key instance: Copy parts
-                - Multiple str: Use as parts ("a", "b", "c" -> ["a", "b", "c"])
+            *args: Single positional argument:
+                - str: Split on "/" separator ("a/b/c" -> ["a", "b", "c"])
+                - Sequence[str]: Use as parts (["a", "b", "c"])
+                - Key instance: Copy parts
             **kwargs: Additional keyword arguments for BaseModel (e.g., parts=...)
 
         Examples:
             ```py
             FeatureKey("a/b/c")  # String with separator
             FeatureKey(["a", "b", "c"])  # List
-            FeatureKey("a", "b", "c")  # Variadic
             FeatureKey(parts=["a", "b", "c"])  # Keyword argument
             ```
         """
-        # Handle variadic or single argument construction
+        # Handle single argument construction
         if args:
             if len(args) == 1:
                 key = args[0]
@@ -102,14 +100,10 @@ class _Key(BaseModel):
                         f"Cannot create {self.__class__.__name__} from {type(key).__name__}"
                     )
             else:
-                # Multiple arguments - treat as variadic parts
-                # Validate all are strings
-                if not all(isinstance(arg, str) for arg in args):
-                    raise ValueError(
-                        f"Variadic arguments to {self.__class__.__name__} must all be strings, "
-                        f"got types: {[type(arg).__name__ for arg in args]}"
-                    )
-                kwargs["parts"] = tuple(args)  # type: ignore[arg-type]
+                # Multiple arguments provided - not supported
+                raise TypeError(
+                    f"{self.__class__.__name__}() takes exactly 1 positional argument ({len(args)} given)"
+                )
 
         super().__init__(**kwargs)
 
@@ -128,11 +122,6 @@ class _Key(BaseModel):
         @overload
         def __init__(self: Self, key: Self, /) -> None:
             """Initialize from another instance (copy)."""
-            ...
-
-        @overload
-        def __init__(self, *parts: str) -> None:
-            """Initialize from variadic string arguments."""
             ...
 
         @overload
@@ -301,9 +290,6 @@ class FeatureKey(_Key):
 
         FeatureKey(FeatureKey(["a", "b", "c"]))  # FeatureKey copy
         # FeatureKey(parts=['a', 'b', 'c'])
-
-        FeatureKey("a", "b", "c")  # Variadic format
-        # FeatureKey(parts=['a', 'b', 'c'])
         ```
     """
 
@@ -325,11 +311,6 @@ class FeatureKey(_Key):
             ...
 
         @overload
-        def __init__(self, *parts: str) -> None:
-            """Initialize from variadic string arguments."""
-            ...
-
-        @overload
         def __init__(self, *, parts: Sequence[str]) -> None:
             """Initialize from parts keyword argument."""
             ...
@@ -338,7 +319,6 @@ class FeatureKey(_Key):
         def __init__(  # pyright: ignore[reportMissingSuperCall]
             self,
             key: str | Sequence[str] | FeatureKey | None = None,
-            *parts: str,
             **kwargs: Any,
         ) -> None: ...
 
@@ -397,9 +377,6 @@ class FieldKey(_Key):
 
         FieldKey(FieldKey(["a", "b", "c"]))  # FieldKey copy
         # FieldKey(parts=['a', 'b', 'c'])
-
-        FieldKey("a", "b", "c")  # Variadic format
-        # FieldKey(parts=['a', 'b', 'c'])
         ```
     """
 
@@ -421,11 +398,6 @@ class FieldKey(_Key):
             ...
 
         @overload
-        def __init__(self, *parts: str) -> None:
-            """Initialize from variadic string arguments."""
-            ...
-
-        @overload
         def __init__(self, *, parts: Sequence[str]) -> None:
             """Initialize from parts keyword argument."""
             ...
@@ -434,7 +406,6 @@ class FieldKey(_Key):
         def __init__(  # pyright: ignore[reportMissingSuperCall]
             self,
             key: str | Sequence[str] | FieldKey | None = None,
-            *parts: str,
             **kwargs: Any,
         ) -> None: ...
 

--- a/tests/models/types/test_types.py
+++ b/tests/models/types/test_types.py
@@ -32,38 +32,6 @@ class TestFeatureKey:
         assert list(key.parts) == ["a", "b", "c"]
         assert key.to_string() == "a/b/c"
 
-    def test_variadic_input(self):
-        """Test FeatureKey construction with variadic arguments."""
-        key = FeatureKey("a", "b", "c")
-        assert_type(key, FeatureKey)
-        assert_type(key.parts, tuple[str, ...])
-        assert list(key.parts) == ["a", "b", "c"]
-        assert key.to_string() == "a/b/c"
-
-    def test_variadic_single_part(self):
-        """Test FeatureKey construction with single variadic argument."""
-        key = FeatureKey("single")
-        assert_type(key, FeatureKey)
-        assert list(key.parts) == ["single"]
-        assert key.to_string() == "single"
-
-    def test_variadic_many_parts(self):
-        """Test FeatureKey construction with many variadic arguments."""
-        key = FeatureKey("a", "b", "c", "d", "e")
-        assert list(key.parts) == ["a", "b", "c", "d", "e"]
-        assert key.to_string() == "a/b/c/d/e"
-
-    def test_variadic_vs_string_equivalence(self):
-        """Test that variadic and string formats produce identical keys."""
-        key_variadic = FeatureKey("a", "b", "c")
-        key_string = FeatureKey("a/b/c")
-        key_list = FeatureKey(["a", "b", "c"])
-
-        assert key_variadic == key_string
-        assert key_variadic == key_list
-        assert key_string == key_list
-        assert hash(key_variadic) == hash(key_string) == hash(key_list)
-
     def test_list_input(self):
         """Test FeatureKey construction with list."""
         key = FeatureKey(["a", "b", "c"])
@@ -94,18 +62,8 @@ class TestFeatureKey:
         key2 = FeatureKey(["a", "b", "c"])
         assert key1 == key2
 
-    def test_equality_variadic(self):
-        """Test equality between variadic and other construction methods."""
-        key_string = FeatureKey("a/b/c")
-        key_list = FeatureKey(["a", "b", "c"])
-        key_variadic = FeatureKey("a", "b", "c")
-
-        assert key_string == key_list
-        assert key_string == key_variadic
-        assert key_list == key_variadic
-
         # All should have same hash
-        assert hash(key_string) == hash(key_list) == hash(key_variadic)
+        assert hash(key1) == hash(key2)
 
     def test_inequality(self):
         """Test inequality comparison."""
@@ -153,15 +111,10 @@ class TestFeatureKey:
         with pytest.raises(ValidationError, match="Input should be a valid string"):
             FeatureKey([1, 2, 3])  # pyright: ignore[reportCallIssue,reportArgumentType]
 
-    def test_validation_variadic_non_string(self):
-        """Test validation rejects non-string variadic arguments."""
-        with pytest.raises(ValueError, match="must all be strings"):
-            FeatureKey("a", "b", 123)  # pyright: ignore[reportCallIssue,reportArgumentType]
-
-    def test_validation_variadic_double_underscore(self):
-        """Test validation rejects double underscores in variadic arguments."""
-        with pytest.raises(ValidationError, match="cannot contain double underscores"):
-            FeatureKey("a", "b__c", "d")
+    def test_validation_multiple_args_rejected(self):
+        """Test validation rejects multiple positional arguments."""
+        with pytest.raises(TypeError, match="takes exactly 1 positional argument"):
+            FeatureKey("a", "b", "c")  # pyright: ignore[reportCallIssue]
 
     def test_empty_string_splits_to_empty_list(self):
         """Test empty string handling."""
@@ -216,29 +169,6 @@ class TestFieldKey:
         assert list(key.parts) == ["a", "b", "c"]
         assert key.to_string() == "a/b/c"
 
-    def test_variadic_input(self):
-        """Test FieldKey construction with variadic arguments."""
-        key = FieldKey("a", "b", "c")
-        assert list(key.parts) == ["a", "b", "c"]
-        assert key.to_string() == "a/b/c"
-
-    def test_variadic_single_part(self):
-        """Test FieldKey construction with single variadic argument."""
-        key = FieldKey("single")
-        assert list(key.parts) == ["single"]
-        assert key.to_string() == "single"
-
-    def test_variadic_vs_string_equivalence(self):
-        """Test that variadic and string formats produce identical keys."""
-        key_variadic = FieldKey("a", "b", "c")
-        key_string = FieldKey("a/b/c")
-        key_list = FieldKey(["a", "b", "c"])
-
-        assert key_variadic == key_string
-        assert key_variadic == key_list
-        assert key_string == key_list
-        assert hash(key_variadic) == hash(key_string) == hash(key_list)
-
     def test_list_input(self):
         """Test FieldKey construction with list."""
         key = FieldKey(["a", "b", "c"])
@@ -266,18 +196,8 @@ class TestFieldKey:
         assert key1 == key2
         assert key2 == key2
 
-    def test_equality_variadic(self):
-        """Test equality between variadic and other construction methods."""
-        key_string = FieldKey("a/b/c")
-        key_list = FieldKey(["a", "b", "c"])
-        key_variadic = FieldKey("a", "b", "c")
-
-        assert key_string == key_list
-        assert key_string == key_variadic
-        assert key_list == key_variadic
-
         # All should have same hash
-        assert hash(key_string) == hash(key_list) == hash(key_variadic)
+        assert hash(key1) == hash(key2)
 
     def test_inequality(self):
         """Test inequality comparison."""
@@ -315,15 +235,10 @@ class TestFieldKey:
         with pytest.raises(ValidationError, match="Input should be a valid string"):
             FieldKey([1, 2, 3])  # pyright: ignore[reportCallIssue,reportArgumentType]
 
-    def test_validation_variadic_non_string(self):
-        """Test validation rejects non-string variadic arguments."""
-        with pytest.raises(ValueError, match="must all be strings"):
-            FieldKey("a", "b", 123)  # pyright: ignore[reportCallIssue,reportArgumentType]
-
-    def test_validation_variadic_double_underscore(self):
-        """Test validation rejects double underscores in variadic arguments."""
-        with pytest.raises(ValidationError, match="cannot contain double underscores"):
-            FieldKey("a", "b__c", "d")
+    def test_validation_multiple_args_rejected(self):
+        """Test validation rejects multiple positional arguments."""
+        with pytest.raises(TypeError, match="takes exactly 1 positional argument"):
+            FieldKey("a", "b", "c")  # pyright: ignore[reportCallIssue]
 
     def test_immutability(self):
         """Test that FieldKey is immutable (frozen)."""
@@ -352,17 +267,15 @@ class TestTypeChecking:
         key_list = FeatureKey(["a", "b", "c"])
         key_tuple = FeatureKey(("a", "b", "c"))
         key_copy = FeatureKey(key_str)
-        key_variadic = FeatureKey("a", "b", "c")
 
         # All should produce FeatureKey instances
         assert isinstance(key_str, FeatureKey)
         assert isinstance(key_list, FeatureKey)
         assert isinstance(key_tuple, FeatureKey)
         assert isinstance(key_copy, FeatureKey)
-        assert isinstance(key_variadic, FeatureKey)
 
         # All should be equal
-        assert key_str == key_list == key_tuple == key_copy == key_variadic
+        assert key_str == key_list == key_tuple == key_copy
 
 
 class TestJSONSerialization:
@@ -385,14 +298,6 @@ class TestJSONSerialization:
         assert isinstance(json_data, list)
         assert json_data == ["a", "b", "c"]
 
-    def test_feature_key_json_serialization_from_variadic(self):
-        """Test that FeatureKey from variadic args serializes to list format."""
-        key = FeatureKey("a", "b", "c")
-        json_data = key.model_dump()
-
-        assert isinstance(json_data, list)
-        assert json_data == ["a", "b", "c"]
-
     def test_field_key_json_serialization_from_string(self):
         """Test that FieldKey from string serializes to list format."""
         key = FieldKey("a/b/c")
@@ -409,19 +314,11 @@ class TestJSONSerialization:
         assert isinstance(json_data, list)
         assert json_data == ["a", "b", "c"]
 
-    def test_field_key_json_serialization_from_variadic(self):
-        """Test that FieldKey from variadic args serializes to list format."""
-        key = FieldKey("a", "b", "c")
-        json_data = key.model_dump()
-
-        assert isinstance(json_data, list)
-        assert json_data == ["a", "b", "c"]
-
     def test_feature_key_json_roundtrip(self):
         """Test that FeatureKey can be serialized and deserialized."""
         import json
 
-        key = FeatureKey("a", "b", "c")
+        key = FeatureKey("a/b/c")
         json_str = json.dumps(key.model_dump())
 
         # Should serialize to ["a", "b", "c"]
@@ -437,7 +334,7 @@ class TestJSONSerialization:
         """Test that FieldKey can be serialized and deserialized."""
         import json
 
-        key = FieldKey("x", "y", "z")
+        key = FieldKey("x/y/z")
         json_str = json.dumps(key.model_dump())
 
         # Should serialize to ["x", "y", "z"]
@@ -456,8 +353,8 @@ class TestJSONSerialization:
         class MyModel(BaseModel):
             key: FeatureKey
 
-        # Create with variadic
-        model = MyModel(key=FeatureKey("a", "b", "c"))
+        # Create with list
+        model = MyModel(key=FeatureKey(["a", "b", "c"]))
         json_data = model.model_dump()
 
         # key should be serialized as a list
@@ -471,8 +368,8 @@ class TestJSONSerialization:
         class MyModel(BaseModel):
             key: FieldKey
 
-        # Create with variadic
-        model = MyModel(key=FieldKey("x", "y"))
+        # Create with list
+        model = MyModel(key=FieldKey(["x", "y"]))
         json_data = model.model_dump()
 
         # key should be serialized as a list
@@ -507,25 +404,12 @@ class TestFeatureSpecIntegration:
         """Test SampleFeatureSpec accepts FeatureKey instance."""
         from metaxy.models.feature_spec import SampleFeatureSpec
 
-        key = FeatureKey("my", "feature")
+        key = FeatureKey(["my", "feature"])
         spec = SampleFeatureSpec(key=key)
 
         assert isinstance(spec.key, FeatureKey)
         assert spec.key.to_string() == "my/feature"
         assert list(spec.key.parts) == ["my", "feature"]
-
-    def test_feature_spec_serialization_with_variadic_key(self):
-        """Test SampleFeatureSpec serialization when key created with variadic args."""
-        from metaxy.models.feature_spec import SampleFeatureSpec
-
-        spec = SampleFeatureSpec(
-            key=FeatureKey("a", "b", "c"),
-        )
-        json_data = spec.model_dump(mode="json")
-
-        # key should be serialized as list
-        assert isinstance(json_data["key"], list)
-        assert json_data["key"] == ["a", "b", "c"]
 
     def test_feature_dep_with_string_key(self):
         """Test FeatureDep accepts key as string."""
@@ -545,11 +429,11 @@ class TestFeatureSpecIntegration:
         assert isinstance(dep.feature, FeatureKey)
         assert dep.feature.to_string() == "upstream/feature"
 
-    def test_feature_dep_with_feature_key_variadic(self):
-        """Test FeatureDep accepts FeatureKey created with variadic args."""
+    def test_feature_dep_with_feature_key_instance(self):
+        """Test FeatureDep accepts FeatureKey instance."""
         from metaxy.models.feature_spec import FeatureDep
 
-        dep = FeatureDep(feature=FeatureKey("upstream", "feature"))
+        dep = FeatureDep(feature=FeatureKey(["upstream", "feature"]))
 
         assert isinstance(dep.feature, FeatureKey)
         assert dep.feature.to_string() == "upstream/feature"
@@ -572,29 +456,29 @@ class TestFeatureSpecIntegration:
         assert isinstance(field.key, FieldKey)
         assert field.key.to_string() == "my/field"
 
-    def test_field_spec_with_field_key_variadic(self):
-        """Test FieldSpec accepts FieldKey created with variadic args."""
+    def test_field_spec_with_field_key_instance(self):
+        """Test FieldSpec accepts FieldKey instance."""
         from metaxy.models.field import FieldSpec
 
-        field = FieldSpec(key=FieldKey("my", "field"), code_version="1")
+        field = FieldSpec(key=FieldKey(["my", "field"]), code_version="1")
 
         assert isinstance(field.key, FieldKey)
         assert field.key.to_string() == "my/field"
 
-    def test_complete_feature_spec_with_variadic_keys(self):
-        """Test complete SampleFeatureSpec with all keys created using variadic format."""
+    def test_complete_feature_spec_with_list_keys(self):
+        """Test complete SampleFeatureSpec with all keys created using list format."""
         from metaxy.models.feature_spec import FeatureDep, SampleFeatureSpec
         from metaxy.models.field import FieldSpec
 
         spec = SampleFeatureSpec(
-            key=FeatureKey("my", "complete", "feature"),
+            key=FeatureKey(["my", "complete", "feature"]),
             deps=[
-                FeatureDep(feature=FeatureKey("upstream", "one")),
-                FeatureDep(feature=FeatureKey("upstream", "two")),
+                FeatureDep(feature=FeatureKey(["upstream", "one"])),
+                FeatureDep(feature=FeatureKey(["upstream", "two"])),
             ],
             fields=[
-                FieldSpec(key=FieldKey("field", "one"), code_version="1"),
-                FieldSpec(key=FieldKey("field", "two"), code_version="1"),
+                FieldSpec(key=FieldKey(["field", "one"]), code_version="1"),
+                FieldSpec(key=FieldKey(["field", "two"]), code_version="1"),
             ],
         )
 


### PR DESCRIPTION
# Remove variadic argument format from FeatureKey and FieldKey

This PR removes the variadic argument format (`FeatureKey("prefix", "feature")`) from the `FeatureKey` and `FieldKey` classes to simplify the API and reduce potential confusion. The remaining supported formats are:

1. String format with separator: `FeatureKey("prefix/feature")`
2. Sequence format: `FeatureKey(["prefix", "feature"])`
3. Copy constructor: `FeatureKey(another_feature_key)`

The implementation now explicitly rejects multiple positional arguments with a clear error message. This change makes the API more consistent and easier to understand, while still providing flexible initialization options.

Documentation and tests have been updated to reflect this change.