### PR TITLE
[core] MetadataStore API renames

### DIFF
--- a/docs/guide/learn/deletions.md
+++ b/docs/guide/learn/deletions.md
@@ -4,35 +4,35 @@ Metaxy supports two deletion modes: **soft deletes** that preserve history and *
 
 ## Soft deletes
 
-Soft deletes mark records as deleted without physically removing them. When you call `delete_metadata`, Metaxy appends a new row with the `metaxy_deleted_at` [system column](./system-columns.md) set to the deletion timestamp. This preserves your full history—nothing is lost, and you can always query for soft-deleted records if needed.
+Soft deletes mark records as deleted without physically removing them. When you call `delete`, Metaxy appends a new row with the `metaxy_deleted_at` [system column](./system-columns.md) set to the deletion timestamp. This preserves your full history—nothing is lost, and you can always query for soft-deleted records if needed.
 
-By default, `read_metadata` filters out soft-deleted records automatically. You only see active data. Behind the scenes, Metaxy keeps the latest version of each record by coalescing deletion and creation timestamps, so even if you've updated a record multiple times, queries return only the current state.
+By default, `read` filters out soft-deleted records automatically. You only see active data. Behind the scenes, Metaxy keeps the latest version of each record by coalescing deletion and creation timestamps, so even if you've updated a record multiple times, queries return only the current state.
 
 ```python
 import narwhals as nw
 
 with store.open("write"):
-    store.delete_metadata(
+    store.delete(
         MyFeature,
         filters=nw.col("status") == "pending",
     )
 
 with store:
-    active = store.read_metadata(MyFeature)
-    all_rows = store.read_metadata(MyFeature, include_soft_deleted=True)
+    active = store.read(MyFeature)
+    all_rows = store.read(MyFeature, include_soft_deleted=True)
 ```
 
-If you track custom deletion flags in your feature schema, filter them through `read_metadata` filters.
+If you track custom deletion flags in your feature schema, filter them through `read` filters.
 
 ## Hard deletes
 
-Hard deletes permanently remove rows from storage. Use them when you need to physically delete data, such as for compliance requirements or to reclaim space. Pass `soft=False` to `delete_metadata` and specify which records to remove with a filter expression.
+Hard deletes permanently remove rows from storage. Use them when you need to physically delete data, such as for compliance requirements or to reclaim space. Pass `soft=False` to `delete` and specify which records to remove with a filter expression.
 
 ```python
 import narwhals as nw
 
 with store.open("write"):
-    store.delete_metadata(
+    store.delete(
         MyFeature,
         filters=nw.col("quality") < 0.8,
         soft=False,

--- a/docs/guide/learn/feature-definitions.md
+++ b/docs/guide/learn/feature-definitions.md
@@ -201,7 +201,7 @@ Metaxy has a few safe guards in order to combat incorrect versioning information
 Additionally, the following actions always trigger a sync for external feature definitions:
 
 - pushing feature definitions to the metadata store (e.g. `metaxy push` CLI)
-- [`MetadataStore.read_metadata`][metaxy.MetadataStore.resolve_update]
+- [`MetadataStore.read`][metaxy.MetadataStore.resolve_update]
 - [`MetadataStore.resolve_update`][metaxy.MetadataStore.resolve_update]
 
 And some other places where it's appropriate and doesn't create an additional overhead.

--- a/docs/guide/learn/metadata-stores.md
+++ b/docs/guide/learn/metadata-stores.md
@@ -7,7 +7,7 @@ description: "How Metaxy abstracts metadata storage and versioning."
 
 Metaxy abstracts interactions with metadata stored in external systems such as databases, files, or object stores, through a unified interface: [`MetadataStore`][metaxy.MetadataStore].
 
-Metadata stores expose methods for [reading][metaxy.MetadataStore.read_metadata], [writing][metaxy.MetadataStore.write_metadata], deleting metadata, and the most important one: [resolve_update][metaxy.MetadataStore.resolve_update] for receiving a metadata increment.
+Metadata stores expose methods for [reading][metaxy.MetadataStore.read], [writing][metaxy.MetadataStore.write], deleting metadata, and the most important one: [resolve_update][metaxy.MetadataStore.resolve_update] for receiving a metadata increment.
 
 It looks more or less like this:
 
@@ -15,10 +15,10 @@ It looks more or less like this:
 
     ```py
     with store:
-        df = store.read_metadata(MyFeature)
+        df = store.read(MyFeature)
 
     with store.open("write"):
-        store.write_metadata(MyFeature, df)
+        store.write(MyFeature, df)
     ```
 
 Metadata stores implement an append-only storage model and rely on [Metaxy system columns](system-columns.md).
@@ -76,7 +76,7 @@ from datetime import datetime, timedelta, timezone
 import narwhals as nw
 
 with store.open("write"):
-    store.delete_metadata(
+    store.delete(
         MyFeature,
         filters=[nw.col("metaxy_created_at") < datetime.now(timezone.utc) - timedelta(days=30)],
     )

--- a/docs/guide/overview/quickstart.md
+++ b/docs/guide/overview/quickstart.md
@@ -94,7 +94,7 @@ if (len(increment.added) + len(increment.changed)) > 0:
 
 ```py {title="script.py"}
 with store.open("write"):
-    store.write_metadata(VoiceDetection, results)
+    store.write(VoiceDetection, results)
 ```
 
 We have now successfully recorded the metadata for the computed samples! Processed samples will no longer be returned by `MetadataStore.resolve_update` during future pipeline runs.

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,19 +23,35 @@ description: "A high level introduction to Metaxy."
 
 ## Metaxy
 
-Metaxy is a pluggable metadata layer for multi-modal Data and ML pipelines that manages and tracks **metadata**: sample [versions](guide/learn/data-versioning.md), dependencies, and data lineage across complex computational graphs. Metaxy gives you quite a few superpowers:
-
 <div class="annotate" markdown>
 
-- Cache every single sample in the data pipeline. Millions of cache keys can be calculated in under a second. (1)
-- Swap [storage backends](./guide/learn/metadata-stores.md) in dev, testing and production environments without changing a single line of code.
-- Use the [`mx` CLI](./reference/cli.md) to observe and manage metadata without leaving your terminal
-- Metaxy is **composable** and **extensible** (2): use it to build custom integrations and workflows!
+Metaxy is a pluggable metadata layer for building multi-modal Data and ML pipelines that manages and tracks **metadata** across complex computational graphs, including row-level [versions](guide/learn/data-versioning.md) (1), while allowing the codebase to evolve over time without friction. Metaxy gives you quite a few superpowers:
+
+- Cache every single sample in the data pipeline. Millions of cache keys can be calculated in under a second. (2)
+- Freedom from storage lock-in. Swap [storage backends](./integrations/metadata-stores/index.md) in development and production environments without breaking a sweat (3).
+- Use the [`mx` CLI](./reference/cli.md) to observe and manage metadata without leaving the comfort of your terminal.
+- Metaxy is **composable** and **extensible** (4): use it to build custom integrations and workflows!
 
 </div>
 
-1. Our experience at [Anam](https://anam.ai/) with [ClickHouse](./integrations/metadata-stores/databases/clickhouse.md)
-2. See our official integrations [here](./integrations/index.md)
+1. And even more granular [partial data versions](http://localhost:8000/guide/learn/data-versioning/#samples)
+2. Our experience at [Anam](https://anam.ai/) with [ClickHouse](./integrations/metadata-stores/databases/clickhouse.md)
+3. For example, develop against [DeltaLake](./integrations/metadata-stores/storage/delta.md) and scale production with [ClickHouse](./integrations/metadata-stores/databases/clickhouse.md) without code changes.
+4. See our official integrations [here](./integrations/index.md)
+
+
+!!! tip annotate "Granular Data Versioning"
+
+    The feature that makes Metaxy really stand out is the ability to track **partial data dependencies** (1) and **skip downstream updates** unless the exactly required subset of upstream data has changed. At the moment of writing, Metaxy is the only available tool that tackles these problems.
+
+1.  which are **very common** in multi-modal pipelines, for example when you only need to process video frames and not the audio tracks
+
+
+All of this is possible thanks to (1) [Narwhals](https://narwhals-dev.github.io/narwhals/), [Ibis](https://ibis-project.org/), and a few clever tricks.
+{ .annotate }
+
+1. we really do stand on the shoulders of giants
+
 
 ??? abstract annotate "Data vs Metadata Clarifications"
 
@@ -56,20 +72,18 @@ Metaxy is a pluggable metadata layer for multi-modal Data and ML pipelines that 
     | **Data** | The actual multi-modal data itself, such as images, audio files, video files, text documents, and other raw content that your pipelines process and transform. |
     | **Metadata** | Information about the data, typically including references to where data is stored (e.g., object store keys) plus additional descriptive entries such as video length, file size, format, version, and other attributes. |
 
-1. Unless you are a [LanceDB](https://lancedb.com/) fan, in which case [we got you covered](./integrations/metadata-stores/databases/lancedb.md)
+1.  Unless you are a [LanceDB](https://lancedb.com/) fan, in which case [we got you covered](./integrations/metadata-stores/databases/lancedb.md)
 
-The feature that makes Metaxy stand out is the ability to track **partial data dependencies** (1) and **skip downstream updates** unless the exactly required subset of upstream data has changed. At the moment of writing, Metaxy is the only available tool that tackles these problems.
+## Reliability
+
+Metaxy is fanatically tested across all supported metadata stores, Python versions and platforms [^1]. We guarantee versioning consistency across the supported metadata stores.
+
+Metaxy was built to handle large amounts of **big metadata** in distributed environments, makes very little assumptions about usage patterns and cannot enter an inconsistent state.
+
+We have been dogfooding Metaxy since December 2025 at Anam. We are running it in production with [ClickHouse](./integrations/metadata-stores/databases/clickhouse.md), [Dagster](./integrations/orchestration/dagster/index.md), and [Ray](./integrations/compute/ray.md) (1).
 { .annotate }
 
-1. which are **very common** in multi-modal pipelines, for example when you only need to process video frames and not the audio tracks
-
-!!! tip
-    Metaxy is [agnostic](./overview.md#composable) to orchestration frameworks, compute engines, data or [metadata storage](guide/learn/metadata-stores.md). Metaxy has no strict infrastructure requirements, and can scale to handle large amounts of **big metadata**. Metaxy is fanatically tested across all supported Python versions and platforms [^1].
-
-All of this is possible thanks to (1) [Narwhals](https://narwhals-dev.github.io/narwhals/), [Ibis](https://ibis-project.org/), and a few clever tricks.
-{ .annotate }
-
-1. we really do stand on the shoulders of giants
+1. and integrations with these tools are probably the most complete at the moment
 
 ## Installation
 
@@ -132,7 +146,7 @@ Sounds really bad, right? Yes, and it is (1). Until recently, a general solution
 
 ## More Information
 
-Because every main page needs this section.
+Here are a few more useful links:
 
 <div class="annotate" markdown>
 
@@ -147,6 +161,6 @@ Because every main page needs this section.
 
 </div>
 
-1. just one more page, I promise
+1. just one more page, I promise, just one more page
 
 [^1]: The CLI is not tested on Windows yet.

--- a/docs/integrations/orchestration/dagster/index.md
+++ b/docs/integrations/orchestration/dagster/index.md
@@ -141,7 +141,7 @@ The observation automatically tracks:
 
 ## Deletion workflows with Dagster ops
 
-The Dagster integration provides a `delete_metadata` op:
+The Dagster integration provides a `delete` op:
 
 ```python
 import dagster as dg
@@ -151,7 +151,7 @@ import metaxy.ext.dagster as mxd
 # Define a job with the delete op
 @dg.job(resource_defs={"metaxy_store": mxd.MetaxyStoreFromConfigResource(name="default")})
 def cleanup_job():
