### PR TITLE
[federation] DuckDB ADBC scanner support

### DIFF
--- a/src/metaxy/metadata_store/_adbc_scanner_support.py
+++ b/src/metaxy/metadata_store/_adbc_scanner_support.py
@@ -1,0 +1,142 @@
+"""ADBC Scanner support for DuckDB federation.
+
+Experimental support for querying remote ADBC data sources from DuckDB using
+the community `adbc_scanner` extension.
+
+Warning:
+    This feature requires the DuckDB `adbc_scanner` community extension:
+    ```sql
+    INSTALL adbc_scanner FROM community;
+    LOAD adbc_scanner;
+    ```
+
+Example:
+    ```python
+    from metaxy.metadata_store import DuckDBMetadataStore
+
+    # DuckDB can query remote PostgreSQL via ADBC
+    store = DuckDBMetadataStore("local.db")
+
+    with store:
+        # Install and load extension
+        store.install_adbc_scanner()
+
+        # Connect to remote PostgreSQL
+        conn_handle = store.adbc_connect_postgres(
+            host="prod-db.example.com",
+            database="features",
+            user="readonly",
+            password="secret",
+        )
+
+        # Query remote data
+        remote_df = store.adbc_scan(
+            conn_handle,
+            "SELECT * FROM my_feature__key WHERE sample_uid < 1000"
+        )
+
+        # Disconnect
+        store.adbc_disconnect(conn_handle)
+    ```
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import narwhals as nw
+
+
+class ADBCScannerNotAvailableError(Exception):
+    """Raised when adbc_scanner extension is not available."""
+
+    pass
+
+
+def install_adbc_scanner(conn: Any) -> None:
+    """Install and load the adbc_scanner extension.
+
+    Args:
+        conn: DuckDB connection
+
+    Raises:
+        ADBCScannerNotAvailableError: If extension cannot be installed
+    """
+    try:
+        conn.execute("INSTALL adbc_scanner FROM community")
+        conn.execute("LOAD adbc_scanner")
+    except Exception as e:
+        raise ADBCScannerNotAvailableError(
+            "Failed to install adbc_scanner extension. "
+            "This is a DuckDB community extension that may not be available in all environments. "
+            f"Error: {e}"
+        ) from e
+
+
+def adbc_connect(conn: Any, options: dict[str, Any]) -> int:
+    """Connect to an ADBC data source.
+
+    Args:
+        conn: DuckDB connection
+        options: ADBC connection options (driver-specific)
+
+    Returns:
+        Connection handle (integer)
+
+    Example:
+        ```python
+        handle = adbc_connect(conn, {
+            'driver': 'postgresql',
+            'uri': 'postgresql://host:5432/db',
+        })
+        ```
+    """
+    result = conn.execute("SELECT adbc_connect(?)", [options]).fetchone()
+    if result is None:
+        raise RuntimeError("adbc_connect returned no result")
+    return result[0]
+
+
+def adbc_disconnect(conn: Any, handle: int) -> None:
+    """Disconnect from an ADBC data source.
+
+    Args:
+        conn: DuckDB connection
+        handle: Connection handle from adbc_connect()
+    """
+    conn.execute("SELECT adbc_disconnect(?)", [handle])
+
+
+def adbc_scan(conn: Any, handle: int, query: str) -> nw.DataFrame[Any]:
+    """Execute a query on an ADBC connection and return results.
+
+    Args:
+        conn: DuckDB connection
+        handle: Connection handle
+        query: SQL query to execute on the remote database
+
+    Returns:
+        Narwhals DataFrame with query results
+    """
+    import narwhals as nw
+
+    result = conn.execute("SELECT * FROM adbc_scan(?, ?)", [handle, query]).fetchdf()
+    return nw.from_native(result)
+
+
+def adbc_scan_table(conn: Any, handle: int, table_name: str) -> nw.DataFrame[Any]:
+    """Scan an entire table from an ADBC connection.
+
+    Args:
+        conn: DuckDB connection
+        handle: Connection handle
+        table_name: Name of table to scan
+
+    Returns:
+        Narwhals DataFrame with table data
+    """
+    import narwhals as nw
+
+    result = conn.execute("SELECT * FROM adbc_scan_table(?, ?)", [handle, table_name]).fetchdf()
+    return nw.from_native(result)

--- a/tests/metadata_stores/test_adbc_federation.py
+++ b/tests/metadata_stores/test_adbc_federation.py
@@ -1,0 +1,69 @@
+"""Tests for ADBC federation support via DuckDB adbc_scanner extension.
+
+Note:
+    These tests verify the API exists but don't test actual federation
+    since that would require external databases. Full integration tests
+    for federation should be added separately.
+"""
+
+import pytest
+
+from metaxy import HashAlgorithm
+from metaxy.metadata_store.duckdb import DuckDBMetadataStore
+
+
+def test_duckdb_has_adbc_scanner_methods(tmp_path):
+    """Test that DuckDB store has ADBC scanner methods."""
+    store = DuckDBMetadataStore(
+        database=tmp_path / "test.duckdb",
+        hash_algorithm=HashAlgorithm.XXHASH64,
+    )
+
+    # Verify methods exist
+    assert hasattr(store, "install_adbc_scanner")
+    assert hasattr(store, "adbc_connect")
+    assert hasattr(store, "adbc_disconnect")
+    assert hasattr(store, "adbc_scan")
+    assert hasattr(store, "adbc_scan_table")
+
+    # Verify they're callable
+    assert callable(store.install_adbc_scanner)
+    assert callable(store.adbc_connect)
+    assert callable(store.adbc_disconnect)
+    assert callable(store.adbc_scan)
+    assert callable(store.adbc_scan_table)
+
+
+def test_adbc_scanner_requires_open_store(tmp_path):
+    """Test that ADBC scanner methods require an open store."""
+    store = DuckDBMetadataStore(
+        database=tmp_path / "test.duckdb",
+        hash_algorithm=HashAlgorithm.XXHASH64,
+    )
+
+    # Should raise when store is not open
+    with pytest.raises(RuntimeError, match="connection is not open"):
+        store.install_adbc_scanner()
+
+
+@pytest.mark.slow
+def test_adbc_scanner_extension_installation(tmp_path):
+    """Test that adbc_scanner extension can be installed (if available).
+
+    This test is marked as slow because it downloads the extension.
+    It may fail in environments where the extension is not available.
+    """
+    store = DuckDBMetadataStore(
+        database=tmp_path / "test.duckdb",
+        hash_algorithm=HashAlgorithm.XXHASH64,
+    )
+
+    with store:
+        try:
+            # Try to install extension
+            store.install_adbc_scanner()
+            # If successful, extension is available
+            print("✓ adbc_scanner extension installed successfully")
+        except Exception as e:
+            # Extension may not be available in all environments
+            pytest.skip(f"adbc_scanner extension not available: {e}")


### PR DESCRIPTION
- Add _adbc_scanner_support.py module with federation helpers
- Add ADBC scanner methods to DuckDBMetadataStore
- Add tests verifying API surface exists

Note: Requires DuckDB community extension 'adbc_scanner' for actual use.
Tests verify API exists but don't require external databases.