### PR TITLE
Add cascade feature traversal methods to FeatureGraph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ devenv.local.yaml
 # direnv
 .devenv/
 .devenv.flake.nix
+docs/slides/node_modules/

--- a/src/metaxy/__init__.py
+++ b/src/metaxy/__init__.py
@@ -52,6 +52,7 @@ from metaxy.models.fields_mapping import (
 )
 from metaxy.models.lineage import LineageRelationship
 from metaxy.models.types import (
+    CascadeMode,
     CoercibleToFeatureKey,
     CoercibleToFieldKey,
     FeatureDepMetadata,
@@ -151,6 +152,7 @@ def init(
 __all__ = [
     "BufferedMetadataWriter",
     "BaseFeature",
+    "CascadeMode",
     "experimental",
     "FeatureDefinition",
     "FeatureGraph",

--- a/src/metaxy/models/feature.py
+++ b/src/metaxy/models/feature.py
@@ -21,6 +21,7 @@ from metaxy.models.feature_spec import (
 )
 from metaxy.models.plan import FeaturePlan, FQFieldKey
 from metaxy.models.types import (
+    CascadeMode,
     CoercibleToFeatureKey,
     FeatureKey,
     ValidatedFeatureKeyAdapter,
@@ -371,25 +372,30 @@ class FeatureGraph:
         validated_sources = ValidatedFeatureKeySequenceAdapter.validate_python(sources)
 
         source_set = set(validated_sources)
-        visited = set()
-        post_order = []
-        source_set = set(sources)
-        visited = set()
-        post_order = []  # Reverse topological order
+        visited: set[FeatureKey] = set()
+        post_order: list[FeatureKey] = []
 
-        def visit(key: FeatureKey):
+        # Build reverse dependency index for efficient lookup: feature_key -> list of dependents
+        # This avoids O(V) scans per node during traversal
+        reverse_deps: dict[FeatureKey, list[FeatureKey]] = {}
+        for feature_key, definition in self.feature_definitions_by_key.items():
+            if definition.spec.deps:
+                for dep in definition.spec.deps:
+                    dep_key = dep.feature
+                    if dep_key not in reverse_deps:
+                        reverse_deps[dep_key] = []
+                    reverse_deps[dep_key].append(feature_key)
+
+        def visit(key: FeatureKey) -> None:
             """DFS traversal."""
             if key in visited:
                 return
             visited.add(key)
 
-            # Find all features that depend on this one
-            for feature_key, definition in self.feature_definitions_by_key.items():
-                if definition.spec.deps:
-                    for dep in definition.spec.deps:
-                        if dep.feature == key:
-                            # This feature depends on 'key', so visit it
-                            visit(feature_key)
+            # Use the pre-built reverse dependency index for O(1) lookup
+            if key in reverse_deps:
+                for dependent in reverse_deps[key]:
+                    visit(dependent)
 
             post_order.append(key)
 
@@ -400,6 +406,137 @@ class FeatureGraph:
         # Remove sources from result, reverse to get topological order
         result = [k for k in reversed(post_order) if k not in source_set]
         return result
+
+    def get_upstream_features(self, sources: Sequence[CoercibleToFeatureKey]) -> list[FeatureKey]:
+        """Get all features upstream of sources (their dependencies), topologically sorted.
+
+        Performs a depth-first traversal of the dependency graph to find all
+        features that the source features transitively depend on.
+
+        Args:
+            sources: List of source feature keys. Each element can be string, sequence, FeatureKey, or BaseFeature class.
+
+        Returns:
+            List of upstream feature keys in topological order (dependencies first).
+            Does not include the source features themselves unless they are dependencies of other sources.
+
+        Example:
+            ```py
+            # DAG: a -> b -> d
+            #      a -> c -> d
+            graph.get_upstream_features([FeatureKey(["d"])])
+            # [FeatureKey(["a"]), FeatureKey(["b"]), FeatureKey(["c"])]
+
+            # Or use string notation
+            graph.get_upstream_features(["d"])
+            ```
+        """
+        validated_sources = ValidatedFeatureKeySequenceAdapter.validate_python(sources)
+
+        visited: set[FeatureKey] = set()
+        post_order: list[FeatureKey] = []
+
+        def visit(key: FeatureKey) -> None:
+            """DFS traversal following dependencies (upstream)."""
+            if key in visited:
+                return
+            visited.add(key)
+
+            definition = self.feature_definitions_by_key.get(key)
+            if definition and definition.spec.deps:
+                for dep in definition.spec.deps:
+                    visit(dep.feature)
+
+            post_order.append(key)
+
+        # Start DFS from the dependencies of each source, not from the sources themselves.
+        # This naturally excludes sources unless they're reached as dependencies of another source.
+        for source in validated_sources:
+            definition = self.feature_definitions_by_key.get(source)
+            if definition and definition.spec.deps:
+                for dep in definition.spec.deps:
+                    visit(dep.feature)
+
+        return post_order
+
+    def get_cascade_features(
+        self,
+        source: CoercibleToFeatureKey,
+        cascade: CascadeMode | str,
+    ) -> list[FeatureKey]:
+        """Get features to process for cascade operations.
+
+        Determines the ordered list of features based on cascade direction.
+
+        Args:
+            source: Source feature key. Can be string, sequence, FeatureKey, or BaseFeature class.
+            cascade: Cascade mode determining which features to include. Can be:
+                - CascadeMode.NONE or "none": Only the source feature
+                - CascadeMode.DOWNSTREAM or "downstream": Get dependents, order leaf-first (for deletion)
+                - CascadeMode.UPSTREAM or "upstream": Get dependencies, order root-first
+                - CascadeMode.BOTH or "both": Get both upstream and downstream
+
+        Returns:
+            List of feature keys in topological order appropriate for the cascade direction.
+            Includes the source feature.
+
+        Raises:
+            ValueError: If cascade is not a valid option.
+
+        Example:
+            ```py
+            from metaxy.models.types import CascadeMode
+
+            # DAG: a -> b -> c
+            graph.get_cascade_features("b", CascadeMode.DOWNSTREAM)
+            # [FeatureKey(["c"]), FeatureKey(["b"])]  # dependents first
+
+            graph.get_cascade_features("b", "upstream")
+            # [FeatureKey(["a"]), FeatureKey(["b"])]  # dependencies first
+
+            graph.get_cascade_features("b", CascadeMode.NONE)
+            # [FeatureKey(["b"])]  # only source
+            ```
+        """
+        # Convert string to CascadeMode if needed
+        if isinstance(cascade, str):
+            try:
+                cascade_mode = CascadeMode(cascade.lower())
+            except ValueError:
+                valid_options = [mode.value for mode in CascadeMode]
+                raise ValueError(
+                    f"Invalid cascade option: '{cascade}'. Valid options: {', '.join(valid_options)}"
+                ) from None
+        else:
+            if not isinstance(cascade, CascadeMode):
+                valid_options = [mode.value for mode in CascadeMode]
+                raise ValueError(
+                    f"Invalid cascade option type: {type(cascade)!r}. "
+                    f"Expected CascadeMode or str with one of: {', '.join(valid_options)}"
+                )
+            cascade_mode = cascade
+
+        # Validate and coerce the source key
+        validated_source = ValidatedFeatureKeyAdapter.validate_python(source)
+
+        if cascade_mode == CascadeMode.NONE:
+            return [validated_source]
+
+        if cascade_mode == CascadeMode.DOWNSTREAM:
+            downstream = self.get_downstream_features([validated_source])
+            features = downstream + [validated_source]
+            return self.topological_sort_features(features, descending=True)
+
+        if cascade_mode == CascadeMode.UPSTREAM:
+            upstream = self.get_upstream_features([validated_source])
+            features = upstream + [validated_source]
+            return self.topological_sort_features(features, descending=False)
+
+        # cascade_mode == CascadeMode.BOTH
+        upstream = self.get_upstream_features([validated_source])
+        downstream = self.get_downstream_features([validated_source])
+        features = upstream + [validated_source] + downstream
+        return self.topological_sort_features(features, descending=False)
 
     def topological_sort_features(
         self,
@@ -484,6 +621,63 @@ class FeatureGraph:
         if descending:
             return list(reversed(result))
         return result
+
+    def get_cascade_deletion_order(
+        self,
+        feature_key: FeatureKey,
+        cascade: CascadeMode,
+    ) -> list[FeatureKey]:
+        """Get features to delete in cascade order.
+
+        Determines which features to delete based on cascade mode and returns them
+        in the correct deletion order (dependents before dependencies for safe deletion).
+
+        Args:
+            feature_key: The primary feature to delete
+            cascade: Cascade mode determining which related features to include
+
+        Returns:
+            List of features in deletion order (dependents first, dependencies last)
+
+        Example:
+            ```py
+            graph = FeatureGraph.get_active()
+            # Get deletion order for downstream cascade
+            features = graph.get_cascade_deletion_order(FeatureKey(["video", "raw"]), CascadeMode.DOWNSTREAM)
+            ```
+        """
+        features_to_delete: list[FeatureKey] = []
+
+        if cascade == CascadeMode.DOWNSTREAM:
+            # Get all downstream features (dependents)
+            downstream = self.get_downstream_features([feature_key])
+            # Include self
+            features_to_delete = downstream + [feature_key]
+            # Sort in reverse topological order for safe deletion (dependents before dependencies)
+            features_to_delete = self.topological_sort_features(features_to_delete, descending=True)
+
+        elif cascade == CascadeMode.UPSTREAM:
+            # Get all upstream features (dependencies) recursively
+            upstream = self.get_upstream_features([feature_key])
+            # Include self
+            features_to_delete = upstream + [feature_key]
+            # Sort in reverse topological order for safe deletion (dependents before dependencies)
+            features_to_delete = self.topological_sort_features(features_to_delete, descending=True)
+
+        elif cascade == CascadeMode.BOTH:
+            # Get both upstream and downstream
+            upstream_keys = self.get_upstream_features([feature_key])
+            downstream_keys = self.get_downstream_features([feature_key])
+
+            # Combine: dependents -> self -> deps
+            features_to_delete = downstream_keys + [feature_key] + upstream_keys
+            # Sort in reverse topological order for safe deletion (dependents before dependencies)
+            features_to_delete = self.topological_sort_features(features_to_delete, descending=True)
+
+        else:  # CascadeMode.NONE
+            features_to_delete = [feature_key]
+
+        return features_to_delete
 
     def _compute_project_version(
         self,

--- a/src/metaxy/models/types.py
+++ b/src/metaxy/models/types.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator, Sequence
+from enum import Enum
 from typing import (
     TYPE_CHECKING,
     Annotated,
@@ -27,6 +28,23 @@ from metaxy._decorators import public
 
 if TYPE_CHECKING:
     from typing_extensions import Self
+
+
+class CascadeMode(str, Enum):
+    """Cascade mode for deletion operations.
+
+    Attributes:
+        NONE: No cascading - only delete the specified feature
+        DOWNSTREAM: Cascade to dependents (features that depend on the selected feature)
+        UPSTREAM: Cascade to dependencies (features that the selected feature depends on)
+        BOTH: Cascade to both dependencies and dependents
+    """
+
+    NONE = "none"
+    DOWNSTREAM = "downstream"
+    UPSTREAM = "upstream"
+    BOTH = "both"
+
 
 KEY_SEPARATOR = "/"
 

--- a/tests/models/conftest.py
+++ b/tests/models/conftest.py
@@ -2,11 +2,101 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 import pytest
 from metaxy_testing.models import SampleFeatureSpec
 
-from metaxy import BaseFeature, FeatureKey, FieldKey, FieldSpec
+from metaxy import BaseFeature, FeatureDep, FeatureKey, FieldKey, FieldSpec
 from metaxy.models.feature import FeatureGraph
+
+
+@pytest.fixture
+def feature_factory(graph: FeatureGraph) -> Callable[[str, list[type[BaseFeature]] | None], type[BaseFeature]]:
+    """Factory fixture for creating simple test features with minimal boilerplate.
+
+    Args:
+        name: Name for the feature (used in the feature key; field key is fixed as 'x')
+        deps: Optional list of feature classes this feature depends on
+
+    Returns:
+        Feature class
+
+    Example:
+        def test_example(feature_factory):
+            a = feature_factory("a")
+            b = feature_factory("b", deps=[a])
+            c = feature_factory("c", deps=[b])
+    """
+
+    def _create_feature(name: str, deps: list[type[BaseFeature]] | None = None) -> type[BaseFeature]:
+        feature_deps = [FeatureDep(feature=dep) for dep in (deps or [])]
+
+        class TestFeature(
+            BaseFeature,
+            spec=SampleFeatureSpec(
+                key=FeatureKey([name]),
+                fields=[FieldSpec(key=FieldKey(["x"]))],
+                deps=feature_deps,
+            ),
+        ):
+            pass
+
+        return TestFeature
+
+    return _create_feature
+
+
+@pytest.fixture
+def linear_chain(feature_factory) -> dict[str, type[BaseFeature]]:
+    """Create a linear dependency chain: a -> b -> c.
+
+    Returns:
+        Dictionary with keys 'a', 'b', 'c'
+    """
+    a = feature_factory("a")
+    b = feature_factory("b", deps=[a])
+    c = feature_factory("c", deps=[b])
+
+    return {"a": a, "b": b, "c": c}
+
+
+@pytest.fixture
+def diamond_graph(feature_factory) -> dict[str, type[BaseFeature]]:
+    """Create a diamond dependency pattern: a -> b, a -> c, b -> d, c -> d.
+
+    Returns:
+        Dictionary with keys 'a', 'b', 'c', 'd'
+    """
+    a = feature_factory("a")
+    b = feature_factory("b", deps=[a])
+    c = feature_factory("c", deps=[a])
+    d = feature_factory("d", deps=[b, c])
+
+    return {"a": a, "b": b, "c": c, "d": d}
+
+
+@pytest.fixture
+def multi_level_graph(feature_factory) -> dict[str, type[BaseFeature]]:
+    """Create a multi-level graph with multiple branches.
+
+    Structure:
+        a -> b -> d
+        a -> c -> e
+        d -> f
+        e -> f
+
+    Returns:
+        Dictionary with keys 'a', 'b', 'c', 'd', 'e', 'f'
+    """
+    a = feature_factory("a")
+    b = feature_factory("b", deps=[a])
+    c = feature_factory("c", deps=[a])
+    d = feature_factory("d", deps=[b])
+    e = feature_factory("e", deps=[c])
+    f = feature_factory("f", deps=[d, e])
+
+    return {"a": a, "b": b, "c": c, "d": d, "e": e, "f": f}
 
 
 @pytest.fixture

--- a/tests/models/test_feature_graph.py
+++ b/tests/models/test_feature_graph.py
@@ -18,6 +18,7 @@ from metaxy_testing.models import SampleFeatureSpec
 
 from metaxy import (
     BaseFeature,
+    CascadeMode,
     FeatureDefinition,
     FeatureDep,
     FeatureGraph,
@@ -121,99 +122,33 @@ class TestAddFeature:
 class TestBasicTopologicalSorting:
     """Test basic topological sorting scenarios."""
 
-    def test_simple_linear_chain(self, graph: FeatureGraph):
+    def test_simple_linear_chain(self, graph: FeatureGraph, linear_chain):
         """Test sorting a simple linear dependency chain A -> B -> C."""
-
-        class FeatureA(
-            BaseFeature,
-            spec=SampleFeatureSpec(
-                key=FeatureKey(["test", "a"]),
-                fields=[FieldSpec(key=FieldKey(["x"]))],
-            ),
-        ):
-            pass
-
-        class FeatureB(
-            BaseFeature,
-            spec=SampleFeatureSpec(
-                key=FeatureKey(["test", "b"]),
-                fields=[FieldSpec(key=FieldKey(["y"]))],
-                deps=[FeatureDep(feature=FeatureA)],
-            ),
-        ):
-            pass
-
-        class FeatureC(
-            BaseFeature,
-            spec=SampleFeatureSpec(
-                key=FeatureKey(["test", "c"]),
-                fields=[FieldSpec(key=FieldKey(["z"]))],
-                deps=[FeatureDep(feature=FeatureB)],
-            ),
-        ):
-            pass
+        a, b, c = linear_chain["a"], linear_chain["b"], linear_chain["c"]
 
         # Sort all features
         sorted_keys = graph.topological_sort_features()
 
         # Verify order: A before B before C
         assert len(sorted_keys) == 3
-        a_idx = sorted_keys.index(FeatureA.spec().key)
-        b_idx = sorted_keys.index(FeatureB.spec().key)
-        c_idx = sorted_keys.index(FeatureC.spec().key)
+        a_idx = sorted_keys.index(a.spec().key)
+        b_idx = sorted_keys.index(b.spec().key)
+        c_idx = sorted_keys.index(c.spec().key)
 
         assert a_idx < b_idx < c_idx
 
-    def test_diamond_dependency(self, graph: FeatureGraph):
+    def test_diamond_dependency(self, graph: FeatureGraph, diamond_graph):
         """Test sorting a diamond dependency pattern: A -> B, A -> C, B -> D, C -> D."""
-
-        class FeatureA(
-            BaseFeature,
-            spec=SampleFeatureSpec(
-                key=FeatureKey(["test", "a"]),
-                fields=[FieldSpec(key=FieldKey(["x"]))],
-            ),
-        ):
-            pass
-
-        class FeatureB(
-            BaseFeature,
-            spec=SampleFeatureSpec(
-                key=FeatureKey(["test", "b"]),
-                fields=[FieldSpec(key=FieldKey(["y"]))],
-                deps=[FeatureDep(feature=FeatureA)],
-            ),
-        ):
-            pass
-
-        class FeatureC(
-            BaseFeature,
-            spec=SampleFeatureSpec(
-                key=FeatureKey(["test", "c"]),
-                fields=[FieldSpec(key=FieldKey(["z"]))],
-                deps=[FeatureDep(feature=FeatureA)],
-            ),
-        ):
-            pass
-
-        class FeatureD(
-            BaseFeature,
-            spec=SampleFeatureSpec(
-                key=FeatureKey(["test", "d"]),
-                fields=[FieldSpec(key=FieldKey(["w"]))],
-                deps=[FeatureDep(feature=FeatureB), FeatureDep(feature=FeatureC)],
-            ),
-        ):
-            pass
+        a, b, c, d = diamond_graph["a"], diamond_graph["b"], diamond_graph["c"], diamond_graph["d"]
 
         sorted_keys = graph.topological_sort_features()
 
         # Verify dependencies appear before dependents
         assert len(sorted_keys) == 4
-        a_idx = sorted_keys.index(FeatureA.spec().key)
-        b_idx = sorted_keys.index(FeatureB.spec().key)
-        c_idx = sorted_keys.index(FeatureC.spec().key)
-        d_idx = sorted_keys.index(FeatureD.spec().key)
+        a_idx = sorted_keys.index(a.spec().key)
+        b_idx = sorted_keys.index(b.spec().key)
+        c_idx = sorted_keys.index(c.spec().key)
+        d_idx = sorted_keys.index(d.spec().key)
 
         # A must come before B and C
         assert a_idx < b_idx
@@ -1675,3 +1610,608 @@ class TestExternalProvenanceOverride:
         )
         assert computed_version != "manual_hash"
         assert len(computed_version) > 0  # Has a computed hash
+
+
+class TestGetCascadeFeatures:
+    """Tests for FeatureGraph.get_cascade_features method."""
+
+    def test_cascade_downstream_linear_chain(self, graph: FeatureGraph, linear_chain):
+        """Test downstream cascade on a linear dependency chain."""
+        a, b, c = linear_chain["a"], linear_chain["b"], linear_chain["c"]
+
+        # Cascade downstream from A should get [C, B, A] (leaf first)
+        result = graph.get_cascade_features("a", "downstream")
+        assert len(result) == 3
+        assert result == [c.spec().key, b.spec().key, a.spec().key]
+
+    def test_cascade_upstream_linear_chain(self, graph: FeatureGraph, linear_chain):
+        """Test upstream cascade on a linear dependency chain."""
+        a, b, c = linear_chain["a"], linear_chain["b"], linear_chain["c"]
+
+        # Cascade upstream from C should get [A, B, C] (root first)
+        result = graph.get_cascade_features("c", "upstream")
+        assert len(result) == 3
+        assert result == [a.spec().key, b.spec().key, c.spec().key]
+
+    def test_cascade_both_linear_chain(self, graph: FeatureGraph, linear_chain):
+        """Test both cascade directions on a linear chain."""
+        a, b, c = linear_chain["a"], linear_chain["b"], linear_chain["c"]
+
+        # Cascade both from B should get [A, B, C] (dependencies first, then self, then dependents)
+        result = graph.get_cascade_features("b", "both")
+        assert len(result) == 3
+        assert result == [a.spec().key, b.spec().key, c.spec().key]
+
+    def test_cascade_downstream_diamond_pattern(self, graph: FeatureGraph, diamond_graph):
+        """Test downstream cascade on diamond dependency pattern."""
+        a, b, c, d = diamond_graph["a"], diamond_graph["b"], diamond_graph["c"], diamond_graph["d"]
+
+        # Cascade downstream from A should include all features, with D before B and C
+        result = graph.get_cascade_features("a", "downstream")
+        assert len(result) == 4
+        assert a.spec().key in result
+        assert b.spec().key in result
+        assert c.spec().key in result
+        assert d.spec().key in result
+
+        # D should come before B and C (leaf first)
+        d_idx = result.index(d.spec().key)
+        b_idx = result.index(b.spec().key)
+        c_idx = result.index(c.spec().key)
+        a_idx = result.index(a.spec().key)
+        assert d_idx < b_idx
+        assert d_idx < c_idx
+        # A should be last (root)
+        assert a_idx == len(result) - 1
+
+    def test_cascade_upstream_diamond_pattern(self, graph: FeatureGraph, diamond_graph):
+        """Test upstream cascade on diamond dependency pattern."""
+        a, b, c, d = diamond_graph["a"], diamond_graph["b"], diamond_graph["c"], diamond_graph["d"]
+
+        # Cascade upstream from D should include A, B, C in dependency order
+        result = graph.get_cascade_features("d", "upstream")
+        assert len(result) == 4
+        assert a.spec().key in result
+        assert b.spec().key in result
+        assert c.spec().key in result
+        assert d.spec().key in result
+
+        # A should come before B and C (root first)
+        a_idx = result.index(a.spec().key)
+        b_idx = result.index(b.spec().key)
+        c_idx = result.index(c.spec().key)
+        d_idx = result.index(d.spec().key)
+        assert a_idx < b_idx
+        assert a_idx < c_idx
+        # D should be last
+        assert d_idx == len(result) - 1
+
+    def test_cascade_source_included(self, graph: FeatureGraph):
+        """Test that source feature is always included in result."""
+
+        class FeatureA(
+            BaseFeature,
+            spec=SampleFeatureSpec(
+                key=FeatureKey(["a"]),
+                fields=[FieldSpec(key=FieldKey(["x"]))],
+            ),
+        ):
+            pass
+
+        # Downstream from A (no dependents)
+        result = graph.get_cascade_features("a", "downstream")
+        assert len(result) == 1
+        assert result == [FeatureA.spec().key]
+
+        # Upstream from A (no dependencies)
+        result = graph.get_cascade_features("a", "upstream")
+        assert len(result) == 1
+        assert result == [FeatureA.spec().key]
+
+        # Both from A
+        result = graph.get_cascade_features("a", "both")
+        assert len(result) == 1
+        assert result == [FeatureA.spec().key]
+
+    def test_cascade_invalid_direction_raises_error(self, graph: FeatureGraph):
+        """Test that invalid cascade direction raises ValueError."""
+
+        class FeatureA(
+            BaseFeature,
+            spec=SampleFeatureSpec(
+                key=FeatureKey(["a"]),
+                fields=[FieldSpec(key=FieldKey(["x"]))],
+            ),
+        ):
+            pass
+
+        with pytest.raises(ValueError, match="Invalid cascade option: 'invalid'"):
+            graph.get_cascade_features("a", "invalid")
+
+        with pytest.raises(ValueError, match="Invalid cascade option: ''"):
+            graph.get_cascade_features("a", "")
+
+    def test_cascade_with_string_key(self, graph: FeatureGraph):
+        """Test cascade with string key notation."""
+
+        class FeatureA(
+            BaseFeature,
+            spec=SampleFeatureSpec(
+                key=FeatureKey(["video", "raw"]),
+                fields=[FieldSpec(key=FieldKey(["x"]))],
+            ),
+        ):
+            pass
+
+        class FeatureB(
+            BaseFeature,
+            spec=SampleFeatureSpec(
+                key=FeatureKey(["video", "processed"]),
+                fields=[FieldSpec(key=FieldKey(["x"]))],
+                deps=[FeatureDep(feature=FeatureA)],
+            ),
+        ):
+            pass
+
+        # Use string notation
+        result = graph.get_cascade_features("video/raw", "downstream")
+        assert len(result) == 2
+        assert FeatureB.spec().key in result
+        assert FeatureA.spec().key in result
+
+    def test_cascade_no_dependents(self, graph: FeatureGraph):
+        """Test downstream cascade on a leaf node (no dependents)."""
+
+        # DAG: A -> B -> C (C is leaf)
+        class FeatureA(
+            BaseFeature,
+            spec=SampleFeatureSpec(
+                key=FeatureKey(["a"]),
+                fields=[FieldSpec(key=FieldKey(["x"]))],
+            ),
+        ):
+            pass
+
+        class FeatureB(
+            BaseFeature,
+            spec=SampleFeatureSpec(
+                key=FeatureKey(["b"]),
+                fields=[FieldSpec(key=FieldKey(["x"]))],
+                deps=[FeatureDep(feature=FeatureA)],
+            ),
+        ):
+            pass
+
+        class FeatureC(
+            BaseFeature,
+            spec=SampleFeatureSpec(
+                key=FeatureKey(["c"]),
+                fields=[FieldSpec(key=FieldKey(["x"]))],
+                deps=[FeatureDep(feature=FeatureB)],
+            ),
+        ):
+            pass
+
+        # Cascade downstream from C (leaf node)
+        result = graph.get_cascade_features("c", "downstream")
+        assert len(result) == 1
+        assert result == [FeatureC.spec().key]
+
+    def test_cascade_no_dependencies(self, graph: FeatureGraph):
+        """Test upstream cascade on a root node (no dependencies)."""
+
+        # DAG: A -> B -> C (A is root)
+        class FeatureA(
+            BaseFeature,
+            spec=SampleFeatureSpec(
+                key=FeatureKey(["a"]),
+                fields=[FieldSpec(key=FieldKey(["x"]))],
+            ),
+        ):
+            pass
+
+        class FeatureB(
+            BaseFeature,
+            spec=SampleFeatureSpec(
+                key=FeatureKey(["b"]),
+                fields=[FieldSpec(key=FieldKey(["x"]))],
+                deps=[FeatureDep(feature=FeatureA)],
+            ),
+        ):
+            pass
+
+        class FeatureC(
+            BaseFeature,
+            spec=SampleFeatureSpec(
+                key=FeatureKey(["c"]),
+                fields=[FieldSpec(key=FieldKey(["x"]))],
+                deps=[FeatureDep(feature=FeatureB)],
+            ),
+        ):
+            pass
+
+        # Cascade upstream from A (root node)
+        result = graph.get_cascade_features("a", "upstream")
+        assert len(result) == 1
+        assert result == [FeatureA.spec().key]
+
+    def test_cascade_none_mode(self, graph: FeatureGraph, linear_chain):
+        """Test NONE cascade mode returns only the source feature."""
+        b = linear_chain["b"]
+
+        # Test with CascadeMode enum
+        result = graph.get_cascade_features("b", CascadeMode.NONE)
+        assert len(result) == 1
+        assert result == [b.spec().key]
+
+        # Test with string "none"
+        result_str = graph.get_cascade_features("b", "none")
+        assert result_str == result
+
+    def test_cascade_with_enum(self, graph: FeatureGraph, linear_chain):
+        """Test cascade with CascadeMode enum instead of strings."""
+        a, b, c = linear_chain["a"], linear_chain["b"], linear_chain["c"]
+
+        # Test DOWNSTREAM with enum
+        result = graph.get_cascade_features("a", CascadeMode.DOWNSTREAM)
+        assert result == [c.spec().key, b.spec().key, a.spec().key]
+
+        # Test UPSTREAM with enum
+        result = graph.get_cascade_features("c", CascadeMode.UPSTREAM)
+        assert result == [a.spec().key, b.spec().key, c.spec().key]
+
+        # Test BOTH with enum
+        result = graph.get_cascade_features("b", CascadeMode.BOTH)
+        assert result == [a.spec().key, b.spec().key, c.spec().key]
+
+    def test_cascade_case_insensitive_strings(self, graph: FeatureGraph, linear_chain):
+        """Test that cascade string arguments are case-insensitive."""
+        a, b, c = linear_chain["a"], linear_chain["b"], linear_chain["c"]
+
+        # Test various case combinations
+        result_lower = graph.get_cascade_features("a", "downstream")
+        result_upper = graph.get_cascade_features("a", "DOWNSTREAM")
+        result_mixed = graph.get_cascade_features("a", "DownStream")
+
+        assert result_lower == result_upper == result_mixed
+        assert result_lower == [c.spec().key, b.spec().key, a.spec().key]
+
+    def test_cascade_invalid_string_raises(self, graph: FeatureGraph, linear_chain):
+        """Test that invalid cascade strings raise helpful error."""
+        with pytest.raises(ValueError, match="Invalid cascade option"):
+            graph.get_cascade_features("a", "invalid")
+
+        # Error message should suggest valid options
+        with pytest.raises(ValueError, match="none.*downstream.*upstream.*both"):
+            graph.get_cascade_features("a", "bad_mode")
+
+
+class TestGetCascadeDeletionOrder:
+    """Tests for FeatureGraph.get_cascade_deletion_order method."""
+
+    def test_deletion_order_none(self, graph: FeatureGraph, linear_chain):
+        """Test NONE mode returns only the source feature."""
+        b = linear_chain["b"]
+
+        result = graph.get_cascade_deletion_order(b.spec().key, CascadeMode.NONE)
+        assert result == [b.spec().key]
+
+    def test_deletion_order_downstream(self, graph: FeatureGraph, linear_chain):
+        """Test DOWNSTREAM mode includes dependents in deletion order (leaf-first)."""
+        a, b, c = linear_chain["a"], linear_chain["b"], linear_chain["c"]
+
+        # Delete A (which has B and C as downstream dependents)
+        result = graph.get_cascade_deletion_order(a.spec().key, CascadeMode.DOWNSTREAM)
+
+        # Should include A, B, C with dependents first (C -> B -> A)
+        assert len(result) == 3
+        assert result == [c.spec().key, b.spec().key, a.spec().key]
+
+    def test_deletion_order_upstream(self, graph: FeatureGraph, linear_chain):
+        """Test UPSTREAM mode includes dependencies in deletion order (dependent-first)."""
+        a, b, c = linear_chain["a"], linear_chain["b"], linear_chain["c"]
+
+        # Delete C (which has B and A as upstream dependencies)
+        result = graph.get_cascade_deletion_order(c.spec().key, CascadeMode.UPSTREAM)
+
+        # Should include A, B, C with dependents first (C -> B -> A)
+        assert len(result) == 3
+        assert result == [c.spec().key, b.spec().key, a.spec().key]
+
+    def test_deletion_order_both(self, graph: FeatureGraph, linear_chain):
+        """Test BOTH mode includes both dependencies and dependents."""
+        a, b, c = linear_chain["a"], linear_chain["b"], linear_chain["c"]
+
+        # Delete B (middle node)
+        result = graph.get_cascade_deletion_order(b.spec().key, CascadeMode.BOTH)
+
+        # Should include all features (C -> B -> A for safe deletion)
+        assert len(result) == 3
+        assert result == [c.spec().key, b.spec().key, a.spec().key]
+
+    def test_deletion_order_diamond(self, graph: FeatureGraph, diamond_graph):
+        """Test deletion order with diamond dependency pattern."""
+        a, b, c, d = diamond_graph["a"], diamond_graph["b"], diamond_graph["c"], diamond_graph["d"]
+
+        # Delete A (root) with downstream cascade
+        result = graph.get_cascade_deletion_order(a.spec().key, CascadeMode.DOWNSTREAM)
+
+        # All features should be included
+        assert len(result) == 4
+        assert set(result) == {a.spec().key, b.spec().key, c.spec().key, d.spec().key}
+
+        # D must come before B and C (leaf first)
+        d_idx = result.index(d.spec().key)
+        b_idx = result.index(b.spec().key)
+        c_idx = result.index(c.spec().key)
+        a_idx = result.index(a.spec().key)
+
+        assert d_idx < b_idx
+        assert d_idx < c_idx
+        assert b_idx < a_idx
+        assert c_idx < a_idx
+
+    def test_deletion_order_upstream_diamond(self, graph: FeatureGraph, diamond_graph):
+        """Test upstream deletion order with diamond pattern."""
+        a = diamond_graph["a"]
+        d = diamond_graph["d"]
+
+        # Delete D (leaf) with upstream cascade
+        result = graph.get_cascade_deletion_order(d.spec().key, CascadeMode.UPSTREAM)
+
+        # All features should be included
+        assert len(result) == 4
+
+        # D must come first (dependents before dependencies)
+        assert result[0] == d.spec().key
+
+        # A must come last (root)
+        assert result[-1] == a.spec().key
+
+
+class TestGetUpstreamFeatures:
+    """Tests for FeatureGraph.get_upstream_features method."""
+
+    def test_upstream_linear_chain(self, graph: FeatureGraph, linear_chain):
+        """Test upstream collection on a simple linear dependency chain."""
+        a, b, c = linear_chain["a"], linear_chain["b"], linear_chain["c"]
+
+        # Get upstream from C should return [A, B] (not C itself)
+        result = graph.get_upstream_features([c])
+        assert len(result) == 2
+        assert result == [a.spec().key, b.spec().key]
+
+        # Verify topological order: A before B
+        a_idx = result.index(a.spec().key)
+        b_idx = result.index(b.spec().key)
+        assert a_idx < b_idx
+
+    def test_upstream_diamond_pattern(self, graph: FeatureGraph, diamond_graph):
+        """Test upstream collection handles diamond patterns correctly."""
+        a, b, c, d = diamond_graph["a"], diamond_graph["b"], diamond_graph["c"], diamond_graph["d"]
+
+        # Get upstream from D should return [A, B, C]
+        result = graph.get_upstream_features([d])
+        assert len(result) == 3
+        assert a.spec().key in result
+        assert b.spec().key in result
+        assert c.spec().key in result
+
+        # A should appear only once (no duplicates)
+        assert result.count(a.spec().key) == 1
+
+        # A should come before both B and C (topological order)
+        a_idx = result.index(a.spec().key)
+        b_idx = result.index(b.spec().key)
+        c_idx = result.index(c.spec().key)
+        assert a_idx < b_idx
+        assert a_idx < c_idx
+
+    def test_upstream_no_dependencies(self, graph: FeatureGraph):
+        """Test upstream collection for root features with no dependencies."""
+
+        class FeatureA(
+            BaseFeature,
+            spec=SampleFeatureSpec(
+                key=FeatureKey(["a"]),
+                fields=[FieldSpec(key=FieldKey(["x"]))],
+            ),
+        ):
+            pass
+
+        # Root feature has no upstream dependencies
+        result = graph.get_upstream_features([FeatureA])
+        assert len(result) == 0
+        assert result == []
+
+    def test_upstream_multiple_sources(self, graph: FeatureGraph):
+        """Test upstream collection with multiple source features."""
+
+        # DAG: a -> b -> c
+        #      a -> d -> e
+        class FeatureA(
+            BaseFeature,
+            spec=SampleFeatureSpec(
+                key=FeatureKey(["a"]),
+                fields=[FieldSpec(key=FieldKey(["x"]))],
+            ),
+        ):
+            pass
+
+        class FeatureB(
+            BaseFeature,
+            spec=SampleFeatureSpec(
+                key=FeatureKey(["b"]),
+                fields=[FieldSpec(key=FieldKey(["x"]))],
+                deps=[FeatureDep(feature=FeatureA)],
+            ),
+        ):
+            pass
+
+        class FeatureC(
+            BaseFeature,
+            spec=SampleFeatureSpec(
+                key=FeatureKey(["c"]),
+                fields=[FieldSpec(key=FieldKey(["x"]))],
+                deps=[FeatureDep(feature=FeatureB)],
+            ),
+        ):
+            pass
+
+        class FeatureD(
+            BaseFeature,
+            spec=SampleFeatureSpec(
+                key=FeatureKey(["d"]),
+                fields=[FieldSpec(key=FieldKey(["x"]))],
+                deps=[FeatureDep(feature=FeatureA)],
+            ),
+        ):
+            pass
+
+        class FeatureE(
+            BaseFeature,
+            spec=SampleFeatureSpec(
+                key=FeatureKey(["e"]),
+                fields=[FieldSpec(key=FieldKey(["x"]))],
+                deps=[FeatureDep(feature=FeatureD)],
+            ),
+        ):
+            pass
+
+        # Get upstream from both C and E
+        result = graph.get_upstream_features([FeatureC, FeatureE])
+
+        # Should include A, B, D (shared dependency A appears once)
+        assert len(result) == 3
+        assert FeatureA.spec().key in result
+        assert FeatureB.spec().key in result
+        assert FeatureD.spec().key in result
+
+        # A should appear only once even though both chains depend on it
+        assert result.count(FeatureA.spec().key) == 1
+
+        # A should come before B and D
+        a_idx = result.index(FeatureA.spec().key)
+        b_idx = result.index(FeatureB.spec().key)
+        d_idx = result.index(FeatureD.spec().key)
+        assert a_idx < b_idx
+        assert a_idx < d_idx
+
+    def test_upstream_with_string_keys(self, graph: FeatureGraph):
+        """Test upstream collection with string key notation."""
+
+        class FeatureA(
+            BaseFeature,
+            spec=SampleFeatureSpec(
+                key=FeatureKey(["video", "raw"]),
+                fields=[FieldSpec(key=FieldKey(["x"]))],
+            ),
+        ):
+            pass
+
+        class FeatureB(
+            BaseFeature,
+            spec=SampleFeatureSpec(
+                key=FeatureKey(["video", "processed"]),
+                fields=[FieldSpec(key=FieldKey(["x"]))],
+                deps=[FeatureDep(feature=FeatureA)],
+            ),
+        ):
+            pass
+
+        # Use string notation
+        result = graph.get_upstream_features(["video/processed"])
+        assert len(result) == 1
+        assert result == [FeatureA.spec().key]
+
+    def test_upstream_complex_multi_level(self, graph: FeatureGraph, multi_level_graph):
+        """Test upstream collection on a complex multi-level graph."""
+        a = multi_level_graph["a"]
+        b = multi_level_graph["b"]
+        c = multi_level_graph["c"]
+        d = multi_level_graph["d"]
+        e = multi_level_graph["e"]
+        f = multi_level_graph["f"]
+
+        # Get upstream from F
+        result = graph.get_upstream_features([f])
+
+        # Should include A, B, C, D, E
+        assert len(result) == 5
+        assert a.spec().key in result
+        assert b.spec().key in result
+        assert c.spec().key in result
+        assert d.spec().key in result
+        assert e.spec().key in result
+
+        # Verify topological ordering constraints
+        a_idx = result.index(a.spec().key)
+        b_idx = result.index(b.spec().key)
+        c_idx = result.index(c.spec().key)
+        d_idx = result.index(d.spec().key)
+        e_idx = result.index(e.spec().key)
+
+        # A must come before B and C
+        assert a_idx < b_idx
+        assert a_idx < c_idx
+        # B must come before D
+        assert b_idx < d_idx
+        # C must come before E
+        assert c_idx < e_idx
+
+    def test_upstream_excludes_independent_sources(self, graph: FeatureGraph):
+        """Test that source features are not added just for being sources.
+
+        Note: If one source is a dependency of another source, it WILL be included
+        in the result (as it's a true upstream dependency).
+        """
+
+        # DAG:  a -> b
+        #       a -> c
+        # (b and c are siblings, not in each other's dependency chain)
+        class FeatureA(
+            BaseFeature,
+            spec=SampleFeatureSpec(
+                key=FeatureKey(["a"]),
+                fields=[FieldSpec(key=FieldKey(["x"]))],
+            ),
+        ):
+            pass
+
+        class FeatureB(
+            BaseFeature,
+            spec=SampleFeatureSpec(
+                key=FeatureKey(["b"]),
+                fields=[FieldSpec(key=FieldKey(["x"]))],
+                deps=[FeatureDep(feature=FeatureA)],
+            ),
+        ):
+            pass
+
+        class FeatureC(
+            BaseFeature,
+            spec=SampleFeatureSpec(
+                key=FeatureKey(["c"]),
+                fields=[FieldSpec(key=FieldKey(["x"]))],
+                deps=[FeatureDep(feature=FeatureA)],
+            ),
+        ):
+            pass
+
+        # Source features B and C should not be in result (they're siblings)
+        result = graph.get_upstream_features([FeatureB, FeatureC])
+        assert FeatureB.spec().key not in result
+        assert FeatureC.spec().key not in result
+        # Only shared upstream dependency A
+        assert result == [FeatureA.spec().key]
+
+    def test_upstream_includes_source_if_dependency_of_another(self, graph: FeatureGraph, linear_chain):
+        """Test that if one source is a dependency of another source, it's included."""
+        a, b, c = linear_chain["a"], linear_chain["b"], linear_chain["c"]
+
+        # When sources are [B, C], B is a dependency of C, so it should be included
+        result = graph.get_upstream_features([b, c])
+        assert len(result) == 2
+        assert a.spec().key in result
+        assert b.spec().key in result  # B is included because C depends on it
+        assert c.spec().key not in result  # C is not a dependency of any source


### PR DESCRIPTION
[docs] refine social cards (#697)

feat: add cascade deletion support to FeatureGraph

Add topological deletion methods to FeatureGraph:
- get_downstream_features: get dependents
- get_upstream_features: get dependencies
- get_cascade_features: unified cascade interface

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>