-    mxd.delete_metadata()
+    mxd.delete()
 ```
 
 `filters` is a list of SQL WHERE clause strings (e.g., `["status = 'inactive'", "age > 18"]`) that are parsed into Narwhals expressions. Multiple filters are combined with AND logic. See the [filter expressions guide](../../../guide/learn/filters.md) for supported syntax.

--- a/examples/example-aggregation/pipeline.py
+++ b/examples/example-aggregation/pipeline.py
@@ -47,10 +47,10 @@ def main():
         diff = store.resolve_update(Audio, samples=AUDIO_SAMPLES)
         if len(diff.added) > 0:
             print(f"Found {len(diff.added)} new audio recordings")
-            store.write_metadata(Audio, diff.added)
+            store.write(Audio, diff.added)
         elif len(diff.changed) > 0:
             print(f"Found {len(diff.changed)} changed audio recordings")
-            store.write_metadata(Audio, diff.changed)
+            store.write(Audio, diff.changed)
         else:
             print("No new or changed audio recordings")
 
@@ -102,7 +102,7 @@ def main():
 
             embedding_df = pl.DataFrame(embedding_data)
             print(f"Writing embeddings for {len(embedding_data)} speakers")
-            store.write_metadata(SpeakerEmbedding, embedding_df)
+            store.write(SpeakerEmbedding, embedding_df)
 
 
 if __name__ == "__main__":

--- a/examples/example-basic/src/example_basic/compute_child.py
+++ b/examples/example-basic/src/example_basic/compute_child.py
@@ -31,7 +31,7 @@ with config.get_store() as store:
     print(f"\n📊 Computing {child_key.to_string()}...")
     print(f"  feature_version: {mx.current_graph().get_feature_version(child_key)}")
 
-    ids_lazy = store.read_metadata(parent_key, columns=["sample_uid"])
+    ids_lazy = store.read(parent_key, columns=["sample_uid"])
     ids = ids_lazy.collect().to_polars()
 
     diff = store.resolve_update(child_key)
@@ -41,17 +41,17 @@ with config.get_store() as store:
     )
 
     if len(diff.added) > 0:
-        # diff.added is a Narwhals DataFrame - can pass directly to write_metadata
-        store.write_metadata(child_key, diff.added)
+        # diff.added is a Narwhals DataFrame - can pass directly to write
+        store.write(child_key, diff.added)
         print(f"✓ Materialized {len(diff.added)} new samples")
 
     if len(diff.changed) > 0:
         # diff.changed is a Narwhals DataFrame
-        store.write_metadata(child_key, diff.changed)
+        store.write(child_key, diff.changed)
         print(f"✓ Recomputed {len(diff.changed)} changed samples")
 
     # Show child provenance_by_field
-    child_result = store.read_metadata(child_key, current_only=True)
+    child_result = store.read(child_key, with_feature_history=False)
     print("\n📋 Child provenance_by_field:")
     # Materialize Narwhals LazyFrame to Polars DataFrame
     child_df = child_result.collect().to_polars()

--- a/examples/example-basic/src/example_basic/compute_parent.py
+++ b/examples/example-basic/src/example_basic/compute_parent.py
@@ -28,7 +28,7 @@ with config.get_store() as store:
 
     # Check if metadata already exists for current feature_version (avoid duplicates)
     try:
-        existing = store.read_metadata(parent_key, current_only=True)
+        existing = store.read(parent_key, with_feature_history=False)
         feature_version = mx.current_graph().get_feature_version(parent_key)
         if existing.collect().shape[0] > 0:
             print(
@@ -56,6 +56,6 @@ with config.get_store() as store:
             "metaxy_provenance_by_field": pl.Struct({"embeddings": pl.Utf8}),
         },
     )
-    store.write_metadata(parent_key, parent_metadata)
+    store.write(parent_key, parent_metadata)
 
     print(f"Written {len(parent_metadata)} rows for feature {parent_key}")

--- a/examples/example-migration/src/example_migration/compute_child.py
+++ b/examples/example-migration/src/example_migration/compute_child.py
@@ -29,18 +29,18 @@ with config.get_store() as store:
     )
 
     if len(diff_result.added) > 0:
-        store.write_metadata(child_key, diff_result.added)
+        store.write(child_key, diff_result.added)
         print(f"[OK] Materialized {len(diff_result.added)} new samples")
 
     if len(diff_result.changed) > 0:
         # This should NOT happen after migration!
-        store.write_metadata(child_key, diff_result.changed)
+        store.write(child_key, diff_result.changed)
         print(f"[WARN] Recomputed {len(diff_result.changed)} changed samples")
 
     # Show current data
     import narwhals as nw
 
-    child_result = store.read_metadata(child_key, current_only=True)
+    child_result = store.read(child_key, with_feature_history=False)
     child_eager = nw.from_native(child_result.collect())
     print("\nChild provenance_by_field:")
     for row in child_eager.iter_rows(named=True):

--- a/examples/example-migration/src/example_migration/compute_parent.py
+++ b/examples/example-migration/src/example_migration/compute_parent.py
@@ -30,5 +30,5 @@ with config.get_store() as store:
         }
     )
 
-    store.write_metadata(parent_key, parent_data)
+    store.write(parent_key, parent_data)
     print(f"[OK] Materialized {len(parent_data)} samples")

--- a/examples/example-one-to-many/pipeline.py
+++ b/examples/example-one-to-many/pipeline.py
@@ -34,7 +34,7 @@ def main():
         diff = store.resolve_update(Video, samples=nw.from_native(samples))
         if len(diff.added) > 0:
             print(f"Found {len(diff.added)} new videos")
-            store.write_metadata(Video, diff.added)
+            store.write(Video, diff.added)
 
     # Resolve videos that need to be split into chunks
     with store:
@@ -76,7 +76,7 @@ def main():
                 }
             )
             print(f"Writing {len(chunk_paths)} chunks for video {video_id}")
-            store.write_metadata(VideoChunk, nw.from_native(chunk_df))
+            store.write(VideoChunk, nw.from_native(chunk_df))
 
     # Process face recognition on video chunks
     with store:
@@ -109,7 +109,7 @@ def main():
 
             face_df = pl.DataFrame(face_data)
             print(f"Writing face recognition results for {len(face_data)} chunks")
-            store.write_metadata(FaceRecognition, nw.from_native(face_df))
+            store.write(FaceRecognition, nw.from_native(face_df))
 
 
 if __name__ == "__main__":

--- a/src/metaxy/ext/dagster/__init__.py
+++ b/src/metaxy/ext/dagster/__init__.py
@@ -1,5 +1,5 @@
 from metaxy._version import __version__
-from metaxy.ext.dagster.cleanup import delete_metadata
+from metaxy.ext.dagster.cleanup import delete
 from metaxy.ext.dagster.constants import (
     DAGSTER_METAXY_FEATURE_METADATA_KEY,
     DAGSTER_METAXY_INFO_METADATA_KEY,
@@ -67,5 +67,5 @@ __all__ = [
     "DAGSTER_METAXY_KIND",
     "DAGSTER_METAXY_PARTITION_KEY",
     "DAGSTER_METAXY_PROJECT_TAG_KEY",
-    "delete_metadata",
+    "delete",
 ]

--- a/src/metaxy/ext/dagster/cleanup.py
+++ b/src/metaxy/ext/dagster/cleanup.py
@@ -8,7 +8,7 @@ from metaxy.models.types import FeatureKey, ValidatedFeatureKeyList
 
 
 class DeleteMetadataConfig(dg.Config):
-    """Configuration for delete_metadata op.
+    """Configuration for delete op.
 
     Attributes:
         feature_key: Feature key validated using ValidatedFeatureKey semantics.
@@ -28,7 +28,7 @@ class DeleteMetadataConfig(dg.Config):
 
 
 @dg.op
-def delete_metadata(
+def delete(
     context: dg.OpExecutionContext,
     config: DeleteMetadataConfig,
     metaxy_store: dg.ResourceParam[mx.MetadataStore],
@@ -43,21 +43,21 @@ def delete_metadata(
     Example:
         ```python
         import dagster as dg
-        from metaxy.ext.dagster import delete_metadata
+        from metaxy.ext.dagster import delete
         from metaxy.ext.dagster.resources import MetaxyStoreFromConfigResource
 
 
         # Define a job with the delete op
         @dg.job(resource_defs={"metaxy_store": MetaxyStoreFromConfigResource(name="dev")})
         def cleanup_job():
