### PR TITLE
update devenv

### DIFF
--- a/.github/actions/setup-devenv/action.yml
+++ b/.github/actions/setup-devenv/action.yml
@@ -33,10 +33,34 @@ runs:
         # Allow builtins.getEnv for DEVENV_PYTHON_VERSION
         DEVENV_NIX_FLAGS: "--impure"
       run: |
-        direnv allow .
-        direnv export gha >> "$GITHUB_ENV"
+        tmp_devenv_dir="$(mktemp -d)"
+        cp devenv.nix devenv.yaml devenv.lock "$tmp_devenv_dir/"
+
+        cat > "$tmp_devenv_dir/.envrc" <<'EOF'
+        eval "$(devenv direnvrc)"
+        use devenv
+        EOF
+
+        (
+          cd "$tmp_devenv_dir"
+          direnv allow .
+          direnv export gha >> "$GITHUB_ENV"
+        )
+        rm -rf "$tmp_devenv_dir"
 
     - name: Install Python dependencies
       if: inputs.install-deps == 'true'
       shell: bash
       run: uv sync --all-extras --all-groups
+
+    - name: Assert devenv.lock unchanged
+      shell: bash
+      run: |
+        if ! git ls-files --error-unmatch devenv.lock >/dev/null 2>&1; then
+          exit 0
+        fi
+        if ! git diff --exit-code -- devenv.lock; then
+          echo "::error::devenv.lock was modified during CI setup. CI must not modify lockfiles."
+          git --no-pager diff -- devenv.lock || true
+          exit 1
+        fi

--- a/devenv.lock
+++ b/devenv.lock
@@ -3,10 +3,10 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1770167382,
+        "lastModified": 1772757027,
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "195375e3f0a3c3ac4f12b21d3f59a7ddb209bd1f",
+        "rev": "a3365a235e14ca3e581c7e49acda5179687c4d01",
         "type": "github"
       },
       "original": {
@@ -40,10 +40,10 @@
         ]
       },
       "locked": {
-        "lastModified": 1769939035,
+        "lastModified": 1772665116,
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "a8ca480175326551d6c4121498316261cbb5b260",
+        "rev": "39f53203a8458c330f61cc0759fe243f0ac0d198",
         "type": "github"
       },
       "original": {
@@ -74,10 +74,10 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1770136044,
+        "lastModified": 1772598333,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e576e3c9cf9bad747afcddd9e34f51d18c855b4e",
+        "rev": "fabb8c9deee281e50b1065002c9828f2cf7b2239",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
runs like https://github.com/anam-org/metaxy/actions/runs/22754877955/job/65998623025

were failing

```

- [new branch]        gh-pages   -> gh-pages
error: Your local changes to the following files would be overwritten by checkout:
devenv.lock
Please commit your changes or stash them before you switch branches.
Aborting

```

this should fix it by explicitly updating the devenv lockfile



further change the workflow to be clean for docs, and explicitly fail elswhere if the lockfile changes



