### PR TITLE
[core] add staleness_predicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ While Metaxy's core functionality and versioning engine are **_stable_** and qui
 <!-- --8<-- [end:header] -->
 <!-- --8<-- [start:releases] -->
 
+## Unreleased
+
+### Added
+
+- `staleness_predicates` parameter on [`resolve_update`][metaxy.MetadataStore.resolve_update] to mark records as stale based on arbitrary Narwhals expressions, regardless of version
+
 ## 1.1.0
 
 ### Added

--- a/docs/guide/concepts/metadata-stores.md
+++ b/docs/guide/concepts/metadata-stores.md
@@ -122,6 +122,34 @@ It is up to the caller to decide how to handle the processing and potential dele
 
 Once processing is complete, the caller is expected to call `MetadataStore.write` to record metadata about the processed samples.
 
+### Custom Staleness Conditions
+
+By default, `resolve_update` only marks samples as stale when their upstream provenance has changed. The `staleness_predicates` parameter allows marking additional records as stale based on arbitrary conditions.
+This is useful for forcing reprocessing after a bug fix that affected *metadata* (1), backfilling records that were processed with incomplete data, or invalidating samples that meet certain quality criteria.
+{ .annotate }
+
+1. and not *data*, because in this case you should be changing the feature version
+
+Predicates are [Narwhals](https://narwhals-dev.github.io/narwhals/) expressions evaluated against stored metadata. Multiple predicates are OR'd together.
+
+!!! example "Reprocess failed or incomplete samples"
+
+    <!-- skip next -->
+    ```py
+    import narwhals as nw
+
+    with store.open("w"):
+        inc = store.resolve_update(
+            "my/feature",
+            staleness_predicates=[
+                nw.col("status") == "failed",
+                nw.col("embedding_dim").is_null(),
+            ],
+        )
+    ```
+
+    Any record where `status` is `"failed"` **or** `embedding` is null will appear in `inc.stale`, even if its upstream provenance has not changed.
+
 !!! tip "Where are increments computed?"
 
   Learn more [here](../../metaxy/design.md#compute).

--- a/src/metaxy/metadata_store/base.py
+++ b/src/metaxy/metadata_store/base.py
@@ -276,6 +276,7 @@ class MetadataStore(ABC):
         lazy: bool = False,
         versioning_engine: Literal["auto", "native", "polars"] | None = None,
         skip_comparison: bool = False,
+        staleness_predicates: Sequence[nw.Expr] | None = None,
         **kwargs: Any,
     ) -> Increment | LazyIncrement:
         """Calculate an incremental update for a feature.
@@ -316,6 +317,9 @@ class MetadataStore(ABC):
             skip_comparison: If True, skip the increment comparison logic and return all
                 upstream samples in `increment.new`. The `changed` and `removed` frames will
                 be empty.
+            staleness_predicates: Narwhals expressions to treat samples as stale even if their provenance is up-to-date.
+                These expressions are evaluated against existing feature metadata.
+                Multiple predicates are OR'd together.
 
         Raises:
             ValueError: If no `samples` dataframe has been provided when resolving an update for a root feature.
@@ -346,6 +350,27 @@ class MetadataStore(ABC):
             )
             with store.open(mode="w"):
                 result = store.resolve_update(MyFeature, samples=nw.from_native(samples))
+            ```
+
+        !!! example "With staleness predicates"
+
+            Force reprocessing of failed or incomplete samples,
+            regardless of whether their upstream provenance has changed:
+
+            <!-- skip: next -->
+            ```py
+            import narwhals as nw
+
+            with store.open(mode="w"):
+                result = store.resolve_update(
+                    MyFeature,
+                    staleness_predicates=[
+                        nw.col("status") == "failed",
+                        nw.col("embedding_dim").is_null(),
+                    ],
+                )
+
+                # result.stale includes both version-stale and predicate-matched samples
             ```
         """
         import narwhals as nw
@@ -544,6 +569,7 @@ class MetadataStore(ABC):
                     hash_algorithm=self.hash_algorithm,
                     filters=filters_by_key,
                     sample=samples_nw.lazy() if samples_nw is not None else None,
+                    staleness_predicates=tuple(staleness_predicates) if staleness_predicates else (),
                 )
 
         # Convert None to empty DataFrames