-            delete_metadata()
+            delete()
 
 
         # Execute with config to delete inactive customer segments
         cleanup_job.execute_in_process(
             run_config={
                 "ops": {
-                    "delete_metadata": {
+                    "delete": {
                         "config": {
                             "feature_key": ["customer", "segment"],
                             "filters": ["status = 'inactive'"],
@@ -82,6 +82,6 @@ def delete_metadata(
     context.log.info(f"Executing {'soft' if config.soft else 'hard'} delete for {feature_key.to_string()}")
 
     with store.open("write"):
-        store.delete_metadata(feature_key, filters=filter_exprs, soft=config.soft)
+        store.delete(feature_key, filters=filter_exprs, soft=config.soft)
 
     context.log.info(f"Successfully completed delete for {feature_key.to_string()}")

--- a/src/metaxy/ext/dagster/io_manager.py
+++ b/src/metaxy/ext/dagster/io_manager.py
@@ -116,7 +116,7 @@ class MetaxyIOManager(dg.ConfigurableIOManager):
             filters = build_partition_filter_from_input_context(context)
 
             # Read metadata with store info in a single call (avoids extra network round-trip)
-            lazy_frame, resolved_store = self.metadata_store.read_metadata(
+            lazy_frame, resolved_store = self.metadata_store.read(
                 feature=feature_key,
                 filters=filters,
                 with_store_info=True,
@@ -167,7 +167,7 @@ class MetaxyIOManager(dg.ConfigurableIOManager):
         if obj is not None:
             context.log.debug(f'Writing metadata for Metaxy feature "{key.to_string()}" into {self.metadata_store}')
             with self.metadata_store.open("write"):
-                self.metadata_store.write_metadata(feature=feature, df=obj)
+                self.metadata_store.write(feature=feature, df=obj)
             context.log.debug(f'Metadata written for Metaxy feature "{key.to_string()}" into {self.metadata_store}')
         else:
             context.log.debug(
@@ -209,7 +209,7 @@ class MetaxyIOManager(dg.ConfigurableIOManager):
                 )
                 context.add_output_metadata(runtime_metadata)
 
-                mat_lazy_df = self.metadata_store.read_metadata(
+                mat_lazy_df = self.metadata_store.read(
                     feature,
                     filters=[nw.col(METAXY_MATERIALIZATION_ID) == context.run_id],
                 )

--- a/src/metaxy/ext/dagster/observable.py
+++ b/src/metaxy/ext/dagster/observable.py
@@ -102,7 +102,7 @@ def observable_metaxy_asset(
             filters = build_metaxy_partition_filter(metaxy_partition)
 
             with store:
-                lazy_df = store.read_metadata(feature_key, filters=filters)
+                lazy_df = store.read(feature_key, filters=filters)
                 stats = compute_stats_from_lazy_frame(lazy_df)
 
                 # Call the user's function - it can return additional metadata

--- a/src/metaxy/ext/dagster/observation_job.py
+++ b/src/metaxy/ext/dagster/observation_job.py
@@ -432,7 +432,7 @@ def _build_observation_op_for_specs(
 
         with store:
             try:
-                lazy_df = store.read_metadata(feature_key, filters=all_filters)
+                lazy_df = store.read(feature_key, filters=all_filters)
             except FeatureNotFoundError:
                 context.log.warning(
                     f"Feature {feature_key.to_string()} not found in store, returning empty observation"
@@ -452,7 +452,7 @@ def _build_observation_op_for_specs(
 
             if context.has_partition_key:
                 # Read entire feature (no partition filter) for total count
-                full_lazy_df = store.read_metadata(feature_key)
+                full_lazy_df = store.read(feature_key)
                 metadata["dagster/row_count"] = compute_row_count(full_lazy_df)
                 metadata["dagster/partition_row_count"] = partition_row_count
             else:

--- a/src/metaxy/ext/dagster/utils.py
+++ b/src/metaxy/ext/dagster/utils.py
@@ -244,7 +244,7 @@ def compute_feature_stats(
         FeatureStats with row_count and data_version.
     """
     with store:
-        lazy_df = store.read_metadata(feature)
+        lazy_df = store.read(feature)
         return compute_stats_from_lazy_frame(lazy_df)
 
 
@@ -358,7 +358,7 @@ def generate_materialize_results(
 
             # Get materialized-in-run count if materialization_id is set
             if store.materialization_id is not None:  # ty: ignore[possibly-missing-attribute]
-                mat_df = store.read_metadata(  # ty: ignore[possibly-missing-attribute]
+                mat_df = store.read(  # ty: ignore[possibly-missing-attribute]
                     key,
                     filters=[
                         nw.col(METAXY_MATERIALIZATION_ID) == store.materialization_id  # ty: ignore[possibly-missing-attribute]
@@ -507,7 +507,7 @@ def build_runtime_feature_metadata(
     all_filters = dagster_partition_filters + metaxy_partition_filters
 
     # Read metadata with store info in a single call (avoids extra network round-trip)
-    lazy_df, resolved_store = store.read_metadata(  # ty: ignore[possibly-missing-attribute]
+    lazy_df, resolved_store = store.read(  # ty: ignore[possibly-missing-attribute]
         feature_key, filters=all_filters, with_store_info=True
     )
 
@@ -535,7 +535,7 @@ def build_runtime_feature_metadata(
         # with only Dagster partition filters (not metaxy partition)
         if context.has_partition_key:
             # Read with only dagster partition filter for total count
-            full_lazy_df = store.read_metadata(  # ty: ignore[possibly-missing-attribute]
+            full_lazy_df = store.read(  # ty: ignore[possibly-missing-attribute]
                 feature_key, filters=metaxy_partition_filters
             )
             metadata["dagster/row_count"] = compute_row_count(full_lazy_df)

--- a/src/metaxy/ext/mcp/server.py
+++ b/src/metaxy/ext/mcp/server.py
@@ -234,8 +234,8 @@ def _register_tools(server: FastMCP) -> None:
         store_name: str,
         columns: list[str] | None = None,
         filters: list[str] | None = None,
-        current_only: bool = True,
-        latest_only: bool = True,
+        with_feature_history: bool = False,
+        with_sample_history: bool = False,
         include_soft_deleted: bool = False,
         allow_fallback: bool = True,
         sort_by: list[str] | None = None,
@@ -249,8 +249,8 @@ def _register_tools(server: FastMCP) -> None:
             store_name: Name of the metadata store to read from
             columns: List of columns to select (None for all)
             filters: List of SQL-like filter expressions (e.g., "column > 5", "name == 'foo'")
-            current_only: Only return current (non-superseded) rows (default: True)
-            latest_only: Only return latest version of each row (default: True)
+            with_feature_history: Only return current (non-superseded) rows (default: True)
+            with_sample_history: Only return latest version of each row (default: True)
             include_soft_deleted: Include soft-deleted rows (default: False)
             allow_fallback: If True, check fallback stores when feature is not found
                 in the primary store (default: True)
@@ -277,12 +277,12 @@ def _register_tools(server: FastMCP) -> None:
         nw_filters = _parse_filters(filters)
 
         with store:
-            lazy_frame = store.read_metadata(
+            lazy_frame = store.read(
                 definition,
                 columns=columns,
                 filters=nw_filters if nw_filters else None,
-                current_only=current_only,
-                latest_only=latest_only,
+                with_feature_history=with_feature_history,
+                with_sample_history=with_sample_history,
                 include_soft_deleted=include_soft_deleted,
                 allow_fallback=allow_fallback,
             )

--- a/src/metaxy/ext/ray/datasink.py
+++ b/src/metaxy/ext/ray/datasink.py
@@ -93,7 +93,7 @@ class MetaxyDatasink(Datasink[_WriteTaskResult]):
         ctx: TaskContext,
     ) -> _WriteTaskResult:
         """Write blocks of metadata to the store."""
-        # Initialize metaxy on the worker - config and features are needed for write_metadata
+        # Initialize metaxy on the worker - config and features are needed for write
         config = mx.init_metaxy(self.config)
         if config.sync:
             mx.sync_external_features(self.store)
@@ -107,7 +107,7 @@ class MetaxyDatasink(Datasink[_WriteTaskResult]):
 
             try:
                 with self.store.open("write"):
-                    self.store.write_metadata(self._feature_key, block)
+                    self.store.write(self._feature_key, block)
                 rows_written += num_rows
             except Exception:
                 logger.exception(

--- a/src/metaxy/graph/status.py
+++ b/src/metaxy/graph/status.py
@@ -300,8 +300,8 @@ def get_feature_metadata_status(
     # Get store metadata (table_name, uri, etc.)
     store_metadata = metadata_store.get_store_metadata(key)
 
-    # Combine global_filters and target_filters for read_metadata
-    # (read_metadata doesn't distinguish them - it only reads the target feature)
+    # Combine global_filters and target_filters for read
+    # (read doesn't distinguish them - it only reads the target feature)
     combined_filters: list[nw.Expr] = []
     if global_filters:
         combined_filters.extend(global_filters)
@@ -309,7 +309,7 @@ def get_feature_metadata_status(
         combined_filters.extend(target_filters)
 
     try:
-        metadata_lazy = metadata_store.read_metadata(
+        metadata_lazy = metadata_store.read(
             key,
             columns=list(id_columns_seq) if id_columns_seq is not None else None,
             allow_fallback=use_fallback,

--- a/src/metaxy/metadata_store/bigquery.py
+++ b/src/metaxy/metadata_store/bigquery.py
@@ -52,7 +52,7 @@ class BigQueryMetadataStore(IbisMetadataStore):
         When tables are partitioned (e.g., by date or ingestion time with _PARTITIONTIME), BigQuery will
         automatically prune partitions based on WHERE clauses in queries, without needing
         explicit configuration in the metadata store.
-        Make sure to use appropriate `filters` when calling [BigQueryMetadataStore.read_metadata][metaxy.metadata_store.bigquery.BigQueryMetadataStore.read_metadata].
+        Make sure to use appropriate `filters` when calling [BigQueryMetadataStore.read][metaxy.metadata_store.bigquery.BigQueryMetadataStore.read].
 
     Example: Basic Connection
         <!-- skip next -->

--- a/src/metaxy/metadata_store/delta.py
+++ b/src/metaxy/metadata_store/delta.py
@@ -268,7 +268,7 @@ class DeltaMetadataStore(MetadataStore):
 
     # ===== Storage operations =====
 
-    def write_metadata_to_store(
+    def _write_feature(
         self,
         feature_key: FeatureKey,
         df: Frame,
@@ -319,7 +319,7 @@ class DeltaMetadataStore(MetadataStore):
                 delta_write_options=write_opts or None,
             )
 
-    def _drop_feature_metadata_impl(self, feature_key: FeatureKey) -> None:
+    def _drop_feature(self, feature_key: FeatureKey) -> None:
         """Drop Delta table for the specified feature using soft delete.
 
         Uses Delta's delete operation which marks rows as deleted in the transaction log
@@ -336,12 +336,12 @@ class DeltaMetadataStore(MetadataStore):
         # This marks rows as deleted in transaction log without physically removing files
         delta_table.delete()
 
-    def _delete_metadata_impl(
+    def _delete_feature(
         self,
         feature_key: FeatureKey,
         filters: Sequence[nw.Expr] | None = None,
         *,
-        current_only: bool,
+        with_feature_history: bool,
     ) -> None:
         """Hard-delete rows from a Delta table using the native DELETE operation.
 
@@ -372,7 +372,7 @@ class DeltaMetadataStore(MetadataStore):
         # Use Delta's native DELETE operation
         delta_table.delete(predicate=predicate)
 
-    def read_metadata_in_store(
+    def _read_feature(
         self,
         feature: CoercibleToFeatureKey,
         *,

--- a/src/metaxy/metadata_store/lancedb.py
+++ b/src/metaxy/metadata_store/lancedb.py
@@ -270,7 +270,7 @@ class LanceDBMetadataStore(MetadataStore):
 
     # Storage ------------------------------------------------------------------
 
-    def write_metadata_to_store(
+    def _write_feature(
         self,
         feature_key: FeatureKey,
         df: Frame,
@@ -296,7 +296,7 @@ class LanceDBMetadataStore(MetadataStore):
         else:
             self.conn.create_table(table_name, data=df_polars)
 
-    def _drop_feature_metadata_impl(self, feature_key: FeatureKey) -> None:
+    def _drop_feature(self, feature_key: FeatureKey) -> None:
         """Drop Lance table for feature.
 
         Permanently removes the Lance table from the database directory.
@@ -309,12 +309,12 @@ class LanceDBMetadataStore(MetadataStore):
         if self._table_exists(table_name):
             self.conn.drop_table(table_name)
 
-    def _delete_metadata_impl(
+    def _delete_feature(
         self,
         feature_key: FeatureKey,
         filters: Sequence[nw.Expr] | None,
         *,
-        current_only: bool,
+        with_feature_history: bool,
     ) -> None:
         """Hard deletion for LanceDB. Calls the delete method on the Lance table.
 
@@ -352,7 +352,7 @@ class LanceDBMetadataStore(MetadataStore):
         # Use native LanceDB delete for efficient in-place deletion
         table.delete(filter_str)
 
-    def read_metadata_in_store(
+    def _read_feature(
         self,
         feature: CoercibleToFeatureKey,
         *,

--- a/src/metaxy/migrations/generator.py
+++ b/src/metaxy/migrations/generator.py
@@ -110,7 +110,7 @@ def generate_migration(
         from metaxy.metadata_store.system.keys import FEATURE_VERSIONS_KEY
 
         try:
-            feature_versions = store.read_metadata(FEATURE_VERSIONS_KEY, current_only=False)
+            feature_versions = store.read(FEATURE_VERSIONS_KEY, with_feature_history=True)
             # Get most recent snapshot - only collect the top row
             latest_snapshot = nw.from_native(feature_versions.sort("recorded_at", descending=True).head(1).collect())
             if latest_snapshot.shape[0] > 0:
@@ -219,9 +219,9 @@ def generate_migration(
 
         # Check if feature exists in from_snapshot (if not, it's new - skip)
         try:
-            from_metadata = store.read_metadata(
+            from_metadata = store.read(
                 downstream_key,
-                current_only=False,
+                with_feature_history=True,
                 allow_fallback=False,
                 filters=[nw.col("metaxy_snapshot_version") == from_snapshot_version],
             )
@@ -272,7 +272,7 @@ def generate_migration(
 
     parent_migration_id = None
     try:
-        existing_migrations = store.read_metadata(EVENTS_KEY, current_only=False)
+        existing_migrations = store.read(EVENTS_KEY, with_feature_history=True)
         # Get most recent migration by timestamp - only collect the top row
         latest = nw.from_native(existing_migrations.sort("timestamp", descending=True).head(1).collect())
         if latest.shape[0] > 0:

--- a/src/metaxy/migrations/ops.py
+++ b/src/metaxy/migrations/ops.py
@@ -195,9 +195,9 @@ class DataVersionReconciliation(BaseOperation):
 
         # 2. Query feature versions from snapshot metadata
         try:
-            from_version_data = store.read_metadata(
+            from_version_data = store.read(
                 FEATURE_VERSIONS_KEY,
-                current_only=False,
+                with_feature_history=True,
                 allow_fallback=False,
                 filters=[
                     (nw.col("metaxy_snapshot_version") == from_snapshot_version)
@@ -208,9 +208,9 @@ class DataVersionReconciliation(BaseOperation):
             from_version_data = None
 
         try:
-            to_version_data = store.read_metadata(
+            to_version_data = store.read(
                 FEATURE_VERSIONS_KEY,
-                current_only=False,
+                with_feature_history=True,
                 allow_fallback=False,
                 filters=[
                     (nw.col("metaxy_snapshot_version") == to_snapshot_version)
@@ -249,9 +249,9 @@ class DataVersionReconciliation(BaseOperation):
 
         # 3. Load existing metadata with old feature_version
         try:
-            existing_metadata = store.read_metadata(
+            existing_metadata = store.read(
                 feature_key_obj,
-                current_only=False,
+                with_feature_history=True,
                 filters=[nw.col("metaxy_feature_version") == from_feature_version],
                 allow_fallback=False,
             )
@@ -301,7 +301,7 @@ class DataVersionReconciliation(BaseOperation):
             return 0
 
         # 6. Write with new feature_version and snapshot_version
-        # Wrap in Narwhals for write_metadata
+        # Wrap in Narwhals for write
         df_to_write_nw = nw.from_native(df_to_write)
         df_to_write_nw = df_to_write_nw.with_columns(
             nw.lit(to_feature_version).alias("metaxy_feature_version"),
@@ -309,7 +309,7 @@ class DataVersionReconciliation(BaseOperation):
         )
 
         with allow_feature_version_override():
-            store.write_metadata(feature_key_obj, df_to_write_nw)
+            store.write(feature_key_obj, df_to_write_nw)
 
         return len(df_to_write)
 
@@ -382,7 +382,7 @@ class MetadataBackfill(BaseOperation, ABC):
                 to_write = external_df.join(diff.added, on="sample_uid", how="inner")
 
                 # Write
-                store.write_metadata(feature_key_obj, to_write)
+                store.write(feature_key_obj, to_write)
                 return len(to_write)
 
     Example YAML:

--- a/src/metaxy/utils/batched_writer.py
+++ b/src/metaxy/utils/batched_writer.py
@@ -65,7 +65,7 @@ class BatchedMetadataWriter:
             writer.put(batch)
 
         with store:
-            assert len(store.read_metadata(MyFeature).collect()) == 1
+            assert len(store.read(MyFeature).collect()) == 1
         ```
 
     ??? example "Manual lifecycle management"
@@ -140,7 +140,7 @@ class BatchedMetadataWriter:
         """Queue batches for writing.
 
         The batches are accumulated per-feature and written together using
-        `[MetadataStore.write_metadata_multi][]`.
+        `[MetadataStore.write_multi][]`.
 
         Args:
             batches: Mapping from feature keys to dataframes.
@@ -292,7 +292,7 @@ class BatchedMetadataWriter:
 
         # Write to store
         with self._store.open("write"):
-            self._store.write_metadata_multi(combined)
+            self._store.write_multi(combined)
 
         total_rows = sum(rows_per_feature.values())
         feature_count = len(combined)

--- a/tests/ext/dagster/test_cleanup_dagster.py
+++ b/tests/ext/dagster/test_cleanup_dagster.py
@@ -29,8 +29,8 @@ def feature_cls():
     return Logs
 
 
-def test_delete_metadata_op_with_mock():
-    """Test delete_metadata op with mocked store using simple feature key."""
+def test_delete_op_with_mock():
+    """Test delete op with mocked store using simple feature key."""
     store = MagicMock()
 
     ctx = dg.build_op_context(
@@ -42,15 +42,15 @@ def test_delete_metadata_op_with_mock():
         },
     )
 
-    mxd.delete_metadata(ctx)
-    store.delete_metadata.assert_called_once()
-    args, kwargs = store.delete_metadata.call_args
+    mxd.delete(ctx)
+    store.delete.assert_called_once()
+    args, kwargs = store.delete.call_args
     assert args[0] == FeatureKey(["logs"])
     assert kwargs["soft"] is True
 
 
-def test_delete_metadata_op_with_slashed_key():
-    """Test delete_metadata op with slashed feature key format."""
+def test_delete_op_with_slashed_key():
+    """Test delete op with slashed feature key format."""
     store = MagicMock()
 
     ctx = dg.build_op_context(
@@ -62,15 +62,15 @@ def test_delete_metadata_op_with_slashed_key():
         },
     )
 
-    mxd.delete_metadata(ctx)
-    store.delete_metadata.assert_called_once()
-    args, kwargs = store.delete_metadata.call_args
+    mxd.delete(ctx)
+    store.delete.assert_called_once()
+    args, kwargs = store.delete.call_args
     assert args[0] == FeatureKey(["customer", "segment"])
     assert kwargs["soft"] is True
 
 
-def test_delete_metadata_op_hard_delete_with_mock():
-    """Test delete_metadata op with hard delete."""
+def test_delete_op_hard_delete_with_mock():
+    """Test delete op with hard delete."""
     store = MagicMock()
 
     ctx = dg.build_op_context(
@@ -82,14 +82,14 @@ def test_delete_metadata_op_hard_delete_with_mock():
         },
     )
 
-    mxd.delete_metadata(ctx)
-    store.delete_metadata.assert_called_once()
-    args, kwargs = store.delete_metadata.call_args
+    mxd.delete(ctx)
+    store.delete.assert_called_once()
+    args, kwargs = store.delete.call_args
     assert args[0] == FeatureKey(["logs"])
     assert kwargs["soft"] is False
 
 
-def test_delete_metadata_integration(feature_cls, tmp_path):
+def test_delete_integration(feature_cls, tmp_path):
     """Integration test: create job, write data, run delete, verify results."""
 
     # Create a delta store
@@ -98,7 +98,7 @@ def test_delete_metadata_integration(feature_cls, tmp_path):
     # Define a job with the delete op
     @dg.job(resource_defs={"metaxy_store": dg.ResourceDefinition.hardcoded_resource(store)})
     def cleanup_job():
-        mxd.delete_metadata()
+        mxd.delete()
 
     # Write some test data
     test_data = pl.DataFrame(
@@ -114,18 +114,18 @@ def test_delete_metadata_integration(feature_cls, tmp_path):
     )
 
     with store.open("write"):
-        store.write_metadata(feature_cls, test_data)
+        store.write(feature_cls, test_data)
 
     # Verify data was written
     with store:
-        initial_data = store.read_metadata(feature_cls).collect().to_polars()
+        initial_data = store.read(feature_cls).collect().to_polars()
         assert initial_data.height == 3
 
     # Execute the job with config to delete debug logs
     result = cleanup_job.execute_in_process(
         run_config={
             "ops": {
-                "delete_metadata": {
+                "delete": {
                     "config": {
                         "feature_key": ["logs"],
                         "filters": ["level = 'debug'"],
@@ -141,16 +141,16 @@ def test_delete_metadata_integration(feature_cls, tmp_path):
 
     # Verify the data was soft-deleted (only 2 rows remain)
     with store:
-        remaining_data = store.read_metadata(feature_cls).collect().to_polars()
+        remaining_data = store.read(feature_cls).collect().to_polars()
         assert remaining_data.height == 2
         assert set(remaining_data["level"]) == {"info", "warn"}
 
         # Verify soft-deleted row is still in store when including deleted
-        all_data = store.read_metadata(feature_cls, include_soft_deleted=True).collect().to_polars()
+        all_data = store.read(feature_cls, include_soft_deleted=True).collect().to_polars()
         assert all_data.height == 3
 
 
-def test_delete_metadata_integration_hard_delete(feature_cls, tmp_path):
+def test_delete_integration_hard_delete(feature_cls, tmp_path):
     """Integration test for hard delete: data is physically removed."""
 
     # Create a delta store
@@ -159,7 +159,7 @@ def test_delete_metadata_integration_hard_delete(feature_cls, tmp_path):
     # Define a job with the delete op
     @dg.job(resource_defs={"metaxy_store": dg.ResourceDefinition.hardcoded_resource(store)})
     def hard_cleanup_job():
-        mxd.delete_metadata()
+        mxd.delete()
 
     # Write some test data
     test_data = pl.DataFrame(
@@ -175,13 +175,13 @@ def test_delete_metadata_integration_hard_delete(feature_cls, tmp_path):
     )
 
     with store.open("write"):
-        store.write_metadata(feature_cls, test_data)
+        store.write(feature_cls, test_data)
 
     # Execute the job with hard delete
     result = hard_cleanup_job.execute_in_process(
         run_config={
             "ops": {
-                "delete_metadata": {
+                "delete": {
                     "config": {
                         "feature_key": ["logs"],
                         "filters": ["level = 'debug'"],
@@ -197,10 +197,10 @@ def test_delete_metadata_integration_hard_delete(feature_cls, tmp_path):
 
     # Verify the data was physically removed (only 2 rows remain)
     with store:
-        remaining_data = store.read_metadata(feature_cls).collect().to_polars()
+        remaining_data = store.read(feature_cls).collect().to_polars()
         assert remaining_data.height == 2
         assert set(remaining_data["level"]) == {"info", "warn"}
 
         # Verify hard-deleted row is NOT in store even when including deleted
-        all_data = store.read_metadata(feature_cls, include_soft_deleted=True).collect().to_polars()
+        all_data = store.read(feature_cls, include_soft_deleted=True).collect().to_polars()
         assert all_data.height == 2  # Hard delete means it's gone

--- a/tests/ext/dagster/test_metaxify.py
+++ b/tests/ext/dagster/test_metaxify.py
@@ -791,7 +791,7 @@ class TestMetaxifyMaterialization:
         def downstream_asset(store: dg.ResourceParam[mx.MetadataStore]):
             # Read upstream data and verify it exists
             with store:
-                upstream_data = store.read_metadata(upstream_feature).collect()
+                upstream_data = store.read(upstream_feature).collect()
                 assert len(upstream_data) == 3
             return pl.DataFrame(
                 {
@@ -861,7 +861,7 @@ class TestMetaxifyMaterialization:
         def downstream_asset(store: dg.ResourceParam[mx.MetadataStore]):
             # Read upstream data via the store resource
             with store:
-                upstream_data = store.read_metadata(upstream_feature).collect()
+                upstream_data = store.read(upstream_feature).collect()
                 captured_data["rows"] = len(upstream_data)
                 captured_data["ids"] = upstream_data["id"].to_list()
             return pl.DataFrame(
@@ -912,7 +912,7 @@ class TestMetaxifyMaterialization:
 
         # First, write data directly to the store (simulating external feature population)
         with mx.MetaxyConfig.get().get_store("dev") as store:
-            store.write_metadata(
+            store.write(
                 feature=upstream_feature,
                 df=pl.DataFrame(
                     {

--- a/tests/ext/dagster/test_multi_asset_partition.py
+++ b/tests/ext/dagster/test_multi_asset_partition.py
@@ -188,7 +188,7 @@ class TestMultiAssetPartitionMaterialization:
 
         # Verify only US data is in the store so far
         with mx.MetaxyConfig.get().get_store("dev") as store:
-            data_after_a = store.read_metadata(shared_feature).collect()
+            data_after_a = store.read(shared_feature).collect()
             assert len(data_after_a) == 2
             assert set(data_after_a["region"].to_list()) == {"us"}
 
@@ -202,7 +202,7 @@ class TestMultiAssetPartitionMaterialization:
 
         # Verify both US and EU data are now in the store
         with mx.MetaxyConfig.get().get_store("dev") as store:
-            all_data = store.read_metadata(shared_feature).collect()
+            all_data = store.read(shared_feature).collect()
             assert len(all_data) == 5  # 2 US + 3 EU
             assert set(all_data["region"].to_list()) == {"us", "eu"}
             assert set(all_data["id"].to_list()) == {
@@ -414,7 +414,7 @@ class TestCompleteScenario:
 
         # Verify the feature has all 5 records in the store
         with mx.MetaxyConfig.get().get_store("dev") as store:
-            all_data = store.read_metadata(shared_feature).collect()
+            all_data = store.read(shared_feature).collect()
             assert len(all_data) == 5
             assert set(all_data["region"].to_list()) == {"us", "eu"}
             assert set(all_data["id"].to_list()) == {
@@ -511,5 +511,5 @@ class TestMetaxyPartitionWithMultipleColumns:
 
         # Verify both partitions are in the store
         with mx.MetaxyConfig.get().get_store("dev") as store:
-            all_data = store.read_metadata(multi_partition_feature).collect()
+            all_data = store.read(multi_partition_feature).collect()
             assert len(all_data) == 5

--- a/tests/ext/ray/test_datasink.py
+++ b/tests/ext/ray/test_datasink.py
@@ -44,7 +44,7 @@ def test_datasink_writes_metadata(
     ds.write_datasink(datasink)
 
     with delta_store.open("read"):
-        result = delta_store.read_metadata(FEATURE_KEY)
+        result = delta_store.read(FEATURE_KEY)
         assert result is not None
         df = result.collect()
 
@@ -85,7 +85,7 @@ def test_datasink_with_multiple_blocks(
     ds.write_datasink(datasink)
 
     with delta_store.open("read"):
-        result = delta_store.read_metadata(FEATURE_KEY)
+        result = delta_store.read(FEATURE_KEY)
         assert result is not None
         df = result.collect()
 
@@ -125,7 +125,7 @@ def test_datasink_feature_key_formats(
     ds.write_datasink(datasink)
 
     with delta_store.open("read"):
-        result = delta_store.read_metadata(FEATURE_KEY)
+        result = delta_store.read(FEATURE_KEY)
         assert result is not None
         df = result.collect()
         assert len(df) == 5
@@ -174,7 +174,7 @@ root_path = "{delta_root}"
     ds.write_datasink(datasink)
 
     with delta_store.open("read"):
-        result = delta_store.read_metadata(FEATURE_KEY)
+        result = delta_store.read(FEATURE_KEY)
         assert result is not None
         df = result.collect()
         assert len(df) == 5
@@ -203,7 +203,7 @@ def test_datasink_single_row(
     ds.write_datasink(datasink)
 
     with delta_store.open("read"):
-        result = delta_store.read_metadata(FEATURE_KEY)
+        result = delta_store.read(FEATURE_KEY)
         assert result is not None
         df = result.collect()
 
@@ -329,7 +329,7 @@ def test_datasink_result_aggregates_across_multiple_write_tasks(
 
     # Verify the data was actually written
     with delta_store.open("read"):
-        result = delta_store.read_metadata(FEATURE_KEY)
+        result = delta_store.read(FEATURE_KEY)
         assert result is not None
         df = result.collect()
         assert len(df) == 9

--- a/tests/ext/ray/test_datasource.py
+++ b/tests/ext/ray/test_datasource.py
@@ -36,7 +36,7 @@ def test_datasource_reads_metadata(
 
     # First, write some data to the store
     with delta_store.open("write"):
-        delta_store.write_metadata(FEATURE_KEY, test_data.to_arrow())
+        delta_store.write(FEATURE_KEY, test_data.to_arrow())
 
     # Read using datasource
     datasource = MetaxyDatasource(
@@ -75,7 +75,7 @@ def test_datasource_feature_key_formats(
 
     # Write data to the store
     with delta_store.open("write"):
-        delta_store.write_metadata(FEATURE_KEY, test_data.to_arrow())
+        delta_store.write(FEATURE_KEY, test_data.to_arrow())
 
     # Read using different feature key format
     datasource = MetaxyDatasource(
@@ -103,7 +103,7 @@ def test_datasource_single_row(
     single_row_data = make_test_data(sample_uids=["single"], values=[42])
 
     with delta_store.open("write"):
-        delta_store.write_metadata(FEATURE_KEY, single_row_data.to_arrow())
+        delta_store.write(FEATURE_KEY, single_row_data.to_arrow())
 
     datasource = MetaxyDatasource(
         feature=FEATURE_KEY,
@@ -186,7 +186,7 @@ def test_datasource_with_filters(
 
     # Write data to the store
     with delta_store.open("write"):
-        delta_store.write_metadata(FEATURE_KEY, test_data.to_arrow())
+        delta_store.write(FEATURE_KEY, test_data.to_arrow())
 
     # Read with filter: value > 2
     datasource = MetaxyDatasource(
@@ -218,7 +218,7 @@ def test_datasource_with_columns(
 
     # Write data to the store
     with delta_store.open("write"):
-        delta_store.write_metadata(FEATURE_KEY, test_data.to_arrow())
+        delta_store.write(FEATURE_KEY, test_data.to_arrow())
 
     # Read with column selection
     datasource = MetaxyDatasource(
@@ -251,7 +251,7 @@ def test_datasource_with_filters_and_columns(
 
     # Write data to the store
     with delta_store.open("write"):
-        delta_store.write_metadata(FEATURE_KEY, test_data.to_arrow())
+        delta_store.write(FEATURE_KEY, test_data.to_arrow())
 
     # Read with filter and column selection
     datasource = MetaxyDatasource(
@@ -305,7 +305,7 @@ root_path = "{delta_root}"
 
     # Write data first
     with delta_store.open("write"):
-        delta_store.write_metadata(FEATURE_KEY, test_data.to_arrow())
+        delta_store.write(FEATURE_KEY, test_data.to_arrow())
 
     # Create datasource with explicit config
     datasource = MetaxyDatasource(
@@ -380,7 +380,7 @@ def test_datasource_and_datasink_end_to_end(
 
     # Verify the result by reading from destination
     with dest_store.open("read"):
-        result = dest_store.read_metadata(FEATURE_KEY)
+        result = dest_store.read(FEATURE_KEY)
         df = result.collect()
 
         assert len(df) == 3
@@ -402,7 +402,7 @@ def test_datasource_incremental_all_new(
 
     # Write upstream data (root feature)
     with delta_store.open("write"):
-        delta_store.write_metadata(FEATURE_KEY, test_data.to_arrow())
+        delta_store.write(FEATURE_KEY, test_data.to_arrow())
 
     # Read incrementally from derived feature - all samples should be "new"
     datasource = MetaxyDatasource(
@@ -433,13 +433,13 @@ def test_datasource_incremental_up_to_date(
 
     # Write upstream data (root feature)
     with delta_store.open("write"):
-        delta_store.write_metadata(FEATURE_KEY, test_data.to_arrow())
+        delta_store.write(FEATURE_KEY, test_data.to_arrow())
 
     # Compute and write derived data with correct provenance
     with delta_store.open("write"):
         increment = delta_store.resolve_update(DERIVED_FEATURE_KEY)
         derived_data = increment.added.with_columns(nw.lit(100).alias("derived_value"))
-        delta_store.write_metadata(DERIVED_FEATURE_KEY, derived_data.to_arrow())
+        delta_store.write(DERIVED_FEATURE_KEY, derived_data.to_arrow())
 
     # Read incrementally - should return empty since data is up-to-date
     datasource = MetaxyDatasource(

--- a/tests/ext/test_mcp.py
+++ b/tests/ext/test_mcp.py
@@ -261,7 +261,7 @@ class TestGetMetadata:
         )
 
         with store.open("write"):
-            store.write_metadata(parent_cls, test_data)
+            store.write(parent_cls, test_data)
 
         result = await _call_tool(
             mcp_client,
@@ -289,7 +289,7 @@ class TestGetMetadata:
         )
 
         with store.open("write"):
-            store.write_metadata(parent_cls, test_data)
+            store.write(parent_cls, test_data)
 
         result = await _call_tool(
             mcp_client,
@@ -318,7 +318,7 @@ class TestGetMetadata:
         )
 
         with store.open("write"):
-            store.write_metadata(parent_cls, test_data)
+            store.write(parent_cls, test_data)
 
         result = await _call_tool(
             mcp_client,
@@ -348,7 +348,7 @@ class TestGetMetadata:
         )
 
         with store.open("write"):
-            store.write_metadata(parent_cls, test_data)
+            store.write(parent_cls, test_data)
 
         # Sort ascending
         result = await _call_tool(

--- a/tests/ext/test_sqlmodel.py
+++ b/tests/ext/test_sqlmodel.py
@@ -730,10 +730,10 @@ def test_sqlmodel_feature_with_duckdb_store(tmp_path: Path, snapshot: SnapshotAs
         )
 
         # Write metadata
-        store.write_metadata(VideoFeature, nw.from_native(metadata_df))
+        store.write(VideoFeature, nw.from_native(metadata_df))
 
         # Read metadata back
-        result = store.read_metadata(VideoFeature)
+        result = store.read(VideoFeature)
         result_df = collect_to_polars(result)
 
         # Verify data
@@ -880,10 +880,10 @@ def test_sqlmodel_duckdb_custom_id_columns(tmp_path: Path, snapshot: SnapshotAss
         )
 
         # Write parent metadata
-        store.write_metadata(UserActivityFeature, nw.from_native(parent_df))
+        store.write(UserActivityFeature, nw.from_native(parent_df))
 
         # Read back parent metadata
-        parent_result = store.read_metadata(UserActivityFeature)
+        parent_result = store.read(UserActivityFeature)
         parent_result_df = collect_to_polars(parent_result)
 
         # Verify parent data
@@ -926,10 +926,10 @@ def test_sqlmodel_duckdb_custom_id_columns(tmp_path: Path, snapshot: SnapshotAss
         )
 
         # Write child metadata
-        store.write_metadata(UserSummaryFeature, nw.from_native(child_df))
+        store.write(UserSummaryFeature, nw.from_native(child_df))
 
         # Read back child metadata
-        child_result = store.read_metadata(UserSummaryFeature)
+        child_result = store.read(UserSummaryFeature)
         child_result_df = collect_to_polars(child_result)
 
         # Verify child data
@@ -1171,7 +1171,7 @@ def test_sqlmodel_feature_id_columns_with_joins(tmp_path: Path, snapshot: Snapsh
                 ],
             }
         )
-        store.write_metadata(FeatureA, nw.from_native(df_a))
+        store.write(FeatureA, nw.from_native(df_a))
 
         # Write metadata for FeatureB (missing some combinations)
         df_b = pl.DataFrame(
@@ -1187,15 +1187,15 @@ def test_sqlmodel_feature_id_columns_with_joins(tmp_path: Path, snapshot: Snapsh
                 ],
             }
         )
-        store.write_metadata(FeatureB, nw.from_native(df_b))
+        store.write(FeatureB, nw.from_native(df_b))
 
         # Now test that joining works correctly
         # Inner join should only keep rows present in both A and B
         # Expected matches: (1, 2024-01-01), (1, 2024-01-02), (2, 2024-01-01), (3, 2024-01-01)
 
         # Read both features to verify
-        result_a = collect_to_polars(store.read_metadata(FeatureA))
-        result_b = collect_to_polars(store.read_metadata(FeatureB))
+        result_a = collect_to_polars(store.read(FeatureA))
+        result_b = collect_to_polars(store.read(FeatureB))
 
         # Verify the data was written correctly
         assert len(result_a) == 5
@@ -1664,7 +1664,7 @@ def test_sqlmodel_rename_validation_with_store(tmp_path: Path, snapshot: Snapsho
                 ],
             }
         )
-        store.write_metadata(SourceFeature, nw.from_native(source_df))
+        store.write(SourceFeature, nw.from_native(source_df))
 
         # Write target metadata
         target_df = pl.DataFrame(
@@ -1679,7 +1679,7 @@ def test_sqlmodel_rename_validation_with_store(tmp_path: Path, snapshot: Snapsho
                 ],
             }
         )
-        store.write_metadata(TargetFeature, nw.from_native(target_df))
+        store.write(TargetFeature, nw.from_native(target_df))
 
         # When loading input for TargetFeature, the rename should be applied
         # This would be used in the actual pipeline when computing features

--- a/tests/metadata_stores/test_bigquery.py
+++ b/tests/metadata_stores/test_bigquery.py
@@ -263,7 +263,7 @@ def test_bigquery_table_operations(mock_bigquery_connection, test_graph, test_fe
             dataset_id="test_dataset",
         ) as store:
             # Mock the write operation
-            store.write_metadata_to_store = MagicMock()  # ty: ignore[invalid-assignment]
+            store._write_feature = MagicMock()  # ty: ignore[invalid-assignment]
 
             metadata = pl.DataFrame(
                 {
@@ -275,9 +275,9 @@ def test_bigquery_table_operations(mock_bigquery_connection, test_graph, test_fe
                     ],
                 }
             )
-            store.write_metadata(test_features["UpstreamFeatureA"], metadata)
+            store.write(test_features["UpstreamFeatureA"], metadata)
 
             # Verify write was called with correct table name
-            assert store.write_metadata_to_store.called  # ty: ignore[unresolved-attribute]
-            call_args = store.write_metadata_to_store.call_args[0]  # ty: ignore[unresolved-attribute]
+            assert store._write_feature.called  # ty: ignore[unresolved-attribute]
+            call_args = store._write_feature.call_args[0]  # ty: ignore[unresolved-attribute]
             assert call_args[0].table_name == "test_stores__upstream_a"

--- a/tests/metadata_stores/test_delta.py
+++ b/tests/metadata_stores/test_delta.py
@@ -29,7 +29,7 @@ def test_delta_local_absolute_path(tmp_path, test_features) -> None:
                 "metaxy_provenance_by_field": [{"frames": "h1", "audio": "h1"}],
             }
         )
-        store.write_metadata(feature_cls, metadata)
+        store.write(feature_cls, metadata)
 
         # Verify the table was created under the store path, not current directory
         expected_path = store_path / "test_stores" / "upstream_a.delta"
@@ -38,7 +38,7 @@ def test_delta_local_absolute_path(tmp_path, test_features) -> None:
         )
 
         # Verify we can read the data back
-        result = store.read_metadata(feature_cls)
+        result = store.read(feature_cls)
         assert result is not None
         assert result.collect().to_native().height == 1
 
@@ -103,7 +103,7 @@ def test_delta_s3_storage_options_passed(s3_bucket_and_storage_options, test_fea
                 "metaxy_provenance_by_field": [{"frames": "h1", "audio": "h1"}],
             }
         )
-        store.write_metadata(feature_cls, metadata)
+        store.write(feature_cls, metadata)
         assert store.has_feature(feature_cls, check_fallback=False)
 
 
@@ -128,14 +128,14 @@ def test_delta_sink_lazyframe_local(tmp_path, test_features) -> None:
     )
 
     with DeltaMetadataStore(store_path) as store:
-        store.write_metadata(feature_cls, metadata_lazy)
+        store.write(feature_cls, metadata_lazy)
 
         # Verify the table was created
         expected_path = store_path / "test_stores" / "upstream_a.delta"
         assert expected_path.exists()
 
         # Verify we can read the data back
-        result = store.read_metadata(feature_cls)
+        result = store.read(feature_cls)
         assert result is not None
         assert result.collect().to_native().height == 3
 
@@ -162,12 +162,12 @@ def test_delta_sink_lazyframe_s3(s3_bucket_and_storage_options, test_features) -
     )
 
     with DeltaMetadataStore(store_path, storage_options=storage_options) as store:
-        store.write_metadata(feature_cls, metadata_lazy)
+        store.write(feature_cls, metadata_lazy)
 
         # Verify the feature exists
         assert store.has_feature(feature_cls, check_fallback=False)
 
         # Verify we can read the data back
-        result = store.read_metadata(feature_cls)
+        result = store.read(feature_cls)
         assert result is not None
         assert result.collect().to_native().height == 3

--- a/tests/metadata_stores/test_duckdb.py
+++ b/tests/metadata_stores/test_duckdb.py
@@ -34,7 +34,7 @@ def test_duckdb_table_naming(tmp_path: Path, test_graph, test_features: dict[str
                 METAXY_PROVENANCE_BY_FIELD: [{"frames": "h1", "audio": "h1"}],
             }
         )
-        store.write_metadata(test_features["UpstreamFeatureA"], metadata)
+        store.write(test_features["UpstreamFeatureA"], metadata)
 
         # Check table was created with correct name using Ibis
         table_names = store.conn.list_tables()
@@ -54,7 +54,7 @@ def test_duckdb_table_prefix_applied(tmp_path: Path, test_graph, test_features: 
                 METAXY_PROVENANCE_BY_FIELD: [{"frames": "h1", "audio": "h1"}],
             }
         )
-        store.write_metadata(feature, metadata)
+        store.write(feature, metadata)
 
         expected_feature_table = table_prefix + feature.spec.key.table_name
         expected_system_table = table_prefix + FEATURE_VERSIONS_KEY.table_name
@@ -148,11 +148,11 @@ def test_duckdb_persistence_across_instances(tmp_path: Path, test_graph, test_fe
                 ],
             }
         )
-        store1.write_metadata(test_features["UpstreamFeatureA"], metadata)
+        store1.write(test_features["UpstreamFeatureA"], metadata)
 
     # Read data in second instance
     with DuckDBMetadataStore(db_path, auto_create_tables=True) as store2:
-        result = collect_to_polars(store2.read_metadata(test_features["UpstreamFeatureA"]))
+        result = collect_to_polars(store2.read(test_features["UpstreamFeatureA"]))
 
         assert len(result) == 3
         assert set(result["sample_uid"].to_list()) == {1, 2, 3}

--- a/tests/metadata_stores/test_ducklake.py
+++ b/tests/metadata_stores/test_ducklake.py
@@ -236,8 +236,8 @@ def test_ducklake_store_read_write_roundtrip(test_features, monkeypatch, size) -
         )
 
         with store:
-            store.write_metadata(feature, payload)
-            result = collect_to_polars(store.read_metadata(feature))
+            store.write(feature, payload)
+            result = collect_to_polars(store.read(feature))
             actual = result.sort("sample_uid").select(["sample_uid", "metaxy_provenance_by_field"])
             expected = payload.sort("sample_uid")
             assert_frame_equal(actual, expected)
@@ -322,12 +322,12 @@ def test_ducklake_e2e_with_dependencies(test_graph, test_features, num_samples) 
 
             with store:
                 # Write upstream features
-                store.write_metadata(upstream_a, upstream_a_data)
-                store.write_metadata(upstream_b, upstream_b_data)
+                store.write(upstream_a, upstream_a_data)
+                store.write(upstream_b, upstream_b_data)
 
                 # Verify upstream features can be read back
-                result_a = collect_to_polars(store.read_metadata(upstream_a))
-                result_b = collect_to_polars(store.read_metadata(upstream_b))
+                result_a = collect_to_polars(store.read(upstream_a))
+                result_b = collect_to_polars(store.read(upstream_b))
 
                 assert_frame_equal(
                     result_a.sort("sample_uid").select(["sample_uid", "metaxy_provenance_by_field"]),
@@ -346,10 +346,10 @@ def test_ducklake_e2e_with_dependencies(test_graph, test_features, num_samples) 
                     }
                 )
 
-                store.write_metadata(downstream, downstream_data)
+                store.write(downstream, downstream_data)
 
                 # Verify downstream feature can be read back
-                result_d = collect_to_polars(store.read_metadata(downstream))
+                result_d = collect_to_polars(store.read(downstream))
                 assert_frame_equal(
                     result_d.sort("sample_uid").select(["sample_uid", "metaxy_provenance_by_field"]),
                     downstream_data.sort("sample_uid"),
@@ -378,10 +378,10 @@ def test_ducklake_e2e_with_dependencies(test_graph, test_features, num_samples) 
                     }
                 )
 
-                store.write_metadata(upstream_a, updated_upstream_a)
+                store.write(upstream_a, updated_upstream_a)
 
                 # Verify updated metadata - should have num_samples + 1 total
-                result_updated = collect_to_polars(store.read_metadata(upstream_a))
+                result_updated = collect_to_polars(store.read(upstream_a))
                 assert len(result_updated) == num_samples + 1
                 assert set(result_updated["sample_uid"].to_list()) == set(range(1, num_samples + 2))
 
@@ -395,14 +395,14 @@ def test_ducklake_e2e_with_dependencies(test_graph, test_features, num_samples) 
 
             with store2:
                 # Verify we can still read all features after reopening
-                result_a2 = collect_to_polars(store2.read_metadata(upstream_a))
+                result_a2 = collect_to_polars(store2.read(upstream_a))
                 assert len(result_a2) == num_samples + 1  # Original samples + 1 appended
                 assert set(result_a2["sample_uid"].to_list()) == set(range(1, num_samples + 2))
 
-                result_b2 = collect_to_polars(store2.read_metadata(upstream_b))
+                result_b2 = collect_to_polars(store2.read(upstream_b))
                 assert len(result_b2) == num_samples
 
-                result_d2 = collect_to_polars(store2.read_metadata(downstream))
+                result_d2 = collect_to_polars(store2.read(downstream))
                 assert len(result_d2) == num_samples
 
                 # Verify feature list persists (from active graph)

--- a/tests/metadata_stores/test_feature_dep_filters.py
+++ b/tests/metadata_stores/test_feature_dep_filters.py
@@ -174,7 +174,7 @@ def test_feature_dep_filters_integration(any_store: MetadataStore) -> None:
             from metaxy.metadata_store import HashAlgorithmNotSupportedError
 
             try:
-                store.write_metadata(UpstreamFeature, upstream_data)
+                store.write(UpstreamFeature, upstream_data)
 
                 # Resolve downstream feature - this should trigger FeatureDepTransformer
                 # which will read upstream data and apply filters

--- a/tests/metadata_stores/test_hash_algorithms.py
+++ b/tests/metadata_stores/test_hash_algorithms.py
@@ -85,7 +85,7 @@ def test_hash_algorithm_produces_consistent_hashes(
 
     with store, graph.use():
         # Write parent metadata
-        store.write_metadata(ParentFeature, parent_df)
+        store.write(ParentFeature, parent_df)
 
         # Compute child metadata twice
         increment1 = store.resolve_update(
@@ -186,7 +186,7 @@ def test_hash_truncation(
 
     with store, graph.use():
         # Write parent metadata
-        store.write_metadata(ParentFeature, parent_df)
+        store.write(ParentFeature, parent_df)
 
         # Compute child metadata
         increment = store.resolve_update(
@@ -263,7 +263,7 @@ def test_field_level_provenance_structure(
         parent_df = upstream_data["parent"]
 
         # Write parent and compute child
-        store.write_metadata(ParentFeature, parent_df)
+        store.write(ParentFeature, parent_df)
         increment = store.resolve_update(
             ChildFeature,
             target_version=ChildFeature.feature_version(),
@@ -341,7 +341,7 @@ def test_hash_truncation_any_store(config_with_truncation, any_store: MetadataSt
 
     with any_store, graph.use():
         # Write parent metadata
-        any_store.write_metadata(ParentFeature, parent_df)
+        any_store.write(ParentFeature, parent_df)
 
         # Compute child metadata
         increment = any_store.resolve_update(

--- a/tests/metadata_stores/test_input_progress.py
+++ b/tests/metadata_stores/test_input_progress.py
@@ -97,11 +97,11 @@ class TestCalculateInputProgress:
                 }
             )
             upstream_data = add_metaxy_provenance_column(upstream_data, Upstream)
-            store.write_metadata(Upstream, nw.from_native(upstream_data))
+            store.write(Upstream, nw.from_native(upstream_data))
 
             # Write downstream metadata for all samples
             increment = store.resolve_update(Downstream, lazy=False)
-            store.write_metadata(Downstream, increment.added)
+            store.write(Downstream, increment.added)
 
             # Now check progress - should be 100%
             lazy_increment = store.resolve_update(Downstream, lazy=True)
@@ -142,12 +142,12 @@ class TestCalculateInputProgress:
                 }
             )
             upstream_data = add_metaxy_provenance_column(upstream_data, Upstream)
-            store.write_metadata(Upstream, nw.from_native(upstream_data))
+            store.write(Upstream, nw.from_native(upstream_data))
 
             # Write downstream metadata for only 3 samples
             increment = store.resolve_update(Downstream, lazy=False)
             partial_data = increment.added.to_polars().head(3)
-            store.write_metadata(Downstream, partial_data)
+            store.write(Downstream, partial_data)
 
             # Check progress - should be 30% (3/10)
             lazy_increment = store.resolve_update(Downstream, lazy=True)
@@ -188,7 +188,7 @@ class TestCalculateInputProgress:
                 }
             )
             upstream_data = add_metaxy_provenance_column(upstream_data, Upstream)
-            store.write_metadata(Upstream, nw.from_native(upstream_data))
+            store.write(Upstream, nw.from_native(upstream_data))
 
             # Resolve update - should have no input to process
             lazy_increment = store.resolve_update(Downstream, lazy=True)
@@ -234,12 +234,12 @@ class TestCalculateInputProgress:
                 }
             )
             upstream_data = add_metaxy_provenance_column(upstream_data, Upstream)
-            store.write_metadata(Upstream, nw.from_native(upstream_data))
+            store.write(Upstream, nw.from_native(upstream_data))
 
             # Write downstream for 2 out of 3 samples
             increment = store.resolve_update(Downstream, lazy=False)
             partial_data = increment.added.to_polars().head(2)
-            store.write_metadata(Downstream, partial_data)
+            store.write(Downstream, partial_data)
 
             # Check progress - should be 66.67% (2/3)
             lazy_increment = store.resolve_update(Downstream, lazy=True)
@@ -303,12 +303,12 @@ class TestCalculateInputProgress:
                 }
             )
             upstream_data = add_metaxy_provenance_column(upstream_data, SensorReadings)
-            store.write_metadata(SensorReadings, nw.from_native(upstream_data))
+            store.write(SensorReadings, nw.from_native(upstream_data))
 
             # Write downstream for only 1 hour (1 out of 2 groups)
             increment = store.resolve_update(HourlyStats, lazy=False)
             partial_data = increment.added.to_polars().head(1)
-            store.write_metadata(HourlyStats, partial_data)
+            store.write(HourlyStats, partial_data)
 
             # Progress should count by aggregation groups, not individual readings
             # 1 hour processed out of 2 hours = 50%
@@ -355,7 +355,7 @@ class TestCalculateInputProgress:
                 }
             )
             upstream_data = add_metaxy_provenance_column(upstream_data, Video)
-            store.write_metadata(Video, nw.from_native(upstream_data))
+            store.write(Video, nw.from_native(upstream_data))
 
             # Write frames for 2 videos (multiple frames per video)
             # For expansion lineage, user must manually create expanded rows with frame_id
@@ -368,7 +368,7 @@ class TestCalculateInputProgress:
                 }
             )
             # Read upstream from store to get metaxy_data_version_by_field column
-            upstream_from_store = store.read_metadata(Video).collect().to_polars()
+            upstream_from_store = store.read(Video).collect().to_polars()
             # Join with upstream to get provenance info
             frames_with_upstream = frames_data.join(
                 upstream_from_store.select(
@@ -381,7 +381,7 @@ class TestCalculateInputProgress:
             )
             # Compute provenance for VideoFrames
             frames_with_prov = store.compute_provenance(VideoFrames, nw.from_native(frames_with_upstream))
-            store.write_metadata(VideoFrames, frames_with_prov)
+            store.write(VideoFrames, frames_with_prov)
 
             # Progress should count by parent videos, not individual frames
             # 2 videos processed out of 3 = 66.67%
@@ -429,12 +429,12 @@ class TestCalculateInputProgress:
                 }
             )
             upstream_data = add_metaxy_provenance_column(upstream_data, Upstream)
-            store.write_metadata(Upstream, nw.from_native(upstream_data))
+            store.write(Upstream, nw.from_native(upstream_data))
 
             # Write downstream for 2 out of 4 samples
             increment = store.resolve_update(Downstream, lazy=False)
             partial_data = increment.added.to_polars().head(2)
-            store.write_metadata(Downstream, partial_data)
+            store.write(Downstream, partial_data)
 
             # Check progress - should be 50% (2/4)
             lazy_increment = store.resolve_update(Downstream, lazy=True)
@@ -485,7 +485,7 @@ class TestCalculateInputProgress:
                 }
             )
             upstream_a_data = add_metaxy_provenance_column(upstream_a_data, UpstreamA)
-            store.write_metadata(UpstreamA, nw.from_native(upstream_a_data))
+            store.write(UpstreamA, nw.from_native(upstream_a_data))
 
             # Write upstream B
             upstream_b_data = pl.DataFrame(
@@ -496,12 +496,12 @@ class TestCalculateInputProgress:
                 }
             )
             upstream_b_data = add_metaxy_provenance_column(upstream_b_data, UpstreamB)
-            store.write_metadata(UpstreamB, nw.from_native(upstream_b_data))
+            store.write(UpstreamB, nw.from_native(upstream_b_data))
 
             # Write downstream for 1 out of 3 samples
             increment = store.resolve_update(Downstream, lazy=False)
             partial_data = increment.added.to_polars().head(1)
-            store.write_metadata(Downstream, partial_data)
+            store.write(Downstream, partial_data)
 
             # Check progress - should be 33.33% (1/3)
             lazy_increment = store.resolve_update(Downstream, lazy=True)

--- a/tests/metadata_stores/test_lancedb.py
+++ b/tests/metadata_stores/test_lancedb.py
@@ -46,7 +46,7 @@ def test_lancedb_table_naming(tmp_path, test_graph, test_features) -> None:
                 "metaxy_provenance_by_field": [{"frames": "h1", "audio": "h1"}],
             }
         )
-        store.write_metadata(feature_cls, metadata)
+        store.write(feature_cls, metadata)
 
         # Verify table was created (uses optimized _table_exists internally)
         assert store.has_feature(feature_cls, check_fallback=False)
@@ -219,7 +219,7 @@ def test_lancedb_has_feature_without_listing_tables(tmp_path, test_features) -> 
                 "metaxy_provenance_by_field": [{"frames": "h1", "audio": "h1"}],
             }
         )
-        store.write_metadata(feature_cls, metadata)
+        store.write(feature_cls, metadata)
 
         original_table_names = store.conn.table_names
         table_names_mock = Mock(side_effect=original_table_names)
@@ -251,10 +251,10 @@ def test_lancedb_s3_storage_options_passed(s3_bucket_and_storage_options, test_f
                 ],
             }
         )
-        store.write_metadata(feature_cls, metadata)
+        store.write(feature_cls, metadata)
 
         assert store.has_feature(feature_cls, check_fallback=False)
 
-        result = collect_to_polars(store.read_metadata(feature_cls))
+        result = collect_to_polars(store.read(feature_cls))
         assert len(result) == 2
         assert set(result["sample_uid"].to_list()) == {1, 2}

--- a/tests/metadata_stores/test_lancedb_integration.py
+++ b/tests/metadata_stores/test_lancedb_integration.py
@@ -24,10 +24,10 @@ def test_lancedb_s3_roundtrip_with_moto(s3_bucket_and_storage_options, test_feat
                 ],
             }
         )
-        store.write_metadata(feature_cls, metadata)
+        store.write(feature_cls, metadata)
 
         assert store.has_feature(feature_cls, check_fallback=False)
 
-        result = collect_to_polars(store.read_metadata(feature_cls))
+        result = collect_to_polars(store.read(feature_cls))
         assert result.shape[0] == 2
         assert set(result["sample_uid"].to_list()) == {1, 2}

--- a/tests/metadata_stores/test_load_feature_definitions.py
+++ b/tests/metadata_stores/test_load_feature_definitions.py
@@ -683,7 +683,7 @@ def test_resolve_update_loads_external_feature_definitions(tmp_path: Path):
                     "metaxy_data_version": ["prov1", "prov2"],
                 }
             )
-            store.write_metadata(UpstreamFeature, upstream_metadata)
+            store.write(UpstreamFeature, upstream_metadata)
 
         # Get the expected version when upstream is fully defined
         expected_upstream_version = source_graph.get_feature_version(["resolve_test", "upstream"])

--- a/tests/metadata_stores/test_materialization_id.py
+++ b/tests/metadata_stores/test_materialization_id.py
@@ -29,14 +29,14 @@ def test_store_level_materialization_id(store: MetadataStore):
         id: str
 
     with store.open(mode="write"):
-        store.write_metadata(
+        store.write(
             key,
             pl.DataFrame([{"id": "1", METAXY_PROVENANCE_BY_FIELD: {"default": "abc"}}]),
         )
 
     # Read back and verify materialization_id
     with store.open(mode="read"):
-        df = store.read_metadata(key)
+        df = store.read(key)
         assert df is not None
         df_collected = df.collect()
         assert METAXY_MATERIALIZATION_ID in df_collected.columns
@@ -58,7 +58,7 @@ def test_write_level_materialization_id_override(store: MetadataStore):
         id: str
 
     with store.open(mode="write"):
-        store.write_metadata(
+        store.write(
             key,
             pl.DataFrame([{"id": "1", METAXY_PROVENANCE_BY_FIELD: {"default": "abc"}}]),
             materialization_id="override-run-456",
@@ -66,7 +66,7 @@ def test_write_level_materialization_id_override(store: MetadataStore):
 
     # Verify override was applied
     with store.open(mode="read"):
-        df = store.read_metadata(key)
+        df = store.read(key)
         assert df is not None
         df_collected = df.collect()
         assert df_collected[METAXY_MATERIALIZATION_ID][0] == "override-run-456"
@@ -84,14 +84,14 @@ def test_nullable_materialization_id(store: MetadataStore):
         id: str
 
     with store.open(mode="write"):
-        store.write_metadata(
+        store.write(
             key,
             pl.DataFrame([{"id": "1", METAXY_PROVENANCE_BY_FIELD: {"default": "abc"}}]),
         )
 
     # Verify column exists but is null
     with store.open(mode="read"):
-        df = store.read_metadata(key)
+        df = store.read(key)
         assert df is not None
         df_collected = df.collect()
         assert METAXY_MATERIALIZATION_ID in df_collected.columns
@@ -111,17 +111,17 @@ def test_filter_by_materialization_id(store: MetadataStore):
 
     # Write multiple batches with different IDs
     with store.open(mode="write"):
-        store.write_metadata(
+        store.write(
             key,
             pl.DataFrame([{"id": "1", METAXY_PROVENANCE_BY_FIELD: {"default": "abc"}}]),
             materialization_id="run-1",
         )
-        store.write_metadata(
+        store.write(
             key,
             pl.DataFrame([{"id": "2", METAXY_PROVENANCE_BY_FIELD: {"default": "def"}}]),
             materialization_id="run-2",
         )
-        store.write_metadata(
+        store.write(
             key,
             pl.DataFrame([{"id": "3", METAXY_PROVENANCE_BY_FIELD: {"default": "ghi"}}]),
             materialization_id="run-1",
@@ -129,7 +129,7 @@ def test_filter_by_materialization_id(store: MetadataStore):
 
     # Filter by run-1
     with store.open(mode="read"):
-        df = store.read_metadata(key, filters=[nw.col(METAXY_MATERIALIZATION_ID) == "run-1"])
+        df = store.read(key, filters=[nw.col(METAXY_MATERIALIZATION_ID) == "run-1"])
         assert df is not None
         df_collected = df.collect()
         assert len(df_collected) == 2
@@ -137,7 +137,7 @@ def test_filter_by_materialization_id(store: MetadataStore):
 
     # Filter by run-2
     with store.open(mode="read"):
-        df = store.read_metadata(key, filters=[nw.col(METAXY_MATERIALIZATION_ID) == "run-2"])
+        df = store.read(key, filters=[nw.col(METAXY_MATERIALIZATION_ID) == "run-2"])
         assert df is not None
         df_collected = df.collect()
         assert len(df_collected) == 1
@@ -158,7 +158,7 @@ def test_materialization_id_multiple_writes(store: MetadataStore):
     # Write with different materialization_ids
     with store.open(mode="write"):
         for i in range(3):
-            store.write_metadata(
+            store.write(
                 key,
                 pl.DataFrame(
                     [
@@ -173,7 +173,7 @@ def test_materialization_id_multiple_writes(store: MetadataStore):
 
     # Read all and verify each has its materialization_id
     with store.open(mode="read"):
-        df = store.read_metadata(key, latest_only=False)
+        df = store.read(key, with_sample_history=True)
         assert df is not None
         df_collected = df.collect()
         assert len(df_collected) == 3

--- a/tests/metadata_stores/test_metadata_store.py
+++ b/tests/metadata_stores/test_metadata_store.py
@@ -135,7 +135,7 @@ def populated_store(
             prefix="hash_a",
             include_path=True,
         )
-        store.write_metadata(UpstreamFeatureA, upstream_a_data)
+        store.write(UpstreamFeatureA, upstream_a_data)
 
     yield store
 
@@ -156,7 +156,7 @@ def multi_env_stores(
             prefix="prod_hash",
             include_path=False,
         )
-        prod.write_metadata(UpstreamFeatureA, upstream_data)
+        prod.write(UpstreamFeatureA, upstream_data)
 
     yield {"prod": prod, "staging": staging, "dev": dev}
 
@@ -164,7 +164,7 @@ def multi_env_stores(
 # Basic CRUD Tests
 
 
-def test_write_and_read_metadata(empty_store: DeltaMetadataStore, UpstreamFeatureA, make_upstream_a_data) -> None:
+def test_write_and_read(empty_store: DeltaMetadataStore, UpstreamFeatureA, make_upstream_a_data) -> None:
     """Test basic write and read operations."""
     with empty_store.open("write"):
         metadata = make_upstream_a_data(
@@ -173,8 +173,8 @@ def test_write_and_read_metadata(empty_store: DeltaMetadataStore, UpstreamFeatur
             include_path=False,
         )
 
-        empty_store.write_metadata(UpstreamFeatureA, metadata)
-        result = collect_to_polars(empty_store.read_metadata(UpstreamFeatureA))
+        empty_store.write(UpstreamFeatureA, metadata)
+        result = collect_to_polars(empty_store.read(UpstreamFeatureA))
 
         assert len(result) == 3
         assert "sample_uid" in result.columns
@@ -192,7 +192,7 @@ def test_write_invalid_schema(empty_store: DeltaMetadataStore, UpstreamFeatureA)
         )
 
         with pytest.raises(MetadataSchemaError, match="metaxy_provenance_by_field"):
-            empty_store.write_metadata(UpstreamFeatureA, invalid_df)
+            empty_store.write(UpstreamFeatureA, invalid_df)
 
 
 def test_write_append(
@@ -213,10 +213,10 @@ def test_write_append(
             include_path=False,
         )
 
-        empty_store.write_metadata(UpstreamFeatureA, df1)
-        empty_store.write_metadata(UpstreamFeatureA, df2)
+        empty_store.write(UpstreamFeatureA, df1)
+        empty_store.write(UpstreamFeatureA, df2)
 
-        result = collect_to_polars(empty_store.read_metadata(UpstreamFeatureA))
+        result = collect_to_polars(empty_store.read(UpstreamFeatureA))
         assert len(result) == 4
         assert set(result["sample_uid"].to_list()) == {1, 2, 3, 4}
 
@@ -224,7 +224,7 @@ def test_write_append(
 def test_read_with_filters(populated_store: DeltaMetadataStore, UpstreamFeatureA) -> None:
     """Test reading with Polars filter expressions."""
     with populated_store.open("write"):
-        result = collect_to_polars(populated_store.read_metadata(UpstreamFeatureA, filters=[nw.col("sample_uid") > 1]))
+        result = collect_to_polars(populated_store.read(UpstreamFeatureA, filters=[nw.col("sample_uid") > 1]))
 
         assert len(result) == 2
         assert set(result["sample_uid"].to_list()) == {2, 3}
@@ -234,7 +234,7 @@ def test_read_with_column_selection(populated_store: DeltaMetadataStore, Upstrea
     """Test reading specific columns."""
     with populated_store.open("write"):
         result = collect_to_polars(
-            populated_store.read_metadata(UpstreamFeatureA, columns=["sample_uid", "metaxy_provenance_by_field"])
+            populated_store.read(UpstreamFeatureA, columns=["sample_uid", "metaxy_provenance_by_field"])
         )
 
         assert set(result.columns) == {"sample_uid", "metaxy_provenance_by_field"}
@@ -245,7 +245,7 @@ def test_read_nonexistent_feature(empty_store: DeltaMetadataStore, UpstreamFeatu
     """Test that reading nonexistent feature raises error."""
     with empty_store.open("write"):
         with pytest.raises(FeatureNotFoundError):
-            empty_store.read_metadata(UpstreamFeatureA)
+            empty_store.read(UpstreamFeatureA)
 
 
 # Feature Existence Tests
@@ -285,7 +285,7 @@ def test_read_from_fallback(multi_env_stores: dict[str, DeltaMetadataStore], Ups
 
     with dev, staging, prod:
         # Read from prod via fallback chain
-        result = collect_to_polars(dev.read_metadata(UpstreamFeatureA, allow_fallback=True))
+        result = collect_to_polars(dev.read(UpstreamFeatureA, allow_fallback=True))
         assert len(result) == 3
 
 
@@ -295,7 +295,7 @@ def test_read_no_fallback(multi_env_stores: dict[str, DeltaMetadataStore], Upstr
 
     with dev:
         with pytest.raises(FeatureNotFoundError):
-            dev.read_metadata(UpstreamFeatureA, allow_fallback=False)
+            dev.read(UpstreamFeatureA, allow_fallback=False)
 
 
 def test_soft_delete_from_fallback_creates_soft_deletion_marker(
@@ -309,15 +309,15 @@ def test_soft_delete_from_fallback_creates_soft_deletion_marker(
     with dev, staging, prod:
         assert not dev.has_feature(UpstreamFeatureA, check_fallback=False)
 
-        dev.delete_metadata(
+        dev.delete(
             UpstreamFeatureA,
             filters=nw.col("sample_uid") == 1,
             soft=True,
-            current_only=True,
+            with_feature_history=False,
         )
 
         soft_deletion_markers = collect_to_polars(
-            dev.read_metadata(
+            dev.read(
                 UpstreamFeatureA,
                 include_soft_deleted=True,
                 allow_fallback=False,
@@ -328,7 +328,7 @@ def test_soft_delete_from_fallback_creates_soft_deletion_marker(
         assert soft_deletion_markers["metaxy_deleted_at"].is_not_null().all()
 
         active = collect_to_polars(
-            dev.read_metadata(
+            dev.read(
                 UpstreamFeatureA,
                 filters=[nw.col("sample_uid") == 1],
                 allow_fallback=True,
@@ -357,7 +357,7 @@ def test_write_to_dev_not_prod(
             }
         )
 
-        dev.write_metadata(UpstreamFeatureB, new_data)
+        dev.write(UpstreamFeatureB, new_data)
 
         # Should be in dev
         assert dev.has_feature(UpstreamFeatureB, check_fallback=False)
@@ -383,14 +383,14 @@ def test_store_not_open_write_raises(empty_store: DeltaMetadataStore, UpstreamFe
     )
 
     with pytest.raises(StoreNotOpenError, match="must be opened before use"):
-        empty_store.write_metadata(UpstreamFeatureA, metadata)
+        empty_store.write(UpstreamFeatureA, metadata)
 
 
 def test_store_not_open_read_raises(populated_store: DeltaMetadataStore, UpstreamFeatureA) -> None:
     """Test that reading from a closed store raises StoreNotOpenError."""
     # Store is already closed after fixture setup
     with pytest.raises(StoreNotOpenError, match="must be opened before use"):
-        populated_store.read_metadata(UpstreamFeatureA)
+        populated_store.read(UpstreamFeatureA)
 
 
 def test_store_not_open_has_feature_raises(populated_store: DeltaMetadataStore, UpstreamFeatureA) -> None:
@@ -414,7 +414,7 @@ def test_store_context_manager_opens_and_closes(
     assert not empty_store._is_open
 
 
-def test_write_metadata_casts_null_typed_system_columns(empty_store: DeltaMetadataStore, UpstreamFeatureA) -> None:
+def test_write_casts_null_typed_system_columns(empty_store: DeltaMetadataStore, UpstreamFeatureA) -> None:
     """Test that system columns with Null dtype are cast to correct types."""
     # Create a DataFrame with Null-typed system columns
     # This can happen with empty frames or certain Polars operations
@@ -444,10 +444,10 @@ def test_write_metadata_casts_null_typed_system_columns(empty_store: DeltaMetada
     assert df.schema["metaxy_materialization_id"] == pl.Null
 
     with empty_store.open("write"):
-        empty_store.write_metadata(UpstreamFeatureA, df)
+        empty_store.write(UpstreamFeatureA, df)
 
         # Read back and verify columns are now correctly typed
-        result = collect_to_polars(empty_store.read_metadata(UpstreamFeatureA))
+        result = collect_to_polars(empty_store.read(UpstreamFeatureA))
 
         assert result.schema["metaxy_provenance"] == pl.String
         assert result.schema["metaxy_feature_version"] == pl.String

--- a/tests/metadata_stores/test_proper_dataframe_write.py
+++ b/tests/metadata_stores/test_proper_dataframe_write.py
@@ -126,10 +126,10 @@ class TestProperDataframeWrite:
             warnings.simplefilter("always")
 
             with any_store.open("write"):
-                any_store.write_metadata(RootFeature, df)
+                any_store.write(RootFeature, df)
 
                 # Verify write succeeded
-                result = collect_to_polars(any_store.read_metadata(RootFeature))
+                result = collect_to_polars(any_store.read(RootFeature))
                 assert len(result) == 3
 
             # Check for MetaxyColumnMissingWarning
@@ -175,11 +175,11 @@ class TestProperDataframeWrite:
             warnings.simplefilter("always")
 
             with any_store.open("write"):
-                any_store.write_metadata(RootFeature, root_df)
-                any_store.write_metadata(DownstreamFeature, downstream_df)
+                any_store.write(RootFeature, root_df)
+                any_store.write(DownstreamFeature, downstream_df)
 
                 # Verify write succeeded
-                result = collect_to_polars(any_store.read_metadata(DownstreamFeature))
+                result = collect_to_polars(any_store.read(DownstreamFeature))
                 assert len(result) == 3
 
             # Check for MetaxyColumnMissingWarning

--- a/tests/metadata_stores/test_resolve_update_root_features.py
+++ b/tests/metadata_stores/test_resolve_update_root_features.py
@@ -145,7 +145,7 @@ class TestResolveUpdateRootFeatures:
                 }
             )
             initial_metadata = add_metaxy_provenance_column(initial_metadata, video_feature)
-            store.write_metadata(video_feature, initial_metadata)
+            store.write(video_feature, initial_metadata)
 
             # User provides updated samples
             import narwhals as nw

--- a/tests/metadata_stores/test_resolve_update_skip_comparison.py
+++ b/tests/metadata_stores/test_resolve_update_skip_comparison.py
@@ -104,7 +104,7 @@ class TestResolveUpdateSkipComparisonRootFeatures:
 
             # Verify system columns are present in added
             # Note: resolve_update returns provenance and data_version columns,
-            # but feature_version and snapshot_version are added by write_metadata
+            # but feature_version and snapshot_version are added by write
             assert METAXY_PROVENANCE in result.added.columns
             assert METAXY_PROVENANCE_BY_FIELD in result.added.columns
             assert METAXY_DATA_VERSION in result.added.columns
@@ -166,7 +166,7 @@ class TestResolveUpdateSkipComparisonRootFeatures:
                 }
             )
             initial_metadata = add_metaxy_provenance_column(initial_metadata, VideoEmbeddingsFeature)
-            store.write_metadata(VideoEmbeddingsFeature, initial_metadata)
+            store.write(VideoEmbeddingsFeature, initial_metadata)
 
             # Now resolve_update with skip_comparison=True
             # Provide the same samples plus a new one
@@ -253,7 +253,7 @@ class TestResolveUpdateSkipComparisonDownstreamFeatures:
                 }
             )
             upstream_data = add_metaxy_provenance_column(upstream_data, UpstreamFeature)
-            store.write_metadata(UpstreamFeature, upstream_data)
+            store.write(UpstreamFeature, upstream_data)
 
             # Call resolve_update on downstream with skip_comparison=True
             result = store.resolve_update(
@@ -328,7 +328,7 @@ class TestResolveUpdateSkipComparisonDownstreamFeatures:
                 }
             )
             upstream_data = add_metaxy_provenance_column(upstream_data, UpstreamFeature)
-            store.write_metadata(UpstreamFeature, upstream_data)
+            store.write(UpstreamFeature, upstream_data)
 
             # Write some downstream metadata (simulate existing data)
             existing_downstream = pl.DataFrame(
@@ -341,7 +341,7 @@ class TestResolveUpdateSkipComparisonDownstreamFeatures:
                 }
             )
             existing_downstream = add_metaxy_provenance_column(existing_downstream, DownstreamFeature)
-            store.write_metadata(DownstreamFeature, existing_downstream)
+            store.write(DownstreamFeature, existing_downstream)
 
             # Call resolve_update with skip_comparison=True
             result = store.resolve_update(
@@ -480,7 +480,7 @@ class TestResolveUpdateSkipComparisonDefaultBehavior:
                 }
             )
             initial_metadata = add_metaxy_provenance_column(initial_metadata, RootFeature)
-            store.write_metadata(RootFeature, initial_metadata)
+            store.write(RootFeature, initial_metadata)
 
             # Provide samples with skip_comparison=False (explicit, but it's the default)
             user_samples = pl.DataFrame(
@@ -550,7 +550,7 @@ class TestResolveUpdateSkipComparisonDefaultBehavior:
                 }
             )
             initial_metadata = add_metaxy_provenance_column(initial_metadata, RootFeature)
-            store.write_metadata(RootFeature, initial_metadata)
+            store.write(RootFeature, initial_metadata)
 
             # Provide samples with explicit skip_comparison=False
             user_samples = pl.DataFrame(
@@ -650,7 +650,7 @@ class TestResolveUpdateSkipComparisonComplexScenarios:
                 }
             )
             root_data = add_metaxy_provenance_column(root_data, RootFeature)
-            store.write_metadata(RootFeature, root_data)
+            store.write(RootFeature, root_data)
 
             # Write intermediate metadata
             intermediate_data = pl.DataFrame(
@@ -664,7 +664,7 @@ class TestResolveUpdateSkipComparisonComplexScenarios:
                 }
             )
             intermediate_data = add_metaxy_provenance_column(intermediate_data, IntermediateFeature)
-            store.write_metadata(IntermediateFeature, intermediate_data)
+            store.write(IntermediateFeature, intermediate_data)
 
             # Call resolve_update on leaf with skip_comparison=True
             result = store.resolve_update(
@@ -759,7 +759,7 @@ class TestResolveUpdateSkipComparisonComplexScenarios:
                 }
             )
             root_data = add_metaxy_provenance_column(root_data, RootFeature)
-            store.write_metadata(RootFeature, root_data)
+            store.write(RootFeature, root_data)
 
             # Write branch A metadata
             branch_a_data = pl.DataFrame(
@@ -773,7 +773,7 @@ class TestResolveUpdateSkipComparisonComplexScenarios:
                 }
             )
             branch_a_data = add_metaxy_provenance_column(branch_a_data, BranchAFeature)
-            store.write_metadata(BranchAFeature, branch_a_data)
+            store.write(BranchAFeature, branch_a_data)
 
             # Write branch B metadata
             branch_b_data = pl.DataFrame(
@@ -787,7 +787,7 @@ class TestResolveUpdateSkipComparisonComplexScenarios:
                 }
             )
             branch_b_data = add_metaxy_provenance_column(branch_b_data, BranchBFeature)
-            store.write_metadata(BranchBFeature, branch_b_data)
+            store.write(BranchBFeature, branch_b_data)
 
             # Call resolve_update on leaf with skip_comparison=True
             result = store.resolve_update(

--- a/tests/metaxy_testing/src/metaxy_testing/doctest_fixtures.py
+++ b/tests/metaxy_testing/src/metaxy_testing/doctest_fixtures.py
@@ -116,7 +116,7 @@ class DocsStoreFixtures:
         )
 
         with self._store_with_data.open("write"):
-            self._store_with_data.write_metadata(MyFeature, sample_data)
+            self._store_with_data.write(MyFeature, sample_data)
 
     def teardown(self) -> None:
         """Clean up all resources via ExitStack."""

--- a/tests/metaxy_testing/src/metaxy_testing/metaxy_project.py
+++ b/tests/metaxy_testing/src/metaxy_testing/metaxy_project.py
@@ -1115,7 +1115,7 @@ database = "{staging_db_path}"
         # Use the project's graph context so the store can resolve feature plans
         with graph.use():
             with store.open("write"):
-                store.write_metadata(feature_key, sample_data)
+                store.write(feature_key, sample_data)
                 # Record the feature graph snapshot so copy_metadata can determine snapshot_version
                 SystemTableStorage(store).push_graph_snapshot()
 
@@ -1139,4 +1139,4 @@ database = "{staging_db_path}"
         store = self.stores[store_name]
 
         with graph.use(), store.open("write"):
-            store.write_metadata(feature_key, data)
+            store.write(feature_key, data)

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -184,12 +184,12 @@ def test_full_graph_migration_single_operation_single_feature(tmp_path: Path):
             }
         )
         upstream_data = add_metaxy_provenance_column(upstream_data, Upstream)
-        store.write_metadata(Upstream, upstream_data)
+        store.write(Upstream, upstream_data)
 
         # Write downstream
         diff = store.resolve_update(Downstream)
         if len(diff.added) > 0:
-            store.write_metadata(Downstream, diff.added)
+            store.write(Downstream, diff.added)
 
         SystemTableStorage(store).push_graph_snapshot()
         snapshot_version = graph.snapshot_version
@@ -548,11 +548,11 @@ def test_full_graph_migration_resume_after_partial_failure(tmp_path: Path):
             }
         )
         upstream_data = add_metaxy_provenance_column(upstream_data, Upstream)
-        store.write_metadata(Upstream, upstream_data)
+        store.write(Upstream, upstream_data)
 
         diff = store.resolve_update(Downstream)
         if len(diff.added) > 0:
-            store.write_metadata(Downstream, diff.added)
+            store.write(Downstream, diff.added)
 
         SystemTableStorage(store).push_graph_snapshot()
         snapshot_version = graph.snapshot_version
@@ -743,7 +743,7 @@ def test_data_version_reconciliation_root_feature_error(tmp_path: Path):
             }
         )
         data = add_metaxy_provenance_column(data, Root)
-        store.write_metadata(Root, data)
+        store.write(Root, data)
 
         SystemTableStorage(store).push_graph_snapshot()
         from_snapshot = graph.snapshot_version

--- a/tests/migrations/test_spec_changes_no_migration.py
+++ b/tests/migrations/test_spec_changes_no_migration.py
@@ -104,7 +104,7 @@ def test_migration_detector_uses_feature_version_not_feature_spec_version(tmp_pa
                 ],
             }
         )
-        store_v1.write_metadata(simple_key, data)
+        store_v1.write(simple_key, data)
         SystemTableStorage(store_v1).push_graph_snapshot()
 
     # Verify snapshot captures the version
@@ -192,7 +192,7 @@ def test_no_migration_when_only_non_computational_properties_change(tmp_path: Pa
                 "metaxy_provenance_by_field": [{"default": "h1"}],
             }
         )
-        store.write_metadata(feature_key, data)
+        store.write(feature_key, data)
         SystemTableStorage(store).push_graph_snapshot()
 
     # Currently, there's no way to change spec without changing feature_version
@@ -366,7 +366,7 @@ def test_snapshot_stores_both_versions(tmp_path: Path):
                 "metaxy_provenance_by_field": [{"default": "h1"}],
             }
         )
-        store.write_metadata(feature_key, data)
+        store.write(feature_key, data)
         SystemTableStorage(store).push_graph_snapshot()
 
         # Check snapshot data structure

--- a/tests/models/serialization/test_serialize_stability.py
+++ b/tests/models/serialization/test_serialize_stability.py
@@ -86,7 +86,7 @@ def test_serialize_uses_to_snapshot(store: MetadataStore, test_graph: FeatureGra
             # Read back the serialized data from the store
             from metaxy.metadata_store.system import FEATURE_VERSIONS_KEY
 
-            versions_lazy = store.read_metadata_in_store(FEATURE_VERSIONS_KEY)
+            versions_lazy = store._read_feature(FEATURE_VERSIONS_KEY)
             assert versions_lazy is not None, "Feature versions should be recorded"
 
             versions_df = versions_lazy.collect().to_polars()

--- a/tests/models/serialization/test_snapshot_push.py
+++ b/tests/models/serialization/test_snapshot_push.py
@@ -73,7 +73,7 @@ def test_record_snapshot_first_time(tmp_path: Path):
             # Verify data was written to feature_versions table
             from metaxy.metadata_store.system import FEATURE_VERSIONS_KEY
 
-            versions_lazy = store.read_metadata_in_store(FEATURE_VERSIONS_KEY)
+            versions_lazy = store._read_feature(FEATURE_VERSIONS_KEY)
             assert versions_lazy is not None
             versions_df = versions_lazy.collect().to_polars()
 
@@ -133,7 +133,7 @@ def test_record_snapshot_metadata_only_changes(tmp_path: Path):
             assert result1.snapshot_version == snapshot_v1
 
             # Verify initial state
-            versions_lazy = store.read_metadata_in_store(FEATURE_VERSIONS_KEY)
+            versions_lazy = store._read_feature(FEATURE_VERSIONS_KEY)
             assert versions_lazy is not None
             versions_df = versions_lazy.collect().to_polars()
             assert versions_df.height == 2  # upstream + downstream
@@ -192,7 +192,7 @@ def test_record_snapshot_metadata_only_changes(tmp_path: Path):
                 assert result2.snapshot_version == snapshot_v2
 
                 # Verify new rows were added (new snapshot)
-                versions_lazy_after = store.read_metadata_in_store(FEATURE_VERSIONS_KEY)
+                versions_lazy_after = store._read_feature(FEATURE_VERSIONS_KEY)
                 assert versions_lazy_after is not None
                 versions_df_after = versions_lazy_after.collect().to_polars()
                 # Old rows (2) + new rows (2) = 4
@@ -242,7 +242,7 @@ def test_record_snapshot_no_changes(tmp_path: Path):
             # Verify no new rows appended
             from metaxy.metadata_store.system import FEATURE_VERSIONS_KEY
 
-            versions_lazy = store.read_metadata_in_store(FEATURE_VERSIONS_KEY)
+            versions_lazy = store._read_feature(FEATURE_VERSIONS_KEY)
             assert versions_lazy is not None
             versions_df = versions_lazy.collect().to_polars()
             assert versions_df.height == 1  # Still only 1 row
@@ -354,7 +354,7 @@ def test_record_snapshot_partial_metadata_changes(tmp_path: Path):
                 assert result2.snapshot_version == snapshot_v2
 
                 # Verify correct rows appended (3 original + 3 new = 6)
-                versions_lazy = store.read_metadata_in_store(FEATURE_VERSIONS_KEY)
+                versions_lazy = store._read_feature(FEATURE_VERSIONS_KEY)
                 assert versions_lazy is not None
                 versions_df = versions_lazy.collect().to_polars()
                 assert versions_df.height == 6
@@ -399,7 +399,7 @@ def test_record_snapshot_append_only_behavior(tmp_path: Path):
             result1 = SystemTableStorage(store).push_graph_snapshot()
             assert result1.snapshot_version == snapshot_v1
 
-            versions_lazy_v1 = store.read_metadata_in_store(FEATURE_VERSIONS_KEY)
+            versions_lazy_v1 = store._read_feature(FEATURE_VERSIONS_KEY)
             assert versions_lazy_v1 is not None
             versions_df_v1 = versions_lazy_v1.collect().to_polars()
             assert versions_df_v1.height == 2  # upstream + my_feature
@@ -445,7 +445,7 @@ def test_record_snapshot_append_only_behavior(tmp_path: Path):
                 assert result2.snapshot_version == snapshot_v2
 
                 # Verify append-only: old rows still exist
-                versions_lazy_v2 = store.read_metadata_in_store(FEATURE_VERSIONS_KEY)
+                versions_lazy_v2 = store._read_feature(FEATURE_VERSIONS_KEY)
                 assert versions_lazy_v2 is not None
                 versions_df_v2 = versions_lazy_v2.collect().to_polars()
 
@@ -611,7 +611,7 @@ def test_snapshot_push_result_snapshot_comparison(snapshot: SnapshotAssertion, t
                 )
 
                 # Get final feature_versions table state
-                versions_lazy = store.read_metadata_in_store(FEATURE_VERSIONS_KEY)
+                versions_lazy = store._read_feature(FEATURE_VERSIONS_KEY)
                 assert versions_lazy is not None
                 versions_df = versions_lazy.collect().to_polars()
 
@@ -668,7 +668,7 @@ def test_feature_info_changes_trigger_repush(tmp_path: Path):
             assert result1.snapshot_version == snapshot_v1
 
             # Get initial recorded_at
-            versions_lazy = store.read_metadata_in_store(FEATURE_VERSIONS_KEY)
+            versions_lazy = store._read_feature(FEATURE_VERSIONS_KEY)
             assert versions_lazy is not None
             versions_df1 = versions_lazy.collect().to_polars()
             assert versions_df1.height == 1
@@ -709,7 +709,7 @@ def test_feature_info_changes_trigger_repush(tmp_path: Path):
                 assert result2.snapshot_version == snapshot_v2
 
                 # Verify new row was appended
-                versions_lazy2 = store.read_metadata_in_store(FEATURE_VERSIONS_KEY)
+                versions_lazy2 = store._read_feature(FEATURE_VERSIONS_KEY)
                 assert versions_lazy2 is not None
                 versions_df2 = versions_lazy2.collect().to_polars()
                 assert versions_df2.height == 2  # Original + new

--- a/tests/models/test_column_selection.py
+++ b/tests/models/test_column_selection.py
@@ -1063,7 +1063,7 @@ class TestColumnSelection:
             _ = SystemTableStorage(store).push_graph_snapshot()
 
             # Read the snapshot from feature_versions table
-            versions = store.read_metadata(FEATURE_VERSIONS_KEY, current_only=False).collect().to_polars()
+            versions = store.read(FEATURE_VERSIONS_KEY, with_feature_history=True).collect().to_polars()
 
             # Find the downstream feature record
             downstream_record = versions.filter(pl.col("feature_key") == "test/downstream")

--- a/tests/models/test_expansion_relationships.py
+++ b/tests/models/test_expansion_relationships.py
@@ -72,7 +72,7 @@ class TestExpansionRelationships:
                 }
             )
             video_data = add_metaxy_provenance_column(video_data, Video)
-            store.write_metadata(Video, nw.from_native(video_data))
+            store.write(Video, nw.from_native(video_data))
 
             # Write child metadata (multiple frames per video)
             frames_data = pl.DataFrame(
@@ -91,7 +91,7 @@ class TestExpansionRelationships:
                 }
             )
             frames_data = add_metaxy_provenance_column(frames_data, VideoFrames)
-            store.write_metadata(VideoFrames, nw.from_native(frames_data))
+            store.write(VideoFrames, nw.from_native(frames_data))
 
             # Resolve update
             diff = store.resolve_update(VideoFrames)
@@ -145,7 +145,7 @@ class TestExpansionRelationships:
                 }
             )
             article_data = add_metaxy_provenance_column(article_data, Article)
-            store.write_metadata(Article, nw.from_native(article_data))
+            store.write(Article, nw.from_native(article_data))
 
             # Child metadata (existing)
             para_data = pl.DataFrame(
@@ -163,7 +163,7 @@ class TestExpansionRelationships:
                 }
             )
             para_data = add_metaxy_provenance_column(para_data, ArticleParagraphs)
-            store.write_metadata(ArticleParagraphs, nw.from_native(para_data))
+            store.write(ArticleParagraphs, nw.from_native(para_data))
 
             # Resolve update
             diff = store.resolve_update(ArticleParagraphs)

--- a/tests/models/test_feature_schema_field.py
+++ b/tests/models/test_feature_schema_field.py
@@ -38,7 +38,7 @@ def test_push_graph_snapshot_stores_feature_schema(tmp_path: Path):
             SystemTableStorage(store).push_graph_snapshot()
 
             # Read and verify feature_schema field
-            versions_lazy = store.read_metadata_in_store(FEATURE_VERSIONS_KEY)
+            versions_lazy = store._read_feature(FEATURE_VERSIONS_KEY)
             assert versions_lazy is not None
             versions_df = versions_lazy.collect().to_polars()
 
@@ -106,7 +106,7 @@ def test_feature_schema_differs_between_features(tmp_path: Path):
             SystemTableStorage(store).push_graph_snapshot()
 
             # Read and verify
-            versions_lazy = store.read_metadata_in_store(FEATURE_VERSIONS_KEY)
+            versions_lazy = store._read_feature(FEATURE_VERSIONS_KEY)
             assert versions_lazy is not None
             versions_df = versions_lazy.collect().to_polars()
 
@@ -237,7 +237,7 @@ def test_feature_schema_for_feature_without_custom_fields(tmp_path: Path):
             SystemTableStorage(store).push_graph_snapshot()
 
             # Read and verify
-            versions_lazy = store.read_metadata_in_store(FEATURE_VERSIONS_KEY)
+            versions_lazy = store._read_feature(FEATURE_VERSIONS_KEY)
             assert versions_lazy is not None
             versions_df = versions_lazy.collect().to_polars()
 

--- a/tests/models/test_id_columns.py
+++ b/tests/models/test_id_columns.py
@@ -444,10 +444,10 @@ def test_metadata_store_integration_with_custom_id_columns(graph: FeatureGraph, 
                 }
             )
         )
-        store.write_metadata(UserFeature, user_df)
+        store.write(UserFeature, user_df)
 
         # Read it back and verify
-        read_user = store.read_metadata(UserFeature).collect()
+        read_user = store.read(UserFeature).collect()
         assert "user_id" in read_user.columns
         assert "sample_uid" not in read_user.columns
         assert len(read_user) == 3
@@ -472,10 +472,10 @@ def test_metadata_store_integration_with_custom_id_columns(graph: FeatureGraph, 
                 }
             )
         )
-        store.write_metadata(SessionFeature, session_df)
+        store.write(SessionFeature, session_df)
 
         # Read session metadata
-        read_session = store.read_metadata(SessionFeature).collect()
+        read_session = store.read(SessionFeature).collect()
         assert "user_id" in read_session.columns
         assert "session_id" in read_session.columns
         assert "sample_uid" not in read_session.columns
@@ -623,8 +623,8 @@ def test_backwards_compatibility_default_id_columns(graph: FeatureGraph, tmp_pat
                 }
             )
         )
-        store.write_metadata(LegacyFeature, df)
+        store.write(LegacyFeature, df)
 
-        result = store.read_metadata(LegacyFeature).collect()
+        result = store.read(LegacyFeature).collect()
         assert "sample_uid" in result.columns
         assert len(result) == 3

--- a/tests/models/test_tags_field.py
+++ b/tests/models/test_tags_field.py
@@ -35,7 +35,7 @@ def test_push_graph_snapshot_with_default_tags(tmp_path: Path):
             SystemTableStorage(store).push_graph_snapshot()
 
             # Read and verify tags field
-            versions_lazy = store.read_metadata_in_store(FEATURE_VERSIONS_KEY)
+            versions_lazy = store._read_feature(FEATURE_VERSIONS_KEY)
             assert versions_lazy is not None
             versions_df = versions_lazy.collect().to_polars()
 
@@ -74,7 +74,7 @@ def test_push_graph_snapshot_with_custom_tags(tmp_path: Path):
             SystemTableStorage(store).push_graph_snapshot(tags=custom_tags)
 
             # Read and verify tags field
-            versions_lazy = store.read_metadata_in_store(FEATURE_VERSIONS_KEY)
+            versions_lazy = store._read_feature(FEATURE_VERSIONS_KEY)
             assert versions_lazy is not None
             versions_df = versions_lazy.collect().to_polars()
 
@@ -114,7 +114,7 @@ def test_push_graph_snapshot_tags_persist_across_pushes(tmp_path: Path):
             SystemTableStorage(store).push_graph_snapshot(tags={"environment": "production"})
 
             # Read and verify - should only have one row (no changes)
-            versions_lazy = store.read_metadata_in_store(FEATURE_VERSIONS_KEY)
+            versions_lazy = store._read_feature(FEATURE_VERSIONS_KEY)
             assert versions_lazy is not None
             versions_df = versions_lazy.collect().to_polars()
 
@@ -168,7 +168,7 @@ def test_push_graph_snapshot_tags_updated_with_feature_changes(tmp_path: Path):
                 SystemTableStorage(store).push_graph_snapshot(tags={"environment": "production", "build": "124"})
 
                 # Read and verify - should have two rows
-                versions_lazy = store.read_metadata_in_store(FEATURE_VERSIONS_KEY)
+                versions_lazy = store._read_feature(FEATURE_VERSIONS_KEY)
                 assert versions_lazy is not None
                 versions_df = versions_lazy.collect().to_polars()
 

--- a/tests/models/test_typed_id_columns.py
+++ b/tests/models/test_typed_id_columns.py
@@ -298,10 +298,10 @@ def test_metadata_store_with_custom_id_columns(graph: FeatureGraph, tmp_path: Pa
             )
         )
 
-        store.write_metadata(CustomIDFeature, df)
+        store.write(CustomIDFeature, df)
 
         # Read back and verify
-        result = store.read_metadata(CustomIDFeature).collect()
+        result = store.read(CustomIDFeature).collect()
 
         assert "uuid" in result.columns
         assert len(result) == 3

--- a/tests/test_hash_truncation.py
+++ b/tests/test_hash_truncation.py
@@ -445,11 +445,11 @@ class TestMetadataStoreTruncation:
                         ],
                     }
                 )
-                store.write_metadata(TestFeature, metadata)
+                store.write(TestFeature, metadata)
 
                 # Read back and verify
 
-                result = store.read_metadata(TestFeature).collect()
+                result = store.read(TestFeature).collect()
                 result_pl = result.to_polars()
                 assert result_pl.height == 2
 
@@ -580,11 +580,11 @@ class TestEndToEnd:
                         ],
                     }
                 )
-                store.write_metadata(ParentFeature, parent_data)
+                store.write(ParentFeature, parent_data)
 
                 # Verify stored versions are truncated
 
-                result = store.read_metadata(ParentFeature).collect()
+                result = store.read(ParentFeature).collect()
                 result_pl = result.to_polars()
 
                 for row in result_pl.iter_rows(named=True):

--- a/tests/utils/test_batched_writer.py
+++ b/tests/utils/test_batched_writer.py
@@ -120,7 +120,7 @@ def test_batched_writer_basic(store: MetadataStore, writer_feature: type[BaseFea
         assert rows_written[writer_feature.spec().key] == 3
 
         # Verify data was written
-        result = store.read_metadata(writer_feature).collect().to_polars()
+        result = store.read(writer_feature).collect().to_polars()
         assert len(result) == 3
         assert set(result["id"].to_list()) == {"a", "b", "c"}
 
@@ -139,7 +139,7 @@ def test_batched_writer_context_manager(store: MetadataStore, writer_feature: ty
             writer.put({writer_feature: batch})
 
         # Verify data was written after context exit
-        result = store.read_metadata(writer_feature).collect().to_polars()
+        result = store.read(writer_feature).collect().to_polars()
         assert len(result) == 2
 
 
@@ -167,7 +167,7 @@ def test_batched_writer_batch_size_trigger(store: MetadataStore, writer_feature:
             assert writer.num_written.get(feature_key, 0) >= 5  # At least one batch should have been flushed
 
         # Verify all data was written after stop
-        result = store.read_metadata(writer_feature).collect().to_polars()
+        result = store.read(writer_feature).collect().to_polars()
         assert len(result) == 10
 
 
@@ -200,7 +200,7 @@ def test_batched_writer_interval_trigger(store: MetadataStore, writer_feature: t
             assert writer.num_written.get(feature_key, 0) == 1
 
         # Verify data was written
-        result = store.read_metadata(writer_feature).collect().to_polars()
+        result = store.read(writer_feature).collect().to_polars()
         assert len(result) == 1
 
 
@@ -225,7 +225,7 @@ def test_batched_writer_no_batch_size(store: MetadataStore, writer_feature: type
             assert writer.num_written == {}
 
         # After stop, all data should be written
-        result = store.read_metadata(writer_feature).collect().to_polars()
+        result = store.read(writer_feature).collect().to_polars()
         assert len(result) == 20
 
 
@@ -251,7 +251,7 @@ def test_batched_writer_accepts_dataframe_types(
             writer.put({writer_feature: batch})
 
         # Verify data was written
-        result = store.read_metadata(writer_feature).collect().to_polars()
+        result = store.read(writer_feature).collect().to_polars()
         assert len(result) == 2
         assert set(result["id"].to_list()) == {"df1", "df2"}
 
@@ -311,7 +311,7 @@ def test_batched_writer_multiple_batches(store: MetadataStore, writer_feature: t
                 writer.put({writer_feature: batch})
 
         # Verify all data was written
-        result = store.read_metadata(writer_feature).collect().to_polars()
+        result = store.read(writer_feature).collect().to_polars()
         assert len(result) == 10
 
 
@@ -397,7 +397,7 @@ def test_batched_writer_feature_key_string(store: MetadataStore, writer_feature:
             writer.put({"test/batched_writer": batch})
 
         # Verify data was written
-        result = store.read_metadata(writer_feature).collect().to_polars()
+        result = store.read(writer_feature).collect().to_polars()
         assert len(result) == 1
 
 
@@ -431,7 +431,7 @@ def test_batched_writer_thread_safety(store: MetadataStore, writer_feature: type
             assert not errors, f"Errors during concurrent writes: {errors}"
 
         # Verify all data was written (5 threads * 10 rows each = 50 rows)
-        result = store.read_metadata(writer_feature).collect().to_polars()
+        result = store.read(writer_feature).collect().to_polars()
         assert len(result) == 50
 
 
@@ -459,8 +459,8 @@ def test_batched_writer_multi_feature(
             writer.put({writer_feature: batch1, second_feature: batch2})
 
         # Verify both features have data
-        result1 = store.read_metadata(writer_feature).collect().to_polars()
-        result2 = store.read_metadata(second_feature).collect().to_polars()
+        result1 = store.read(writer_feature).collect().to_polars()
+        result2 = store.read(second_feature).collect().to_polars()
         assert len(result1) == 2
         assert len(result2) == 2
 
@@ -502,8 +502,8 @@ def test_batched_writer_multi_feature_accumulated(
             writer.put({writer_feature: batch3})
 
         # Verify all data was written
-        result1 = store.read_metadata(writer_feature).collect().to_polars()
-        result2 = store.read_metadata(second_feature).collect().to_polars()
+        result1 = store.read(writer_feature).collect().to_polars()
+        result2 = store.read(second_feature).collect().to_polars()
         assert len(result1) == 2  # acc_a and acc_b
         assert len(result2) == 1  # acc_x
 


### PR DESCRIPTION
Resolve #853

Renamed: 

- `write_metadata` -> `write`
- `read_metadata` -> `read`
- `delete_metadata` -> `delete`

And made corresponding abstract methods private so they are not confused with public methods.