### PR TITLE
feat: add cascade deletion to CLI

### DIFF
--- a/src/metaxy/cli/utils.py
+++ b/src/metaxy/cli/utils.py
@@ -149,6 +149,7 @@ def print_error_list(
 class CLIErrorCode(str, Enum):
     """Error codes for CLI errors."""
 
+    CASCADE_ERROR = "CASCADE_ERROR"
     CONFLICTING_FLAGS = "CONFLICTING_FLAGS"
     FEATURES_NOT_FOUND = "FEATURES_NOT_FOUND"
     GENERIC_ERROR = "GENERIC_ERROR"


### PR DESCRIPTION
Add delete_metadata command with cascade support:
- Supports downstream, upstream, and both directions
- Validates metadata store compatibility
- Comprehensive test coverage

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>