--- a/src/metaxy/models/constants.py
+++ b/src/metaxy/models/constants.py
@@ -57,6 +57,11 @@ METAXY_DELETED_AT = f"{SYSTEM_COLUMN_PREFIX}deleted_at"
 METAXY_MATERIALIZATION_ID = f"{SYSTEM_COLUMN_PREFIX}materialization_id"
 """External orchestration run ID (e.g., Dagster Run ID, Airflow Run ID) for tracking pipeline executions."""
 
+# --- Internal Column Names (used during increment resolution) ---------------------
+
+_STALE_BY_PREDICATE = "__stale_by_predicate"
+"""Temporary boolean column marking rows matched by user-provided staleness predicates."""
+
 # --- System Column Sets ------------------------------------------------------------
 
 ALL_SYSTEM_COLUMNS = frozenset(

--- a/src/metaxy/versioning/engine.py
+++ b/src/metaxy/versioning/engine.py
@@ -640,6 +640,7 @@ class VersioningEngine(ABC):
         hash_algorithm: HashAlgorithm,
         filters: Mapping[FeatureKey, Sequence[nw.Expr]],
         sample: FrameT | None,
+        staleness_predicates: tuple[nw.Expr, ...] = (),
     ) -> tuple[FrameT, FrameT | None, FrameT | None, FrameT | None]:
         """Compute expected provenance and compare with current to find changes.
 
@@ -654,6 +655,8 @@ class VersioningEngine(ABC):
             hash_algorithm: Hash algorithm for provenance computation.
             filters: Runtime filters to apply per feature.
             sample: For root features, user-provided DataFrame with provenance columns.
+            staleness_predicates: Narwhals expressions that identify stale records regardless
+                of version. Records matching any predicate are treated as stale. OR'd together.
 
         Returns:
             Tuple of (added, changed, removed, input_df) DataFrames. Changed and
@@ -682,7 +685,7 @@ class VersioningEngine(ABC):
         from metaxy.versioning.increment_resolver import IncrementResolver
 
         resolver: IncrementResolver[FrameT] = IncrementResolver(self.plan, self)
-        added, changed, removed = resolver.resolve(expected, current, join_columns)
+        added, changed, removed = resolver.resolve(expected, current, join_columns, staleness_predicates)
 
         return added, changed, removed, input_df
 

--- a/src/metaxy/versioning/increment_resolver.py
+++ b/src/metaxy/versioning/increment_resolver.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import functools
+import operator
 from typing import TYPE_CHECKING, Generic, cast
 
 import narwhals as nw
 from narwhals.typing import FrameT
 
 from metaxy.models.constants import (
+    _STALE_BY_PREDICATE,
     METAXY_PROVENANCE,
     METAXY_PROVENANCE_BY_FIELD,
 )
@@ -35,18 +38,23 @@ class IncrementResolver(Generic[FrameT]):
         expected: FrameT,
         current: FrameT | None,
         join_columns: list[str],
+        staleness_predicates: tuple[nw.Expr, ...] = (),
     ) -> tuple[FrameT, FrameT | None, FrameT | None]:
         """Compare expected and current metadata to find incremental changes.
 
         Performs set operations using provenance columns to identify:
         - Added: Samples in expected but not in current (anti-join)
-        - Changed: Samples in both with different provenance (inner join + filter)
+        - Changed: Samples in both with different provenance (inner join + filter),
+          plus samples matching any staleness predicate regardless of provenance
         - Removed: Samples in current but not in expected (anti-join)
 
         Args:
             expected: DataFrame with expected provenance from upstream.
             current: Current metadata from the store, or None for initial load.
             join_columns: Columns to use for matching samples.
+            staleness_predicates: Narwhals expressions that identify stale records
+                regardless of version. Records matching any predicate are treated as
+                stale. OR'd together.
 
         Returns:
             Tuple of (added, changed, removed) DataFrames. Changed and removed
@@ -76,22 +84,36 @@ class IncrementResolver(Generic[FrameT]):
             ),
         )
 
