### PR TITLE
deven shell hook for osx

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -76,7 +76,7 @@ in
       pkgs.harfbuzz
     ]);
 
-    DYLD_LIBRARY_PATH = lib.optionalString pkgs.stdenv.isDarwin (lib.makeLibraryPath [
+    DYLD_FALLBACK_LIBRARY_PATH = lib.optionalString pkgs.stdenv.isDarwin (lib.makeLibraryPath [
       pkgs.cairo
       pkgs.pango
       pkgs.gdk-pixbuf


### PR DESCRIPTION
`DYLD_LIBRARY_PATH` is SIP protected on OSX, modifications are stripped.
We have explored using `DYLD_FALLBACK_LIBRARY_PATH` also that is not working (for doc changes).


A `devenv shell -- ` would be working fine though.