### PR TITLE
[chore] configure coverage

### DIFF
--- a/.github/coverage_subprocess.pth
+++ b/.github/coverage_subprocess.pth
@@ -1,0 +1,1 @@
+import os; os.environ.get("COVERAGE_PROCESS_START") and __import__("coverage").process_startup()

--- a/.github/workflows/_qa.yml
+++ b/.github/workflows/_qa.yml
@@ -106,15 +106,26 @@ jobs:
           arguments: "'.#\"python${{ matrix.python-version }}\"'"
       - name: Install Dependencies
         run: uv python pin ${{ matrix.python-version }} && uv sync --all-extras --all-groups
+      - name: Install Coverage Subprocess Support
+        run: cp .github/coverage_subprocess.pth $(uv run python -c "import sysconfig; print(sysconfig.get_path('purelib'))")/
       - name: Run Tests
         id: pytest
+        env:
+          # Enable subprocess coverage collection
+          COVERAGE_PROCESS_START: ${{ github.workspace }}/pyproject.toml
+          COVERAGE_FILE: ${{ github.workspace }}/.coverage
         run: >
           uv run pytest
           --cov=src/metaxy
-          --cov-report=term-missing
-          --cov-report=xml
           --durations=10
           --junit-xml=./junit.xml
+
+      - name: Combine Coverage Data
+        if: always()
+        run: |
+          uv run coverage combine --keep || true
+          uv run coverage xml -o coverage.xml
+          uv run coverage report --format=markdown >> $GITHUB_STEP_SUMMARY || true
 
       # Restore original environment to prevent Nix tools from interfering with subsequent steps
       - name: Restore Original Environment After Nix

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.coverage
+
 # Python-generated files
 __pycache__/
 *.py[oc]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,8 +180,13 @@ min_confidence = 60
 
 [tool.coverage.run]
 source = ["src/metaxy"]
+branch = true
+parallel = true
+concurrency = ["multiprocessing", "thread"]
+sigterm = true
 omit = [
   "src/metaxy/_testing.py",
+  "src/metaxy/_testing/*",
   "tests/*",
   "examples/*",
 ]

--- a/src/metaxy/_testing/__init__.py
+++ b/src/metaxy/_testing/__init__.py
@@ -10,12 +10,15 @@ This is a private module (_testing) containing testing utilities organized into:
 # Runbook system
 # Metaxy project helpers
 from metaxy._testing.metaxy_project import (
+    COVERAGE_ENV_VARS,
     ExternalMetaxyProject,
     HashAlgorithmCases,
     MetaxyProject,
     TempFeatureModule,
     TempMetaxyProject,
+    _get_coverage_env,
     assert_all_results_equal,
+    env_override,
 )
 from metaxy._testing.models import SampleFeature, SampleFeatureSpec
 from metaxy._testing.pytest_helpers import (
@@ -61,6 +64,9 @@ __all__ = [
     "ExternalMetaxyProject",
     "TempMetaxyProject",
     "assert_all_results_equal",
+    "env_override",
+    "COVERAGE_ENV_VARS",
+    "_get_coverage_env",
     # Pytest helpers
     "add_metaxy_provenance_column",
     "add_metaxy_system_columns",


### PR DESCRIPTION
This PR configures `coverage` and adds a hook that would initialize it for tests running subprocess commands (e.g. CLI and others). 