-        # Find changed samples (in both but different provenance)
+        # Evaluate staleness predicates against current metadata before the join,
+        # so predicates can reference user columns (e.g. dataset, extra) from stored metadata.
+        select_columns = [*join_columns, f"__current_{METAXY_PROVENANCE}"]
+        if staleness_predicates:
+            current = current.with_columns(
+                functools.reduce(operator.or_, staleness_predicates).alias(_STALE_BY_PREDICATE),
+            )
+            select_columns.append(_STALE_BY_PREDICATE)
+
+        current_for_join = cast(FrameT, current.select(select_columns))
+
+        expected_columns = expected.collect_schema().names()  # ty: ignore[invalid-argument-type]
+
+        joined = expected.join(  # ty: ignore[invalid-argument-type]
+            current_for_join,  # ty: ignore[invalid-argument-type]
+            on=join_columns,
+            how="inner",
+            suffix="__right",
+        )
+
+        # Changed: provenance differs OR marked stale by predicates
+        changed_filter: nw.Expr = nw.col(f"__current_{METAXY_PROVENANCE}").is_null() | (
+            nw.col(METAXY_PROVENANCE) != nw.col(f"__current_{METAXY_PROVENANCE}")
+        )
+        if staleness_predicates:
+            changed_filter = changed_filter | nw.col(_STALE_BY_PREDICATE)
+
         changed = cast(
             FrameT,
-            expected.join(  # ty: ignore[invalid-argument-type]
-                cast(  # ty: ignore[invalid-argument-type]
-                    FrameT,
-                    current.select(*join_columns, f"__current_{METAXY_PROVENANCE}"),
-                ),
-                on=join_columns,
-                how="inner",
-            )
-            .filter(
-                nw.col(f"__current_{METAXY_PROVENANCE}").is_null()
-                | (nw.col(METAXY_PROVENANCE) != nw.col(f"__current_{METAXY_PROVENANCE}"))
-            )
-            .drop(f"__current_{METAXY_PROVENANCE}"),
+            joined.filter(changed_filter).select(expected_columns),
         )
 
         # Find removed samples (in current but not expected)

