### PR TITLE
[docs,tests] enable doctests with Sybil

### DIFF
--- a/.claude/skills/sybil/SKILL.md
+++ b/.claude/skills/sybil/SKILL.md
@@ -1,0 +1,248 @@
+---
+name: sybil
+description: Use Sybil for testing code examples in documentation and docstrings. Covers pytest integration, parsers, skip directives, and namespace management.
+---
+
+# Sybil Documentation Testing
+
+Sybil validates code examples embedded in documentation and docstrings by parsing and executing them as part of normal test runs.
+
+**Official Documentation**: https://sybil.readthedocs.io/en/latest/
+
+## Installation
+
+```bash
+pip install sybil[pytest]
+```
+
+## Pytest Integration
+
+Configure in `conftest.py`. See [pytest integration docs](https://sybil.readthedocs.io/en/latest/integration.html#pytest-integration).
+
+```python
+from sybil import Sybil
+from sybil.parsers.markdown.codeblock import PythonCodeBlockParser
+from sybil.parsers.markdown.skip import SkipParser
+
+pytest_collect_file = Sybil(
+    parsers=[
+        SkipParser(),
+        PythonCodeBlockParser(),
+    ],
+    patterns=["*.md", "**/*.py"],
+).pytest()
+```
+
+### Sybil Parameters
+
+See [API reference](https://sybil.readthedocs.io/en/latest/api.html#sybil.Sybil).
+
+| Parameter        | Description                                                     |
+| ---------------- | --------------------------------------------------------------- |
+| `parsers`        | Sequence of parser callables                                    |
+| `patterns`       | File glob patterns to include (e.g., `["*.md", "src/**/*.py"]`) |
+| `excludes`       | File glob patterns to exclude                                   |
+| `setup`          | Callable receiving namespace dict, called before each document  |
+| `teardown`       | Callable receiving namespace dict, called after each document   |
+| `fixtures`       | List of pytest fixture names to inject into namespace           |
+| `document_types` | Map file extensions to Document classes                         |
+
+### Document Types
+
+See [API reference](https://sybil.readthedocs.io/en/latest/api.html#documents).
+
+- **Default**: Parse entire file
+- `PythonDocument`: Import `.py` file as module, names available in namespace
+- `PythonDocStringDocument`: Parse only docstrings from `.py` files
+
+```python
+from sybil.document import PythonDocStringDocument
+
+pytest_collect_file = Sybil(
+    parsers=[...],
+    patterns=["src/**/*.py"],
+    document_types={".py": PythonDocStringDocument},
+).pytest()
+```
+
+### Fixtures
+
+```python
+import pytest
+from sybil import Sybil
+
+
+@pytest.fixture
+def my_fixture():
+    return {"key": "value"}
+
+
+pytest_collect_file = Sybil(
+    parsers=[...],
+    patterns=["*.md"],
+    fixtures=["my_fixture"],  # Available in document namespace
+).pytest()
+```
+
+### Setup/Teardown
+
+```python
+def sybil_setup(namespace):
+    namespace["helper"] = lambda x: x * 2
+
+
+def sybil_teardown(namespace):
+    pass  # Cleanup if needed
+
+
+pytest_collect_file = Sybil(
+    parsers=[...],
+    setup=sybil_setup,
+    teardown=sybil_teardown,
+).pytest()
+```
+
+## Disable pytest's Built-in Doctest
+
+Add to `pyproject.toml` to prevent conflicts:
+
+```toml
+[tool.pytest.ini_options]
+addopts = "-p no:doctest"
+```
+
+## Markdown Parsers
+
+See [Markdown parsers docs](https://sybil.readthedocs.io/en/latest/markdown.html).
+
+```python
+from sybil.parsers.markdown.codeblock import PythonCodeBlockParser, CodeBlockParser
+from sybil.parsers.markdown.skip import SkipParser
+from sybil.parsers.markdown.clear import ClearNamespaceParser
+```
+
+## Skip Directives
+
+See [skip directive docs](https://sybil.readthedocs.io/en/latest/markdown.html#skipping-examples).
+
+**SkipParser must come before other parsers** to handle skip directives.
+
+````markdown
+<!-- skip: next -->
+
+```python
+# This example is skipped
+```
+````
+
+<!-- skip: next "reason for skipping" -->
+
+```python
+# Skipped and reported as skipped test with reason
+```
+
+<!-- skip: start -->
+
+```python
+# Multiple examples
+```
+
+```python
+# All skipped
+```
+
+<!-- skip: end -->
+
+<!-- skip: next if(condition_var) -->
+
+```python
+# Conditionally skipped based on namespace variable
+```
+
+````
+## Invisible Code Blocks
+
+Setup code that doesn't render in documentation. See [invisible code blocks docs](https://sybil.readthedocs.io/en/latest/markdown.html#invisible-code-blocks).
+
+```markdown
+<!-- invisible-code-block: python
+setup_var = "hidden setup"
+-->
+````
+
+## Clear Namespace
+
+Reset the document namespace for isolation. See [clear namespace docs](https://sybil.readthedocs.io/en/latest/markdown.html#clearing-the-namespace).
+
+```markdown
+<!-- clear-namespace -->
+```
+
+## Custom Evaluators
+
+See [evaluators API](https://sybil.readthedocs.io/en/latest/api.html#evaluators).
+
+```python
+from sybil.parsers.markdown.codeblock import CodeBlockParser
+from sybil.evaluators.python import PythonEvaluator
+
+# Custom evaluator with future imports
+evaluator = PythonEvaluator(future_imports=["annotations"])
+
+parser = CodeBlockParser(language="python", evaluator=evaluator)
+```
+
+## Running Sybil Tests
+
+Sybil tests are collected like regular pytest tests. To run only Sybil tests:
+
+```bash
+# Run tests from specific directory containing documented code
+pytest src/mypackage/ -v
+
+# Exclude regular tests, only run documentation examples
+pytest docs/ -v
+```
+
+To exclude Sybil tests from regular test runs, use pytest's `--ignore` flag or configure `addopts` in `pyproject.toml`.
+
+## Example: Complete conftest.py
+
+```python
+"""Sybil configuration for docstring testing."""
+
+from sybil import Sybil
+from sybil.document import PythonDocStringDocument
+from sybil.evaluators.python import PythonEvaluator
+from sybil.parsers.markdown.codeblock import CodeBlockParser
+from sybil.parsers.markdown.skip import SkipParser
+
+import mypackage
+
+
+def sybil_setup(namespace):
+    """Pre-populate namespace for all examples."""
+    namespace["pkg"] = mypackage
+
+
+def sybil_teardown(namespace):
+    """Cleanup after document."""
+    pass
+
+
+pytest_collect_file = Sybil(
+    parsers=[
+        SkipParser(),
+        CodeBlockParser(language="python", evaluator=PythonEvaluator()),
+        CodeBlockParser(language="py", evaluator=PythonEvaluator()),
+    ],
+    patterns=["src/mypackage/**/*.py"],
+    document_types={".py": PythonDocStringDocument},
+    setup=sybil_setup,
+    teardown=sybil_teardown,
+    excludes=[
+        "**/tests/**",
+        "**/_internal/**",
+    ],
+).pytest()
+```

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ examples/.generated
 
 # Claude stuff
 PLAN.md
+.claude/plans
 plans/*.md
 .cache/
 .pg-wrappers/initdb

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,2 @@
+# Root conftest.py - intentionally minimal
+# Sybil docstring testing is configured in src/metaxy/conftest.py

--- a/docs/.mkdocs-metaxy/src/mkdocs_metaxy/griffe_public.py
+++ b/docs/.mkdocs-metaxy/src/mkdocs_metaxy/griffe_public.py
@@ -1,7 +1,7 @@
 """Griffe extension for @public decorator detection.
 
 This extension controls API visibility in documentation based on the presence
-of the `@public` decorator from `metaxy._public`.
+of the `@public` decorator from `metaxy._decorators`.
 
 Objects decorated with `@public` will appear in documentation.
 Objects without the decorator will be removed from the Griffe tree,
@@ -26,7 +26,7 @@ def _has_public_decorator(obj: griffe.Object) -> bool:
         return False
 
     for decorator in obj.decorators:
-        if decorator.callable_path == "metaxy._public.public":
+        if decorator.callable_path == "metaxy._decorators.public":
             return True
 
     return False

--- a/docs/.mkdocs-metaxy/src/mkdocs_metaxy/validate_public.py
+++ b/docs/.mkdocs-metaxy/src/mkdocs_metaxy/validate_public.py
@@ -44,7 +44,7 @@ def _has_public_decorator(obj: griffe.Object) -> bool:
         return True
 
     for decorator in obj.decorators:
-        if decorator.callable_path in ("metaxy._public.public",):
+        if decorator.callable_path in ("metaxy._decorators.public",):
             return True
 
     return False
@@ -130,7 +130,7 @@ def on_files(files: list, config: dict) -> list:
         for file_path, identifier in sorted(errors):
             log.error(f"  {file_path}: {identifier}")
         log.error(
-            "\nAdd the @public decorator from metaxy._public to these objects, or remove them from the documentation."
+            "\nAdd the @public decorator from metaxy._decorators to these objects, or remove them from the documentation."
         )
         # This will cause mkdocs build --strict to fail
         raise SystemExit(1)

--- a/docs/reference/api/index.md
+++ b/docs/reference/api/index.md
@@ -7,7 +7,11 @@ description: "Python API reference for Metaxy."
 
 ## `metaxy`
 
-The top-level `metaxy` module provides the main public API for Metaxy.
+The top-level `metaxy` module provides the main public API for Metaxy. It is typically referenced as `mx`:
+
+```python
+import metaxy as mx
+```
 
 ## Initialization
 
@@ -19,4 +23,4 @@ Metaxy abstracts interactions with metadata through the [MetadaStore][metaxy.met
 
 ## Dependency Specification
 
-Metaxy has a declarative [feature specification system](./definitions/index.md) that allows users to express dependencies between their features and their versioned fields.
+Metaxy has a declarative [feature specification system](./definitions/index.md) that allows users to express dependencies on versioned fields of other upstream features.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -97,8 +97,13 @@ plugins:
             docstring_options:
               ignore_init_summary: true
             show_source: true
+            separate_signature: true
+            overloads_only: true
+            modernize_annotations: true
+            line_length: 60
             show_docstring_classes: true
             show_docstring_description: true
+            show_docstring_examples: true
             show_docstring_parameters: true
             show_root_heading: true
             show_root_full_path: true
@@ -106,8 +111,6 @@ plugins:
             scoped_crossrefs: true
             show_category_heading: true
             show_signature_annotations: true
-            separate_signature: true
-            line_length: 120
             merge_init_into_class: true
             docstring_section_style: list
             members_order: source

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,7 @@ dev = [
   "pandas>=2.3.3",
   "ray>2.36.0; sys_platform != 'win32' or python_version < '3.13'",
   "numpy>=2.2.6",
+  "sybil>=9.3.0",
 ]
 
 examples = [
@@ -246,7 +247,7 @@ exclude = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "--snapshot-details --doctest-modules --ignore=src/metaxy/ext/mcp --ignore=tests/fixtures"
+addopts = "--snapshot-details -p no:doctest --ignore=tests/fixtures --ignore=examples"
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 env = [

--- a/src/metaxy/__init__.py
+++ b/src/metaxy/__init__.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from metaxy._public import public
+from metaxy._decorators import public
 from metaxy._version import __version__
 from metaxy.config import MetaxyConfig, StoreConfig
 from metaxy.entrypoints import (

--- a/src/metaxy/_decorators.py
+++ b/src/metaxy/_decorators.py
@@ -1,4 +1,7 @@
-"""Public API decorator for documentation whitelisting."""
+"""Private module containing decorators for internal use.
+
+This module is not part of the public API.
+"""
 
 from __future__ import annotations
 
@@ -29,17 +32,14 @@ def public(obj: _T) -> _T:
 
     Example:
         ```python
-        from metaxy import public
-
-
-        @public
-        class MyFeature(BaseFeature):
+        @mx.public
+        class MyFeature(mx.BaseFeature):
             '''This feature will appear in documentation.'''
 
             pass
 
 
-        @public
+        @mx.public
         def my_function():
             '''This function will appear in documentation.'''
             pass

--- a/src/metaxy/_testing/doctest_fixtures.py
+++ b/src/metaxy/_testing/doctest_fixtures.py
@@ -1,0 +1,38 @@
+"""Pre-defined features for docstring examples.
+
+These features have stable import paths so they work with to_snapshot()/from_snapshot().
+"""
+
+from metaxy.models.feature import BaseFeature, FeatureGraph
+from metaxy.models.feature_spec import FeatureSpec
+
+# Define spec at module level for stable reference
+_MY_FEATURE_SPEC = FeatureSpec(key="my/feature", id_columns=["id"])
+
+
+class MyFeature(BaseFeature, spec=None):
+    """Pre-populated feature for docstring examples.
+
+    Available in all docstring examples as `MyFeature`.
+    Has key "my/feature" and id column "id".
+    """
+
+    id: str
+
+
+# Set up class attributes (bypassing metaclass project detection)
+MyFeature._spec = _MY_FEATURE_SPEC
+MyFeature.project = "docs"
+
+
+def register_doctest_fixtures(graph: FeatureGraph) -> None:
+    """Register doctest fixtures to the given graph.
+
+    Args:
+        graph: The FeatureGraph to register fixtures to.
+    """
+    MyFeature.graph = graph
+    graph.add_feature(MyFeature)
+
+
+__all__ = ["MyFeature", "register_doctest_fixtures"]

--- a/src/metaxy/config.py
+++ b/src/metaxy/config.py
@@ -21,7 +21,7 @@ from pydantic_settings import (
 )
 from typing_extensions import Self
 
-from metaxy._public import public
+from metaxy._decorators import public
 
 if TYPE_CHECKING:
     from metaxy.metadata_store.base import (

--- a/src/metaxy/conftest.py
+++ b/src/metaxy/conftest.py
@@ -1,0 +1,166 @@
+"""Sybil conftest for docstring code block testing.
+
+Configures Sybil to parse and test markdown code blocks (```python and ```py)
+found in docstrings throughout the src/metaxy codebase.
+
+Import style enforcement:
+    All docstring examples must use `import metaxy as mx` instead of
+    `from metaxy import ...`. The `mx` module is pre-populated in the
+    namespace along with common symbols for convenience.
+"""
+
+from sybil import Sybil
+from sybil.document import PythonDocStringDocument
+from sybil.evaluators.python import PythonEvaluator
+from sybil.parsers.markdown.codeblock import CodeBlockParser
+from sybil.parsers.markdown.skip import SkipParser
+
+import metaxy as mx
+
+
+# Workaround for pytest-cases compatibility issue
+# pytest-cases patches getfixtureclosure and has an assertion that fails for SybilItem
+# because SybilItem doesn't have the same structure as regular test functions.
+# We patch pytest-cases to skip its assertion for non-function items.
+def _patch_pytest_cases():
+    try:
+        import pytest_cases.plugin as pc_plugin
+    except ImportError:
+        return
+
+    if not hasattr(pc_plugin, "_getfixtureclosure"):
+        return
+
+    original_getfixtureclosure = pc_plugin._getfixtureclosure
+
+    def patched_getfixtureclosure(fm, fixturenames, parentnode, ignore_args=frozenset()):
+        # Check if this is a SybilItem or similar non-function item
+        # These don't have proper funcargs and cause assertion failures in pytest-cases
+        from sybil.integration.pytest import SybilItem
+
+        if isinstance(parentnode, SybilItem):
+            # Bypass pytest-cases entirely for Sybil items - use pytest's native implementation
+            if pc_plugin.PYTEST8_OR_GREATER:
+                return fm.__class__.getfixtureclosure(fm, parentnode, fixturenames, ignore_args=ignore_args)
+            elif pc_plugin.PYTEST46_OR_GREATER:
+                return fm.__class__.getfixtureclosure(fm, fixturenames, parentnode, ignore_args=ignore_args)
+            else:
+                return fm.__class__.getfixtureclosure(fm, fixturenames, parentnode)
+
+        return original_getfixtureclosure(fm, fixturenames, parentnode, ignore_args)
+
+    pc_plugin._getfixtureclosure = patched_getfixtureclosure  # type: ignore[invalid-assignment]
+
+    # Also patch the wrapper if it exists
+    if pc_plugin.PYTEST8_OR_GREATER:
+
+        def patched_wrapper(fm, parentnode, initialnames, ignore_args):
+            return patched_getfixtureclosure(
+                fm, fixturenames=initialnames, parentnode=parentnode, ignore_args=ignore_args
+            )
+
+        pc_plugin.getfixtureclosure = patched_wrapper  # type: ignore[invalid-assignment]
+
+
+_patch_pytest_cases()
+
+
+class ImportStyleCheckingEvaluator(PythonEvaluator):
+    """PythonEvaluator that checks import style before execution."""
+
+    def __call__(self, example):
+        # Check for forbidden import style
+        if "from metaxy import" in example.parsed:
+            return (
+                "Use 'import metaxy as mx' instead of 'from metaxy import'.\n"
+                "The 'mx' module is pre-populated in the doctest namespace."
+            )
+        # Delegate to parent for actual execution
+        return super().__call__(example)
+
+
+def sybil_setup(namespace):
+    """Set up an isolated FeatureGraph for each docstring document.
+
+    This provides a clean graph context so examples don't need boilerplate.
+    Examples can define features and they'll be registered to this isolated graph.
+
+    Pre-populated symbols:
+        - mx: The metaxy module (import metaxy as mx)
+        - graph: The active FeatureGraph instance for this document
+        - MyFeature: A pre-defined feature class with key "my/feature"
+    """
+    from metaxy._testing.doctest_fixtures import MyFeature, register_doctest_fixtures
+    from metaxy.models import feature as feature_module
+    from metaxy.models.feature import FeatureGraph
+
+    # Create isolated graph and enter its context
+    isolated_graph = FeatureGraph()
+    context_manager = isolated_graph.use()
+    context_manager.__enter__()
+
+    # Register pre-defined fixtures to the isolated graph
+    register_doctest_fixtures(isolated_graph)
+
+    # IMPORTANT: Override the module-level 'graph' variable so docstring examples
+    # in feature.py use our isolated graph instead of the global singleton.
+    # We restore it in teardown.
+    namespace["_original_module_graph"] = feature_module.graph
+    feature_module.graph = isolated_graph
+
+    # Internal state
+    namespace["_sybil_graph"] = isolated_graph
+    namespace["_sybil_context_manager"] = context_manager
+
+    # Pre-populated symbols for examples
+    namespace["mx"] = mx
+    namespace["graph"] = isolated_graph
+    namespace["MyFeature"] = MyFeature
+
+
+def sybil_teardown(namespace):
+    """Clean up the isolated FeatureGraph context."""
+    # Restore the original module-level graph
+    original_graph = namespace.get("_original_module_graph")
+    if original_graph is not None:
+        from metaxy.models import feature as feature_module
+
+        feature_module.graph = original_graph
+
+    context_manager = namespace.get("_sybil_context_manager")
+    if context_manager:
+        context_manager.__exit__(None, None, None)
+
+
+# Create parsers for both ```python and ```py code blocks
+# SkipParser must come before other parsers to handle skip directives
+python_evaluator = ImportStyleCheckingEvaluator()
+parsers = [
+    SkipParser(),
+    CodeBlockParser(language="python", evaluator=python_evaluator),
+    CodeBlockParser(language="py", evaluator=python_evaluator),
+]
+
+# Configure Sybil to extract docstrings from Python files and parse code blocks
+# Uses relative patterns since this conftest is in src/metaxy/
+pytest_collect_file = Sybil(
+    parsers=parsers,
+    patterns=["**/*.py"],
+    document_types={".py": PythonDocStringDocument},
+    setup=sybil_setup,
+    teardown=sybil_teardown,
+    excludes=[
+        # Sybil uses PurePath.match() which requires patterns to match from the right side
+        "ext/mcp/*",  # MCP module has import conflict with 'mcp' package
+        "*/mcp/*",  # Deeper nested mcp files
+        "_testing/*",  # Internal testing utilities - examples not meant to be executed
+        "_testing/*/*",  # Nested _testing subdirectories (parametric, etc)
+        "ext/dagster/*",  # Dagster examples require dagster context
+        "*/dagster/*",  # Deeper nested dagster files
+        "ext/ray/*",  # Ray examples require specific setup
+        "*/ray/*",  # Deeper nested ray files
+        "metadata_store/system/*",  # System storage examples need store setup
+        "*/system/*",  # Deeper nested system files
+        "conftest.py",  # Don't test this file itself
+    ],
+).pytest()

--- a/src/metaxy/ext/dagster/dagster_type.py
+++ b/src/metaxy/ext/dagster/dagster_type.py
@@ -11,7 +11,7 @@ import dagster as dg
 import narwhals as nw
 
 import metaxy as mx
-from metaxy._public import public
+from metaxy._decorators import public
 from metaxy.ext.dagster.constants import (
     DAGSTER_COLUMN_LINEAGE_METADATA_KEY,
     DAGSTER_COLUMN_SCHEMA_METADATA_KEY,

--- a/src/metaxy/ext/dagster/io_manager.py
+++ b/src/metaxy/ext/dagster/io_manager.py
@@ -6,7 +6,7 @@ import pydantic
 from narwhals.typing import IntoFrame
 
 import metaxy as mx
-from metaxy._public import public
+from metaxy._decorators import public
 from metaxy.ext.dagster.constants import (
     DAGSTER_METAXY_FEATURE_METADATA_KEY,
     DAGSTER_METAXY_PARTITION_KEY,

--- a/src/metaxy/ext/dagster/metaxify.py
+++ b/src/metaxy/ext/dagster/metaxify.py
@@ -9,7 +9,7 @@ from dagster._core.definitions.events import (
 from typing_extensions import Self
 
 import metaxy as mx
-from metaxy._public import public
+from metaxy._decorators import public
 from metaxy.ext.dagster.constants import (
     DAGSTER_COLUMN_LINEAGE_METADATA_KEY,
     DAGSTER_COLUMN_SCHEMA_METADATA_KEY,

--- a/src/metaxy/ext/dagster/observable.py
+++ b/src/metaxy/ext/dagster/observable.py
@@ -6,7 +6,7 @@ from typing import Any
 import dagster as dg
 
 import metaxy as mx
-from metaxy._public import public
+from metaxy._decorators import public
 from metaxy.ext.dagster.constants import (
     DAGSTER_METAXY_FEATURE_METADATA_KEY,
     DAGSTER_METAXY_PARTITION_METADATA_KEY,

--- a/src/metaxy/ext/dagster/observation_job.py
+++ b/src/metaxy/ext/dagster/observation_job.py
@@ -7,7 +7,7 @@ from typing import Any
 import dagster as dg
 
 import metaxy as mx
-from metaxy._public import public
+from metaxy._decorators import public
 from metaxy.ext.dagster.constants import (
     DAGSTER_METAXY_FEATURE_METADATA_KEY,
     DAGSTER_METAXY_PARTITION_KEY,

--- a/src/metaxy/ext/dagster/resources.py
+++ b/src/metaxy/ext/dagster/resources.py
@@ -1,7 +1,7 @@
 import dagster as dg
 
 import metaxy as mx
-from metaxy._public import public
+from metaxy._decorators import public
 
 
 @public

--- a/src/metaxy/ext/dagster/selection.py
+++ b/src/metaxy/ext/dagster/selection.py
@@ -3,7 +3,7 @@
 import dagster as dg
 
 import metaxy as mx
-from metaxy._public import public
+from metaxy._decorators import public
 from metaxy.ext.dagster.constants import (
     DAGSTER_METAXY_FEATURE_METADATA_KEY,
     DAGSTER_METAXY_PROJECT_TAG_KEY,

--- a/src/metaxy/ext/dagster/utils.py
+++ b/src/metaxy/ext/dagster/utils.py
@@ -5,7 +5,7 @@ import dagster as dg
 import narwhals as nw
 
 import metaxy as mx
-from metaxy._public import public
+from metaxy._decorators import public
 from metaxy.ext.dagster.constants import (
     DAGSTER_METAXY_FEATURE_CODE_VERSION_TAG_KEY,
     DAGSTER_METAXY_FEATURE_METADATA_KEY,

--- a/src/metaxy/ext/sqlalchemy/plugin.py
+++ b/src/metaxy/ext/sqlalchemy/plugin.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 
 from sqlalchemy import Column, DateTime, Index, MetaData, String, Table
 
-from metaxy._public import public
+from metaxy._decorators import public
 from metaxy.config import MetaxyConfig
 from metaxy.ext.sqlalchemy.config import SQLAlchemyConfig
 from metaxy.metadata_store.system import EVENTS_KEY, FEATURE_VERSIONS_KEY
@@ -334,20 +334,17 @@ def filter_feature_sqla_metadata(
 
     Example: Basic Usage
 
+        <!-- skip next -->
         ```py
         from metaxy.ext.sqlalchemy import filter_feature_sqla_metadata
-        from metaxy import init_metaxy
-        from metaxy.config import MetaxyConfig
+        from sqlalchemy import MetaData
 
         # Load features first
-        init_metaxy()
+        mx.init_metaxy()
 
         # Get store instance
-        config = MetaxyConfig.get()
+        config = mx.MetaxyConfig.get()
         store = config.get_store("my_store")
-
-        # With custom metadata
-        from sqlalchemy import MetaData
 
         my_metadata = MetaData()
         # ... define tables in my_metadata ...
@@ -358,8 +355,8 @@ def filter_feature_sqla_metadata(
 
     Example: With SQLModel
 
+        <!-- skip next -->
         ```py
-        # With SQLModel
         from sqlmodel import SQLModel
 
         url, metadata = filter_feature_sqla_metadata(store, SQLModel.metadata)

--- a/src/metaxy/ext/sqlmodel/plugin.py
+++ b/src/metaxy/ext/sqlmodel/plugin.py
@@ -12,7 +12,7 @@ from sqlmodel import Field, SQLModel
 from sqlmodel.main import SQLModelMetaclass
 
 from metaxy import FeatureSpec
-from metaxy._public import public
+from metaxy._decorators import public
 from metaxy.config import MetaxyConfig
 from metaxy.ext.sqlmodel.config import SQLModelPluginConfig
 from metaxy.models.constants import (
@@ -235,21 +235,21 @@ class BaseSQLModelFeature(SQLModel, BaseFeature, metaclass=SQLModelFeatureMeta, 
 
     !!! example
 
+        <!-- skip next -->
         ```py
         from metaxy.integrations.sqlmodel import BaseSQLModelFeature
-        from metaxy import FeatureSpec, FeatureKey, FieldSpec, FieldKey
         from sqlmodel import Field
 
 
         class VideoFeature(
             BaseSQLModelFeature,
             table=True,
-            spec=FeatureSpec(
-                key=FeatureKey(["video"]),
+            spec=mx.FeatureSpec(
+                key=mx.FeatureKey(["video"]),
                 id_columns=["uid"],
                 fields=[
-                    FieldSpec(
-                        key=FieldKey(["video_file"]),
+                    mx.FieldSpec(
+                        key=mx.FieldKey(["video_file"]),
                         code_version="1",
                     ),
                 ],
@@ -435,25 +435,23 @@ def filter_feature_sqlmodel_metadata(
 
     Example: Basic Usage
 
+        <!-- skip next -->
         ```py
         from sqlmodel import SQLModel
         from metaxy.ext.sqlmodel import filter_feature_sqlmodel_metadata
-        from metaxy import init_metaxy
-        from metaxy.config import MetaxyConfig
+        from alembic import context
 
         # Load features first
-        init_metaxy()
+        mx.init_metaxy()
 
         # Get store instance
-        config = MetaxyConfig.get()
+        config = mx.MetaxyConfig.get()
         store = config.get_store("my_store")
 
         # Filter SQLModel metadata with prefix transformation
         url, metadata = filter_feature_sqlmodel_metadata(store, SQLModel.metadata)
 
         # Use with Alembic env.py
-        from alembic import context
-
         url, target_metadata = filter_feature_sqlmodel_metadata(store, SQLModel.metadata)
         context.configure(url=url, target_metadata=target_metadata)
         ```

--- a/src/metaxy/metadata_store/_ducklake_support.py
+++ b/src/metaxy/metadata_store/_ducklake_support.py
@@ -14,7 +14,7 @@ from pydantic import (
     field_validator,
 )
 
-from metaxy._public import public
+from metaxy._decorators import public
 
 
 @runtime_checkable

--- a/src/metaxy/metadata_store/base.py
+++ b/src/metaxy/metadata_store/base.py
@@ -15,7 +15,7 @@ from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from typing_extensions import Self
 
-from metaxy._public import public
+from metaxy._decorators import public
 from metaxy._utils import switch_implementation_to_polars
 from metaxy.config import MetaxyConfig
 from metaxy.metadata_store.exceptions import (
@@ -76,6 +76,7 @@ class MetadataStoreConfig(BaseSettings):
     Store-specific config classes should inherit from this and add their own fields.
 
     Example:
+        <!-- skip next -->
         ```python
         from metaxy.metadata_store.duckdb import DuckDBMetadataStoreConfig
 
@@ -323,6 +324,7 @@ class MetadataStore(ABC):
 
         !!! example "With a root feature"
 
+            <!-- skip next -->
             ```py
             samples = pl.DataFrame(
                 {
@@ -577,6 +579,7 @@ class MetadataStore(ABC):
                 are missing from the DataFrame.
 
         Example:
+            <!-- skip next -->
             ```py
 
                 # Read upstream metadata
@@ -901,6 +904,7 @@ class MetadataStore(ABC):
               validation and system column handling from that method applies.
 
         Example:
+            <!-- skip next -->
             ```py
             with store.open(mode="write"):
                 store.write_metadata_multi(
@@ -966,6 +970,7 @@ class MetadataStore(ABC):
             A new store instance configured according to the config object
 
         Example:
+            <!-- skip next -->
             ```python
             from metaxy.metadata_store.duckdb import (
                 DuckDBMetadataStore,
@@ -1033,6 +1038,7 @@ class MetadataStore(ABC):
             NotImplementedError: If provenance tracking not supported by this store
 
         Example:
+            <!-- skip next -->
             ```python
             with self._create_versioning_engine(plan) as engine:
                 result = engine.resolve_update(...)
@@ -1534,6 +1540,7 @@ class MetadataStore(ABC):
             feature: Feature class or key to drop metadata for
 
         Example:
+            <!-- skip next -->
             ```py
             store.drop_feature_metadata(MyFeature)
             assert not store.has_feature(MyFeature)
@@ -1865,12 +1872,14 @@ class MetadataStore(ABC):
             FeatureNotFoundError: If a specified feature doesn't exist in source store
 
         Examples:
+            <!-- skip next -->
             ```py
             # Copy all features
             with source_store.open("read"), dest_store.open("write"):
                 stats = dest_store.copy_metadata(from_store=source_store)
             ```
 
+            <!-- skip next -->
             ```py
             # Copy specific features
             with source_store.open("read"), dest_store.open("write"):
@@ -1880,6 +1889,7 @@ class MetadataStore(ABC):
                 )
             ```
 
+            <!-- skip next -->
             ```py
             # Copy with global filters applied to all features
             with source_store.open("read"), dest_store.open("write"):
@@ -1889,6 +1899,7 @@ class MetadataStore(ABC):
                 )
             ```
 
+            <!-- skip next -->
             ```py
             # Copy specific features with per-feature filters
             with source_store.open("read"), dest_store.open("write"):

--- a/src/metaxy/metadata_store/bigquery.py
+++ b/src/metaxy/metadata_store/bigquery.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
 
 from pydantic import Field
 
-from metaxy._public import public
+from metaxy._decorators import public
 from metaxy.metadata_store.ibis import IbisMetadataStore, IbisMetadataStoreConfig
 from metaxy.versioning.types import HashAlgorithm
 
@@ -16,6 +16,7 @@ class BigQueryMetadataStoreConfig(IbisMetadataStoreConfig):
     """Configuration for BigQueryMetadataStore.
 
     Example:
+        <!-- skip next -->
         ```python
         config = BigQueryMetadataStoreConfig(
             project_id="my-project",
@@ -54,6 +55,7 @@ class BigQueryMetadataStore(IbisMetadataStore):
         Make sure to use appropriate `filters` when calling [BigQueryMetadataStore.read_metadata][metaxy.metadata_store.bigquery.BigQueryMetadataStore.read_metadata].
 
     Example: Basic Connection
+        <!-- skip next -->
         ```py
         store = BigQueryMetadataStore(
             project_id="my-project",
@@ -62,6 +64,7 @@ class BigQueryMetadataStore(IbisMetadataStore):
         ```
 
     Example: With Service Account
+        <!-- skip next -->
         ```py
         store = BigQueryMetadataStore(
             project_id="my-project",
@@ -71,6 +74,7 @@ class BigQueryMetadataStore(IbisMetadataStore):
         ```
 
     Example: With Location Configuration
+        <!-- skip next -->
         ```py
         store = BigQueryMetadataStore(
             project_id="my-project",
@@ -80,6 +84,7 @@ class BigQueryMetadataStore(IbisMetadataStore):
         ```
 
     Example: With Custom Hash Algorithm
+        <!-- skip next -->
         ```py
         store = BigQueryMetadataStore(
             project_id="my-project",
@@ -135,6 +140,7 @@ class BigQueryMetadataStore(IbisMetadataStore):
             automatically optimize queries with appropriate WHERE clauses on the partition column.
 
         Example:
+            <!-- skip next -->
             ```py
             # Using environment authentication
             store = BigQueryMetadataStore(

--- a/src/metaxy/metadata_store/clickhouse.py
+++ b/src/metaxy/metadata_store/clickhouse.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
     from metaxy.metadata_store.base import MetadataStore
 
-from metaxy._public import public
+from metaxy._decorators import public
 from metaxy.metadata_store.ibis import (
     Frame,
     IbisMetadataStore,
@@ -52,6 +52,7 @@ class ClickHouseMetadataStore(IbisMetadataStore):
     [ClickHouse](https://clickhouse.com/) metadata store using [Ibis](https://ibis-project.org/) backend.
 
     Example: Connection Parameters
+        <!-- skip next -->
         ```py
         store = ClickHouseMetadataStore(
             backend="clickhouse",

--- a/src/metaxy/metadata_store/delta.py
+++ b/src/metaxy/metadata_store/delta.py
@@ -16,7 +16,7 @@ from packaging.version import Version
 from pydantic import Field
 from typing_extensions import Self
 
-from metaxy._public import public
+from metaxy._decorators import public
 from metaxy._utils import collect_to_polars
 from metaxy.metadata_store.base import MetadataStore, MetadataStoreConfig
 from metaxy.metadata_store.types import AccessMode

--- a/src/metaxy/metadata_store/duckdb.py
+++ b/src/metaxy/metadata_store/duckdb.py
@@ -11,7 +11,7 @@ from typing_extensions import Self
 if TYPE_CHECKING:
     from metaxy.metadata_store.base import MetadataStore
 
-from metaxy._public import public
+from metaxy._decorators import public
 from metaxy.metadata_store._ducklake_support import (
     DuckDBPyConnection,
     DuckLakeAttachmentConfig,

--- a/src/metaxy/metadata_store/exceptions.py
+++ b/src/metaxy/metadata_store/exceptions.py
@@ -1,6 +1,6 @@
 """Exceptions for metadata store operations."""
 
-from metaxy._public import public
+from metaxy._decorators import public
 
 
 @public

--- a/src/metaxy/metadata_store/ibis.py
+++ b/src/metaxy/metadata_store/ibis.py
@@ -16,7 +16,7 @@ from narwhals.typing import Frame
 from pydantic import Field
 from typing_extensions import Self
 
-from metaxy._public import public
+from metaxy._decorators import public
 from metaxy.metadata_store.base import (
     MetadataStore,
     MetadataStoreConfig,
@@ -101,6 +101,7 @@ class IbisMetadataStore(MetadataStore, ABC):
     For other backends, override the calculator instance variable with backend-specific implementations.
 
     Example:
+        <!-- skip next -->
         ```py
         # ClickHouse
         store = IbisMetadataStore("clickhouse://user:pass@host:9000/db")
@@ -153,6 +154,7 @@ class IbisMetadataStore(MetadataStore, ABC):
             ImportError: If Ibis or required backend driver not installed
 
         Example:
+            <!-- skip next -->
             ```py
             # Using connection string
             store = IbisMetadataStore("clickhouse://user:pass@host:9000/db")
@@ -350,6 +352,7 @@ class IbisMetadataStore(MetadataStore, ABC):
             ValueError: If connection_string is not available
 
         Example:
+            <!-- skip next -->
             ```python
             store = IbisMetadataStore("postgresql://user:pass@host:5432/db")
             print(store.sqlalchemy_url)  # postgresql://user:pass@host:5432/db

--- a/src/metaxy/metadata_store/lancedb.py
+++ b/src/metaxy/metadata_store/lancedb.py
@@ -13,7 +13,7 @@ from narwhals.typing import Frame
 from pydantic import Field
 from typing_extensions import Self
 
-from metaxy._public import public
+from metaxy._decorators import public
 from metaxy._utils import collect_to_polars
 from metaxy.metadata_store.base import MetadataStore, MetadataStoreConfig
 from metaxy.metadata_store.types import AccessMode

--- a/src/metaxy/migrations/detector.py
+++ b/src/metaxy/migrations/detector.py
@@ -40,18 +40,22 @@ def detect_diff_migration(
         DiffMigration if changes detected and written, None otherwise
 
     Example:
+        <!-- skip next -->
         ```py
         # Compare latest snapshot in store vs current graph
         with store:
             migration = detect_diff_migration(store, project="my_project")
             if migration:
-            print(f"Migration written to {migration.yaml_path}")
+                print(f"Migration written to {migration.yaml_path}")
+        ```
 
+        <!-- skip next -->
         ```py
         # Use custom operation
         migration = detect_diff_migration(store, project="my_project", ops=[{"type": "myproject.ops.CustomOp"}])
         ```
 
+        <!-- skip next -->
         ```py
         # Use custom name
         migration = detect_diff_migration(store, project="my_project", name="example_migration")

--- a/src/metaxy/migrations/generator.py
+++ b/src/metaxy/migrations/generator.py
@@ -85,13 +85,15 @@ def generate_migration(
         ValueError: If only one snapshot_version is provided, or snapshots not found
 
     Example (default mode):
+        <!-- skip next -->
         ```py
         migration = generate_migration(store, project="my_project")
         if migration:
-        migration.to_yaml("migrations/001_update.yaml")
-
+            migration.to_yaml("migrations/001_update.yaml")
         ```
+
     Example (historical mode):
+        <!-- skip next -->
         ```py
         migration = generate_migration(
             store,

--- a/src/metaxy/models/feature_spec.py
+++ b/src/metaxy/models/feature_spec.py
@@ -11,8 +11,8 @@ import pydantic
 from pydantic import BeforeValidator
 from typing_extensions import Self
 
+from metaxy._decorators import public
 from metaxy._hashing import truncate_hash
-from metaxy._public import public
 from metaxy.models.bases import FrozenBaseModel
 from metaxy.models.field import CoersibleToFieldSpecsTypeAdapter, FieldSpec
 from metaxy.models.fields_mapping import FieldsMapping
@@ -63,34 +63,36 @@ class FeatureDep(pydantic.BaseModel):
     Example: Basic Usage
         ```py
         # Keep all columns with default field mapping (1:1 lineage)
-        FeatureDep(feature="upstream")
+        mx.FeatureDep(feature="upstream")
 
         # Keep only specific columns
-        FeatureDep(feature="upstream/feature", columns=("col1", "col2"))
+        mx.FeatureDep(feature="upstream/feature", columns=("col1", "col2"))
 
         # Rename columns to avoid conflicts
-        FeatureDep(feature="upstream/feature", rename={"old_name": "new_name"})
+        mx.FeatureDep(feature="upstream/feature", rename={"old_name": "new_name"})
 
         # SQL filters
-        FeatureDep(feature="upstream", filters=["age >= 25", "status = 'active'"])
+        mx.FeatureDep(feature="upstream", filters=["age >= 25", "status = 'active'"])
 
         # Optional dependency (left join - samples preserved even if no match)
-        FeatureDep(feature="enrichment/data", optional=True)
+        mx.FeatureDep(feature="enrichment/data", optional=True)
         ```
 
     Example: Lineage Relationships
         ```py
+        from metaxy.models.lineage import LineageRelationship
+
         # Aggregation: many sensor readings aggregate to one hourly stat
-        FeatureDep(feature="sensor_readings", lineage=LineageRelationship.aggregation(on=["sensor_id", "hour"]))
+        mx.FeatureDep(feature="sensor_readings", lineage=LineageRelationship.aggregation(on=["sensor_id", "hour"]))
 
         # Expansion: one video expands to many frames
-        FeatureDep(feature="video", lineage=LineageRelationship.expansion(on=["video_id"]))
+        mx.FeatureDep(feature="video", lineage=LineageRelationship.expansion(on=["video_id"]))
 
         # Mixed lineage: aggregate from one parent, identity from another
         # In FeatureSpec:
         deps = [
-            FeatureDep(feature="readings", lineage=LineageRelationship.aggregation(on=["sensor_id"])),
-            FeatureDep(feature="sensor_info", lineage=LineageRelationship.identity()),
+            mx.FeatureDep(feature="readings", lineage=LineageRelationship.aggregation(on=["sensor_id"])),
+            mx.FeatureDep(feature="sensor_info", lineage=LineageRelationship.identity()),
         ]
         ```
     """
@@ -304,9 +306,9 @@ class FeatureSpec(FrozenBaseModel):
 
         Example:
             ```py
-            spec = FeatureSpec(
-                key=FeatureKey(["my", "feature"]),
-                fields=[FieldSpec(key=FieldKey(["default"]))],
+            spec = mx.FeatureSpec(
+                key=mx.FeatureKey(["my", "feature"]),
+                id_columns=["id"],
             )
             spec.feature_spec_version
             # 'abc123...'  # 64-character hex string

--- a/src/metaxy/models/field.py
+++ b/src/metaxy/models/field.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Annotated, Any, Literal
 from pydantic import BaseModel, BeforeValidator, TypeAdapter
 from pydantic import Field as PydanticField
 
-from metaxy._public import public
+from metaxy._decorators import public
 from metaxy.models.constants import DEFAULT_CODE_VERSION
 from metaxy.models.types import (
     CoercibleToFieldKey,

--- a/src/metaxy/models/fields_mapping.py
+++ b/src/metaxy/models/fields_mapping.py
@@ -14,7 +14,7 @@ from pydantic import BaseModel, ConfigDict, TypeAdapter, field_serializer
 from pydantic import Field as PydanticField
 from typing_extensions import Self
 
-from metaxy._public import public
+from metaxy._decorators import public
 from metaxy.models.types import (
     CoercibleToFieldKey,
     FeatureKey,

--- a/src/metaxy/models/filter_expression.py
+++ b/src/metaxy/models/filter_expression.py
@@ -8,7 +8,7 @@ from pydantic import field_serializer, model_validator
 from sqlglot import exp
 from sqlglot.errors import ParseError
 
-from metaxy._public import public
+from metaxy._decorators import public
 from metaxy.models.bases import FrozenBaseModel
 
 LiteralValue = bool | int | float | str | None

--- a/src/metaxy/models/lineage.py
+++ b/src/metaxy/models/lineage.py
@@ -16,7 +16,7 @@ from pydantic import BaseModel, ConfigDict
 from pydantic import Field as PydanticField
 from typing_extensions import Self
 
-from metaxy._public import public
+from metaxy._decorators import public
 
 
 @public
@@ -58,11 +58,14 @@ class IdentityRelationship(BaseLineageRelationship):
     """One-to-one relationship where each child row maps to exactly one parent row.
 
     This is the default relationship type. Parent and child features share the same
-    ID columns and have the same cardinality. No aggregation is performed.
+    ID columns and have the same cardinality.
 
-    Examples:
-        >>> IdentityRelationship()
-        IdentityRelationship(type=<LineageRelationshipType.IDENTITY: '1:1'>)
+    Construct this relationship via [`LineageRelationship.identity`][metaxy.models.lineage.LineageRelationship.identity] classmethod.
+
+    Example:
+        ```python
+        mx.LineageRelationship.identity()
+        ```
     """
 
     type: Literal[LineageRelationshipType.IDENTITY] = LineageRelationshipType.IDENTITY
@@ -82,13 +85,16 @@ class AggregationRelationship(BaseLineageRelationship):
     Parent features have more granular ID columns than the child. The child aggregates
     multiple parent rows by grouping on a subset of the parent's ID columns.
 
+    Construct this relationship via [`LineageRelationship.aggregation`][metaxy.models.lineage.LineageRelationship.aggregation] classmethod.
+
     Attributes:
         on: Columns to group by for aggregation. These should be a subset of the
             target feature's ID columns. If not specified, uses all target ID columns.
 
-    Examples:
-        >>> AggregationRelationship(on=["sensor_id", "hour"])
-        AggregationRelationship(type=<LineageRelationshipType.AGGREGATION: 'N:1'>, on=['sensor_id', 'hour'])
+    Example:
+        ```python
+        mx.LineageRelationship.aggregation(on=["sensor_id", "hour"])
+        ```
     """
 
     type: Literal[LineageRelationshipType.AGGREGATION] = LineageRelationshipType.AGGREGATION
@@ -112,6 +118,8 @@ class ExpansionRelationship(BaseLineageRelationship):
     Child features have more granular ID columns than the parent. Each parent row
     generates multiple child rows with additional ID columns.
 
+    Construct this relationship via [`LineageRelationship.expansion`][metaxy.models.lineage.LineageRelationship.expansion] classmethod.
+
     Attributes:
         on: Parent ID columns that identify the parent record. Child records with
             the same parent IDs will share the same upstream provenance.
@@ -120,9 +128,10 @@ class ExpansionRelationship(BaseLineageRelationship):
             Can be "sequential", "hash", or a custom pattern. If not specified,
             the feature's load_input() method is responsible for ID generation.
 
-    Examples:
-        >>> ExpansionRelationship(on=["video_id"], id_generation_pattern="sequential")
-        ExpansionRelationship(type=<LineageRelationshipType.EXPANSION: '1:N'>, on=['video_id'], id_generation_pattern='sequential')
+    Example:
+        ```python
+        mx.LineageRelationship.expansion(on=["video_id"], id_generation_pattern="sequential")
+        ```
     """
 
     type: Literal[LineageRelationshipType.EXPANSION] = LineageRelationshipType.EXPANSION
@@ -179,9 +188,10 @@ class LineageRelationship(BaseModel):
         Returns:
             Configured LineageRelationship for 1:1 relationship.
 
-        Examples:
-            >>> LineageRelationship.identity()
-            LineageRelationship(relationship=IdentityRelationship(type=<LineageRelationshipType.IDENTITY: '1:1'>))
+        Example:
+            ```python
+            mx.LineageRelationship.identity()
+            ```
         """
         return cls(relationship=IdentityRelationship())
 
@@ -195,9 +205,10 @@ class LineageRelationship(BaseModel):
         Returns:
             Configured LineageRelationship for N:1 relationship.
 
-        Examples:
-            >>> LineageRelationship.aggregation(on=["sensor_id", "hour"])
-            LineageRelationship(relationship=AggregationRelationship(type=<LineageRelationshipType.AGGREGATION: 'N:1'>, on=['sensor_id', 'hour']))
+        Example:
+            ```py
+            mx.LineageRelationship.aggregation(on=["sensor_id", "hour"])
+            ```
         """
         return cls(relationship=AggregationRelationship(on=on))
 
@@ -219,9 +230,10 @@ class LineageRelationship(BaseModel):
         Returns:
             Configured LineageRelationship for 1:N relationship.
 
-        Examples:
-            >>> LineageRelationship.expansion(on=["video_id"], id_generation_pattern="sequential")
-            LineageRelationship(relationship=ExpansionRelationship(type=<LineageRelationshipType.EXPANSION: '1:N'>, on=['video_id'], id_generation_pattern='sequential'))
+        Example:
+            ```py
+            mx.LineageRelationship.expansion(on=["video_id"], id_generation_pattern="sequential")
+            ```
         """
         return cls(relationship=ExpansionRelationship(on=on, id_generation_pattern=id_generation_pattern))
 

--- a/src/metaxy/models/types.py
+++ b/src/metaxy/models/types.py
@@ -23,7 +23,7 @@ from pydantic import (
     model_validator,
 )
 
-from metaxy._public import public
+from metaxy._decorators import public
 
 if TYPE_CHECKING:
     from typing_extensions import Self
@@ -473,12 +473,9 @@ Accepted formats:
 
 Example:
     ```python
-    from metaxy import FeatureKey
-
-    # All of these are valid `CoercibleToFeatureKey` values:
     key1 = "raw/video"
     key2 = ["raw", "video"]
-    key3 = FeatureKey("raw/video")
+    key3 = mx.FeatureKey("raw/video")
     key4 = MyFeatureClass  # where MyFeatureClass is a BaseFeature subclass
     ```
 """
@@ -494,12 +491,9 @@ Accepted formats:
 
 Example:
     ```python
-    from metaxy import FieldKey
-
-    # All of these are valid `CoercibleToFieldKey` values:
     key1 = "audio/english"
     key2 = ["audio", "english"]
-    key3 = FieldKey("audio/english")
+    key3 = mx.FieldKey("audio/english")
     ```
 """
 

--- a/src/metaxy/utils/batched_writer.py
+++ b/src/metaxy/utils/batched_writer.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 import narwhals as nw
 
-from metaxy._public import public
+from metaxy._decorators import public
 from metaxy.config import MetaxyConfig
 from metaxy.models.feature import FeatureGraph
 from metaxy.models.types import CoercibleToFeatureKey, FeatureKey, ValidatedFeatureKeyAdapter
@@ -50,6 +50,7 @@ class BatchedMetadataWriter:
     main thread to continue processing data without blocking on writes.
 
     Example:
+        <!-- skip next -->
         ```py
         from metaxy.utils import BatchedMetadataWriter
 
@@ -59,6 +60,7 @@ class BatchedMetadataWriter:
         ```
 
     ??? example "Manual lifecycle management"
+        <!-- skip next -->
         ```py
         writer = BatchedMetadataWriter(store)
         writer.start()

--- a/src/metaxy/versioning/types.py
+++ b/src/metaxy/versioning/types.py
@@ -7,7 +7,7 @@ from typing import Any, NamedTuple
 import narwhals as nw
 import polars as pl
 
-from metaxy._public import public
+from metaxy._decorators import public
 from metaxy._utils import lazy_frame_to_polars
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -2885,6 +2885,7 @@ dev = [
     { name = "pytest-rerunfailures" },
     { name = "ray", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
     { name = "ruff" },
+    { name = "sybil" },
     { name = "syrupy" },
     { name = "ty" },
     { name = "vulture" },
@@ -2974,6 +2975,7 @@ dev = [
     { name = "pytest-rerunfailures", specifier = ">=15.0" },
     { name = "ray", marker = "python_full_version < '3.13' or sys_platform != 'win32'", specifier = ">2.36.0" },
     { name = "ruff", specifier = ">=0.14.4" },
+    { name = "sybil", specifier = ">=9.3.0" },
     { name = "syrupy", specifier = ">=5.0.0" },
     { name = "ty", specifier = "==0.0.10" },
     { name = "vulture", specifier = ">=2.14" },
@@ -5693,6 +5695,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e0/de/a0c3d1244912c260638f0f925e190e493ccea37ecaea9bbad7c14413b803/super_collections-0.6.2.tar.gz", hash = "sha256:0c8d8abacd9fad2c7c1c715f036c29f5db213f8cac65f24d45ecba12b4da187a", size = 31315, upload-time = "2025-09-30T00:37:08.067Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/17/43/47c7cf84b3bd74a8631b02d47db356656bb8dff6f2e61a4c749963814d0d/super_collections-0.6.2-py3-none-any.whl", hash = "sha256:291b74d26299e9051d69ad9d89e61b07b6646f86a57a2f5ab3063d206eee9c56", size = 16173, upload-time = "2025-09-30T00:37:07.104Z" },
+]
+
+[[package]]
+name = "sybil"
+version = "9.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/46/bae21847b8d761ddd6ede1811d32818342dbd482c32a2a5805c28d9b2f18/sybil-9.3.0.tar.gz", hash = "sha256:847d1d17b8a857c4bb3f8471b4a57b8affa939a60fbf507e70aa72ad79097c05", size = 89078, upload-time = "2025-12-02T09:29:09.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/08/cd3cf2a82570748cfb3142e795044197deff81ad3b70a0b9a9c22331e70a/sybil-9.3.0-py3-none-any.whl", hash = "sha256:0b108b980ab9fac774953042b07fcb5858aa19a38404d0cb42c30c93423ac0c1", size = 39286, upload-time = "2025-12-02T09:29:08.417Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This enables tests for docstrings, more specifically:

- python-native `Examples` sections
- any included Markdown code blocks

Closes #731