### PR TITLE
streamline pre-commits on osx

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
       pass_filenames: false
     - id: build-docs
       name: Build Docs
-      entry: uv run --group docs mkdocs build --strict
+      entry: nix develop --command uv run --group docs mkdocs build --strict
       language: system
       pass_filenames: false
       files: ^(src/|docs/|pyproject\.toml|uv\.lock|mkdocs\.yml|\.pre-commit-config\.yaml)


### PR DESCRIPTION
still faced additional problems on osx with gits subprocess not inheriting the activated nix env.

this fixes it