--- a/tests/metadata_stores/test_resolve_update_staleness_predicates.py
+++ b/tests/metadata_stores/test_resolve_update_staleness_predicates.py
@@ -1,0 +1,383 @@
+"""Test resolve_update with staleness_predicates parameter.
+
+Records matching any staleness predicate are treated as stale by resolve_update,
+regardless of version. Predicates are OR'd and applied against existing store records.
+
+skip_comparison=True takes precedence (no predicate evaluation needed).
+
+Tests use downstream features with a resolve-then-write pattern to establish
+properly computed provenance before testing predicate behavior.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import narwhals as nw
+import polars as pl
+from metaxy_testing import add_metaxy_provenance_column
+from metaxy_testing.models import SampleFeature, SampleFeatureSpec
+
+from metaxy import FeatureDep, FeatureGraph
+from metaxy.metadata_store.base import MetadataStore
+from metaxy.models.constants import METAXY_PROVENANCE_BY_FIELD
+from metaxy.models.field import FieldSpec
+from metaxy.models.types import FeatureKey, FieldKey
+from metaxy.versioning.types import LazyIncrement
+
+
+def _setup_upstream_and_downstream(
+    store: MetadataStore,
+    graph: FeatureGraph,
+    downstream_cls: Any,
+    upstream_cls: Any,
+    upstream_provenance: list[dict[str, str]],
+    downstream_extra_columns: dict[str, list[Any]] | None = None,
+) -> None:
+    """Write upstream, resolve downstream, augment with extra columns, and write downstream."""
+    sample_uids = list(range(1, len(upstream_provenance) + 1))
+
+    upstream_data = pl.DataFrame(
+        {
+            "sample_uid": sample_uids,
+            METAXY_PROVENANCE_BY_FIELD: upstream_provenance,
+        }
+    )
+    upstream_data = add_metaxy_provenance_column(upstream_data, upstream_cls)
+    store.write(upstream_cls, upstream_data)
+
+    # Resolve downstream to get correctly computed provenance
+    inc = store.resolve_update(downstream_cls)
+    downstream_df = inc.new.to_polars()
+
+    # Add extra user columns by joining on sample_uid (order-independent)
+    if downstream_extra_columns:
+        schema_overrides = {
+            col: pl.Utf8 if all(v is None for v in values) else None for col, values in downstream_extra_columns.items()
+        }
+        extra_df = pl.DataFrame(
+            {"sample_uid": sample_uids, **downstream_extra_columns},
+            schema_overrides={k: v for k, v in schema_overrides.items() if v is not None},
+        )
+        downstream_df = downstream_df.join(extra_df, on="sample_uid", how="left")
+
+    store.write(downstream_cls, downstream_df)
+
+
+def _make_features(graph: FeatureGraph) -> tuple[Any, Any]:
+    """Define a simple upstream/downstream feature pair within the given graph."""
+    with graph.use():
+
+        class UpstreamFeature(
+            SampleFeature,
+            spec=SampleFeatureSpec(
+                key=FeatureKey(["upstream"]),
+                fields=[FieldSpec(key=FieldKey(["value"]), code_version="1")],
+            ),
+        ):
+            pass
+
+        class DownstreamFeature(
+            SampleFeature,
+            spec=SampleFeatureSpec(
+                key=FeatureKey(["downstream"]),
+                deps=[FeatureDep(feature=UpstreamFeature)],
+                fields=[FieldSpec(key=FieldKey(["result"]), code_version="1")],
+            ),
+        ):
+            pass
+
+    return UpstreamFeature, DownstreamFeature
+
+
+def test_predicate_marks_matching_records_as_stale(any_store: MetadataStore) -> None:
+    """Records matching a staleness predicate should appear in inc.stale."""
+    graph = FeatureGraph()
+    UpstreamFeature, DownstreamFeature = _make_features(graph)
+
+    with graph.use(), any_store.open("w"):
+        _setup_upstream_and_downstream(
+            any_store,
+            graph,
+            DownstreamFeature,
+            UpstreamFeature,
+            upstream_provenance=[{"value": "up1"}, {"value": "up2"}, {"value": "up3"}],
+            downstream_extra_columns={
+                "dataset": ["mead", "mead", "voxceleb"],
+                "extra": [None, "has_extra", None],
+            },
+        )
+
+        result = any_store.resolve_update(
+            DownstreamFeature,
+            staleness_predicates=[
+                (nw.col("dataset") == "mead") & nw.col("extra").is_null(),
+            ],
+        )
+
+        # sample_uid=1: dataset='mead' AND extra IS NULL -> stale
+        # sample_uid=2: dataset='mead' but extra='has_extra' -> not stale
+        # sample_uid=3: extra IS NULL but dataset='voxceleb' -> not stale
+        assert len(result.new) == 0
+        assert len(result.orphaned) == 0
+        assert sorted(result.stale["sample_uid"].to_list()) == [1]
+
+
+def test_multiple_predicates_are_ored(any_store: MetadataStore) -> None:
+    """Multiple staleness predicates should be OR'd together."""
+    graph = FeatureGraph()
+    UpstreamFeature, DownstreamFeature = _make_features(graph)
+
+    with graph.use(), any_store.open("w"):
+        _setup_upstream_and_downstream(
+            any_store,
+            graph,
+            DownstreamFeature,
+            UpstreamFeature,
+            upstream_provenance=[{"value": "up1"}, {"value": "up2"}, {"value": "up3"}, {"value": "up4"}],
+            downstream_extra_columns={
+                "dataset": ["mead", "voxceleb", "mead", "voxceleb"],
+                "extra": ["has", None, None, "has"],
+            },
+        )
+
+        result = any_store.resolve_update(
+            DownstreamFeature,
+            staleness_predicates=[
+                nw.col("dataset") == "mead",
+                nw.col("extra").is_null(),
+            ],
+        )
+
+        # 1: dataset='mead' -> match
+        # 2: extra IS NULL -> match
+        # 3: dataset='mead' AND extra IS NULL -> match (both)
+        # 4: neither -> no match
+        assert sorted(result.stale["sample_uid"].to_list()) == [1, 2, 3]
+
+
+def test_predicates_dont_duplicate_version_stale(any_store: MetadataStore) -> None:
+    """Records already stale from version diff shouldn't be duplicated."""
+    graph = FeatureGraph()
+    UpstreamFeature, DownstreamFeature = _make_features(graph)
+
+    with graph.use(), any_store.open("w"):
+        _setup_upstream_and_downstream(
+            any_store,
+            graph,
+            DownstreamFeature,
+            UpstreamFeature,
+            upstream_provenance=[{"value": "up1"}, {"value": "up2"}],
+            downstream_extra_columns={
+                "dataset": ["mead", "mead"],
+            },
+        )
+
+        # Change upstream provenance for sample 1 (version-based stale)
+        upstream_data_v2 = pl.DataFrame(
+            {
+                "sample_uid": [1, 2],
+                METAXY_PROVENANCE_BY_FIELD: [
+                    {"value": "up1_changed"},
+                    {"value": "up2"},
+                ],
+            }
+        )
+        upstream_data_v2 = add_metaxy_provenance_column(upstream_data_v2, UpstreamFeature)
+        any_store.write(UpstreamFeature, upstream_data_v2)
+
+        result = any_store.resolve_update(
+            DownstreamFeature,
+            staleness_predicates=[nw.col("dataset") == "mead"],
+        )
+
+        # sample 1: stale from version diff AND matches predicate -> appears once
+        # sample 2: matches predicate only -> stale from predicate
+        assert sorted(result.stale["sample_uid"].to_list()) == [1, 2]
+
+
+def test_predicates_dont_duplicate_new(any_store: MetadataStore) -> None:
+    """Records already in inc.new shouldn't be added to inc.stale by predicates."""
+    graph = FeatureGraph()
+    UpstreamFeature, DownstreamFeature = _make_features(graph)
+
+    with graph.use(), any_store.open("w"):
+        # Write upstream for sample 1 only
+        upstream_data = pl.DataFrame(
+            {
+                "sample_uid": [1],
+                METAXY_PROVENANCE_BY_FIELD: [{"value": "up1"}],
+            }
+        )
+        upstream_data = add_metaxy_provenance_column(upstream_data, UpstreamFeature)
+        any_store.write(UpstreamFeature, upstream_data)
+
+        # Resolve and write downstream for sample 1 with extra column
+        inc = any_store.resolve_update(DownstreamFeature)
+        downstream_df = inc.new.to_polars().with_columns(pl.Series("dataset", ["mead"]))
+        any_store.write(DownstreamFeature, downstream_df)
+
+        # Now add sample 2 to upstream
+        upstream_data_v2 = pl.DataFrame(
+            {
+                "sample_uid": [1, 2],
+                METAXY_PROVENANCE_BY_FIELD: [{"value": "up1"}, {"value": "up2"}],
+            }
+        )
+        upstream_data_v2 = add_metaxy_provenance_column(upstream_data_v2, UpstreamFeature)
+        any_store.write(UpstreamFeature, upstream_data_v2)
+
+        result = any_store.resolve_update(
+            DownstreamFeature,
+            staleness_predicates=[nw.col("dataset") == "mead"],
+        )
+
+        # sample 2: new (not in downstream store) - should NOT also be in stale
+        # sample 1: matches predicate -> stale
+        assert result.new["sample_uid"].to_list() == [2]
+        assert result.stale["sample_uid"].to_list() == [1]
+
+
+def test_skip_comparison_bypasses_predicates(any_store: MetadataStore) -> None:
+    """skip_comparison=True should take precedence over staleness predicates."""
+    graph = FeatureGraph()
+    UpstreamFeature, DownstreamFeature = _make_features(graph)
+
+    with graph.use(), any_store.open("w"):
+        upstream_data = pl.DataFrame(
+            {
+                "sample_uid": [1],
+                METAXY_PROVENANCE_BY_FIELD: [{"value": "up1"}],
+            }
+        )
+        upstream_data = add_metaxy_provenance_column(upstream_data, UpstreamFeature)
+        any_store.write(UpstreamFeature, upstream_data)
+
+        inc = any_store.resolve_update(DownstreamFeature)
+        downstream_df = inc.new.to_polars().with_columns(pl.Series("needs_reprocess", [1]))
+        any_store.write(DownstreamFeature, downstream_df)
+
+        result = any_store.resolve_update(
+            DownstreamFeature,
+            skip_comparison=True,
+            staleness_predicates=[nw.col("needs_reprocess") == 1],
+        )
+
+        # Everything in new, nothing in stale (skip_comparison bypasses predicates)
+        assert len(result.new) == 1
+        assert len(result.stale) == 0
+
+
+def test_first_run_no_current_metadata(any_store: MetadataStore) -> None:
+    """When no current metadata exists, predicates have nothing to match against."""
+    graph = FeatureGraph()
+    UpstreamFeature, DownstreamFeature = _make_features(graph)
+
+    with graph.use(), any_store.open("w"):
+        upstream_data = pl.DataFrame(
+            {
+                "sample_uid": [1, 2],
+                METAXY_PROVENANCE_BY_FIELD: [
+                    {"value": "up1"},
+                    {"value": "up2"},
+                ],
+            }
+        )
+        upstream_data = add_metaxy_provenance_column(upstream_data, UpstreamFeature)
+        any_store.write(UpstreamFeature, upstream_data)
+
+        # No downstream data written - first run
+        result = any_store.resolve_update(
+            DownstreamFeature,
+            staleness_predicates=[nw.col("dataset") == "mead"],
+        )
+
+        # First run: all samples are new, no stale
+        assert len(result.new) == 2
+        assert len(result.stale) == 0
+
+
+def test_lazy_mode(any_store: MetadataStore) -> None:
+    """Test staleness predicates work with lazy=True."""
+    graph = FeatureGraph()
+    UpstreamFeature, DownstreamFeature = _make_features(graph)
+
+    with graph.use(), any_store.open("w"):
+        _setup_upstream_and_downstream(
+            any_store,
+            graph,
+            DownstreamFeature,
+            UpstreamFeature,
+            upstream_provenance=[{"value": "up1"}, {"value": "up2"}],
+            downstream_extra_columns={
+                "dataset": ["mead", "voxceleb"],
+                "extra": [None, None],
+            },
+        )
+
+        lazy_result = any_store.resolve_update(
+            DownstreamFeature,
+            lazy=True,
+            staleness_predicates=[
+                (nw.col("dataset") == "mead") & nw.col("extra").is_null(),
+            ],
+        )
+
+        assert isinstance(lazy_result, LazyIncrement)
+        result = lazy_result.collect()
+        # Only sample 1 matches: dataset='mead' AND extra IS NULL
+        assert result.stale["sample_uid"].to_list() == [1]
+        assert len(result.new) == 0
+
+
+def test_global_filters_scope_predicates(any_store: MetadataStore) -> None:
+    """Test that global_filters scope the records predicates are evaluated against."""
+    graph = FeatureGraph()
+    UpstreamFeature, DownstreamFeature = _make_features(graph)
+
+    with graph.use(), any_store.open("w"):
+        _setup_upstream_and_downstream(
+            any_store,
+            graph,
+            DownstreamFeature,
+            UpstreamFeature,
+            upstream_provenance=[{"value": "up1"}, {"value": "up2"}, {"value": "up3"}],
+            downstream_extra_columns={
+                "dataset": ["mead", "mead", "voxceleb"],
+            },
+        )
+
+        # Only resolve for sample_uid 1 and 3 via global_filters
+        result = any_store.resolve_update(
+            DownstreamFeature,
+            global_filters=[nw.col("sample_uid").is_in([1, 3])],
+            staleness_predicates=[nw.col("dataset") == "mead"],
+        )
+
+        # sample 1: matches predicate (dataset='mead') and in filter scope -> stale
+        # sample 2: matches predicate but excluded by global_filters
+        # sample 3: in filter scope but dataset='voxceleb' -> not stale
+        assert result.stale["sample_uid"].to_list() == [1]
+        assert len(result.new) == 0
+
+
+def test_no_predicates_default_behavior(any_store: MetadataStore) -> None:
+    """Test that no staleness_predicates (default) doesn't affect behavior."""
+    graph = FeatureGraph()
+    UpstreamFeature, DownstreamFeature = _make_features(graph)
+
+    with graph.use(), any_store.open("w"):
+        _setup_upstream_and_downstream(
+            any_store,
+            graph,
+            DownstreamFeature,
+            UpstreamFeature,
+            upstream_provenance=[{"value": "up1"}, {"value": "up2"}],
+        )
+
+        result = any_store.resolve_update(DownstreamFeature)
+
+        # No changes, no predicates -> nothing stale
+        assert len(result.new) == 0
+        assert len(result.stale) == 0
+        assert len(result.orphaned) == 0


### PR DESCRIPTION
This PR adds a new `staleness_predicates` argument to `MetadataStore.resolve_update` which can be used to treat samples as stale based on arbitrary Narwhals expressions