### PR TITLE
[config] auto-load config for sqlalchemy and sqlmodel integrations

### DIFF
--- a/src/metaxy/config.py
+++ b/src/metaxy/config.py
@@ -451,16 +451,23 @@ class MetaxyConfig(BaseSettings):
         return (init_settings, env_settings, toml_settings)
 
     @classmethod
-    def get(cls, *, _allow_default_config: bool = False) -> "MetaxyConfig":
+    def get(
+        cls, *, load: bool = False, _allow_default_config: bool = False
+    ) -> "MetaxyConfig":
         """Get the current Metaxy configuration.
 
         Args:
+            load: If True and config is not set, calls `MetaxyConfig.load()` to
+                load configuration from file. Useful for plugins that need config
+                but don't want to require manual initialization.
             _allow_default_config: Internal parameter. When True, returns default
                 config without warning if global config is not set. Used by methods
                 like `get_plugin` that may be called at import time.
         """
         cfg = _metaxy_config.get()
         if cfg is None:
+            if load:
+                return cls.load()
             if not _allow_default_config:
                 warnings.warn(
                     UserWarning(

--- a/src/metaxy/ext/sqlalchemy/plugin.py
+++ b/src/metaxy/ext/sqlalchemy/plugin.py
@@ -207,7 +207,7 @@ def _get_features_metadata(
     """
     from metaxy.models.feature import FeatureGraph
 
-    config = MetaxyConfig.get()
+    config = MetaxyConfig.get(load=True)
 
     if project is None:
         project = config.project

--- a/src/metaxy/ext/sqlmodel/plugin.py
+++ b/src/metaxy/ext/sqlmodel/plugin.py
@@ -466,7 +466,7 @@ def filter_feature_sqlmodel_metadata(
 
     from metaxy.ext.sqlalchemy.plugin import _get_store_sqlalchemy_url
 
-    config = MetaxyConfig.get()
+    config = MetaxyConfig.get(load=True)
 
     if project is None:
         project = config.project


### PR DESCRIPTION
I think auto-loading the config should probably become the default behavior in the future. 

For now I'm not sure about it, so I decided to minimize the possible blast radius by limiting auto-loading to plugins that require the config at import-time only (since there is no other way for the user to set it at that point of time). 

Unfortunately, as a library, we don't really have a well-defined entrypoint and cannot enforce certain actions from our users. 