### PR TITLE
[cli] ignore packages that are not dependencies in `metaxy lock`

### DIFF
--- a/docs/guide/concepts/projects.md
+++ b/docs/guide/concepts/projects.md
@@ -100,3 +100,14 @@ my-key = "my_package.features"
 !!! note
 
     Currently the name of the key (`my-key` in the example above) is not used by Metaxy and is not important.
+
+#### Dependency Filtering
+
+The `metaxy lock` command automatically filters distribution entry points to only load features from the current project and its Python dependencies (including transitive). This ensures that features from non-dependency packages remain external and appear in the lock file.
+
+!!! example "Use case: `uv` workspaces"
+
+    This is useful when working with [`uv` workspaces](https://docs.astral.sh/uv/concepts/projects/workspaces/),
+    where all workspace members are installed in the same environment.
+    Without filtering, features from sibling packages that aren't dependencies
+    would be load into the feature graph and be missing from the `metaxy.lock` file.

--- a/src/metaxy/__init__.py
+++ b/src/metaxy/__init__.py
@@ -118,6 +118,8 @@ def coerce_to_feature_key(value: CoercibleToFeatureKey) -> FeatureKey:
 def init(
     config: MetaxyConfig | Path | str | None = None,
     search_parents: bool = True,
+    *,
+    isolated: bool = False,
 ) -> MetaxyConfig:
     """Main user-facing initialization function for Metaxy. It loads feature definitions and the Metaxy [configuration][metaxy.MetaxyConfig].
 
@@ -131,6 +133,8 @@ def init(
                 `METAXY_CONFIG` environment variable can be used to set the config file path.
 
         search_parents: Whether to search parent directories for configuration files during config discovery.
+        isolated: Whether to only load distribution entry points from Python dependencies (including transitive) of this project.
+            Features from non-dependencies available in the same Python environment will be excluded from feature auto-discovery.
 
     Returns:
         The activated Metaxy configuration.
@@ -145,7 +149,7 @@ def init(
             search_parents=search_parents,
         )
     load_lock_file(config)
-    load_features(config.entrypoints)
+    load_features(config.entrypoints, filter_project=config.project)
     return config
 
 

--- a/src/metaxy/cli/app.py
+++ b/src/metaxy/cli/app.py
@@ -82,9 +82,13 @@ def launcher(
 
     logging.getLogger().setLevel(os.environ.get("METAXY_LOG_LEVEL", "INFO"))
 
-    # Load Metaxy configuration with parent directory search
-    # This handles TOML discovery, env vars, and entrypoint loading
-    config = init(config_file)
+    from metaxy.config import MetaxyConfig
+
+    # Load config, then init with it. The lock command needs entrypoint
+    # filtering to prevent non-dependency features from loading into the
+    # graph (they must remain external so they appear in the lock file).
+    loaded_config = MetaxyConfig.load(config_file=config_file, search_parents=True)
+    config = init(loaded_config, isolated=tokens is not None and tokens[0] == "lock")
 
     # Store config in context for commands to access
     # Commands will instantiate and open store as needed

--- a/src/metaxy/cli/context.py
+++ b/src/metaxy/cli/context.py
@@ -51,11 +51,10 @@ class AppContext:
         if _global_app_context is not None:
             raise RuntimeError("AppContext already initialized. It is not allowed to call AppContext.set() again.")
         else:
-            from metaxy import load_features, sync_external_features
+            from metaxy import sync_external_features
             from metaxy.config import MetaxyConfig
 
             MetaxyConfig.set(config)
-            load_features()
 
             # If --sync is enabled, sync external features from the store
             if sync:

--- a/src/metaxy/cli/lock.py
+++ b/src/metaxy/cli/lock.py
@@ -12,7 +12,6 @@ from metaxy.cli.console import console, error_console
 # Lock subcommand app
 app = cyclopts.App(
     name="lock",
-    help="Generate `metaxy.lock` file with [external feature definitions](https://docs.metaxy.io/latest/guide/concepts/definitions/external-features/) fetched from the metadata store.",
     console=console,
     error_console=error_console,
 )
@@ -36,10 +35,14 @@ def lock(
         ),
     ] = "",
 ):
-    """Fetch external feature definitions and serialize them to metaxy.lock.
+    """Generate `metaxy.lock` file with [external feature definitions](https://docs.metaxy.io/latest/guide/concepts/definitions/external-features/) fetched from the metadata store.
 
     Analyzes the current feature graph to find external dependencies, then fetches
     those feature definitions (and their transitive dependencies) from the metadata store.
+
+    Distribution entry points are automatically filtered to only load features from
+    the current project and its Python dependencies (including transitive), preventing
+    unrelated packages from polluting the lock file.
 
     This functionality is currently experimental.
     """

--- a/src/metaxy/entrypoints.py
+++ b/src/metaxy/entrypoints.py
@@ -11,14 +11,18 @@ containing modules are imported (via the Feature metaclass).
 """
 
 import importlib
+import importlib.metadata
 import os
 from contextvars import ContextVar
 from typing import TYPE_CHECKING
 
+from packaging.requirements import Requirement
+from packaging.utils import NormalizedName, canonicalize_name
+
 if TYPE_CHECKING:
     from metaxy.models.feature import FeatureGraph
 
-from importlib.metadata import entry_points
+from importlib.metadata import EntryPoint, entry_points
 
 # Guard against re-entrant calls to load_features
 _loading_features: ContextVar[bool] = ContextVar("_loading_features", default=False)
@@ -104,10 +108,60 @@ def load_entrypoints(
         load_module_entrypoint(module_path, graph=target_graph)
 
 
+def _get_allowed_distributions(project: str) -> frozenset[NormalizedName] | None:
+    """Get the set of distribution names allowed to contribute entry points.
+
+    Returns the canonicalized names of the project and all its transitive
+    dependencies. Returns None if the project is not installed (no filtering).
+    """
+    canonical_project = canonicalize_name(project)
+
+    try:
+        importlib.metadata.requires(project)
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+    allowed: set[NormalizedName] = set()
+    queue = [canonical_project]
+
+    while queue:
+        name = queue.pop()
+        if name in allowed:
+            continue
+        allowed.add(name)
+
+        try:
+            requires = importlib.metadata.requires(name)
+        except importlib.metadata.PackageNotFoundError:
+            continue
+
+        if requires is None:
+            continue
+
+        for req_str in requires:
+            req = Requirement(req_str)
+            if req.marker is not None and not req.marker.evaluate():
+                continue
+            dep_name = canonicalize_name(req.name)
+            if dep_name not in allowed:
+                queue.append(dep_name)
+
+    return frozenset(allowed)
+
+
+def _filter_entry_points_by_distribution(
+    eps: list[EntryPoint],
+    allowed: frozenset[NormalizedName],
+) -> list[EntryPoint]:
+    """Filter entry points to only those from allowed distributions."""
+    return [ep for ep in eps if ep.dist is None or canonicalize_name(ep.dist.name) in allowed]
+
+
 def load_package_entrypoints(
     group: str = DEFAULT_ENTRY_POINT_GROUP,
     *,
     graph: "FeatureGraph | None" = None,
+    filter_project: str | None = None,
 ) -> None:
     """Load entrypoints from installed packages using importlib.metadata.
 
@@ -128,6 +182,9 @@ def load_package_entrypoints(
     Args:
         group: Entry point group name (default: "metaxy.project")
         graph: Target graph. If None, uses FeatureGraph.get_active()
+        filter_project: If set, only load entry points from this project and
+            its Python dependencies (including transitive). Used by ``metaxy lock``
+            to exclude non-dependency packages from the feature graph.
 
     Raises:
         EntrypointLoadError: If any entrypoint fails to load
@@ -157,6 +214,14 @@ def load_package_entrypoints(
         eps = discovered.get(group, [])
 
     eps_list = list(eps)
+
+    if not eps_list:
+        return
+
+    if filter_project is not None:
+        allowed = _get_allowed_distributions(filter_project)
+        if allowed is not None:
+            eps_list = _filter_entry_points_by_distribution(eps_list, allowed)
 
     if not eps_list:
         return
@@ -230,6 +295,7 @@ def load_features(
     *,
     load_packages: bool = True,
     load_env: bool = True,
+    filter_project: str | None = None,
 ) -> "FeatureGraph":
     """Discover and load feature entrypoints from packages and environment.
 
@@ -267,7 +333,7 @@ def load_features(
 
         # Load package-based entrypoints
         if load_packages:
-            load_package_entrypoints(package_entrypoint_group)
+            load_package_entrypoints(package_entrypoint_group, filter_project=filter_project)
 
         # Load environment-based entrypoints
         if load_env:

--- a/src/metaxy/metadata_store/base.py
+++ b/src/metaxy/metadata_store/base.py
@@ -1904,7 +1904,7 @@ class MetadataStore(ABC):
             how="inner",
         )
 
-        return rebased.with_columns(  # type: ignore[return-value]
+        return rebased.with_columns(
             nw.lit(to_feature_version).alias(METAXY_FEATURE_VERSION),
             nw.lit(target_project_version).alias(METAXY_PROJECT_VERSION),
         )

--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from metaxy_testing.models import SampleFeatureSpec
+from packaging.utils import canonicalize_name
 
 from metaxy import (
     BaseFeature,
@@ -18,6 +19,8 @@ from metaxy import (
 )
 from metaxy.entrypoints import (
     EntrypointLoadError,
+    _filter_entry_points_by_distribution,
+    _get_allowed_distributions,
     load_entrypoints,
     load_features,
     load_module_entrypoint,
@@ -652,3 +655,303 @@ def test_missing_dependency_raises_clear_error(graph: FeatureGraph) -> None:
     # But accessing the plan raises a clear error
     with pytest.raises(MetaxyMissingFeatureDependency, match="nonexistent/upstream"):
         graph.get_feature_plan(FeatureKey(["orphan", "feature"]))
+
+
+# ========== Tests for dependency-based filtering ==========
+
+
+class TestGetAllowedDistributions:
+    """Tests for _get_allowed_distributions."""
+
+    def test_returns_none_when_package_not_installed(self) -> None:
+        allowed = _get_allowed_distributions("nonexistent-package-xyz-12345")
+        assert allowed is None
+
+    def test_includes_project_itself(self) -> None:
+        def mock_requires(name: str) -> None:
+            return None
+
+        with patch("metaxy.entrypoints.importlib.metadata.requires", side_effect=mock_requires):
+            allowed = _get_allowed_distributions("my-project")
+            assert allowed is not None
+            assert "my-project" in allowed
+
+    def test_includes_direct_dependencies(self) -> None:
+        def mock_requires(name: str) -> list[str] | None:
+            if name == "my-project":
+                return ["dep-one>=1.0", "dep_two", "Dep-Three[extra]"]
+            return None
+
+        with patch("metaxy.entrypoints.importlib.metadata.requires", side_effect=mock_requires):
+            allowed = _get_allowed_distributions("my-project")
+            assert allowed is not None
+            assert "my-project" in allowed
+            assert "dep-one" in allowed
+            assert "dep-two" in allowed
+            assert "dep-three" in allowed
+
+    def test_includes_transitive_dependencies(self) -> None:
+        def mock_requires(name: str) -> list[str] | None:
+            return {
+                "my-project": ["core>=1.0"],
+                "core": ["utils"],
+            }.get(name)
+
+        with patch("metaxy.entrypoints.importlib.metadata.requires", side_effect=mock_requires):
+            allowed = _get_allowed_distributions("my-project")
+            assert allowed is not None
+            assert "my-project" in allowed
+            assert "core" in allowed
+            assert "utils" in allowed
+
+    def test_canonicalizes_project_name(self) -> None:
+        with patch("metaxy.entrypoints.importlib.metadata.requires", return_value=None):
+            allowed = _get_allowed_distributions("My_Project")
+            assert allowed is not None
+            assert "my-project" in allowed
+
+    def test_excludes_extras_only_dependencies(self) -> None:
+        """Dependencies gated behind extras are not included in the allowed set."""
+
+        def mock_requires(name: str) -> list[str] | None:
+            if name == "proj":
+                return [
+                    "unconditional-dep",
+                    'extras-only-dep ; extra == "dev"',
+                    'another-extras-dep ; extra == "test"',
+                ]
+            return None
+
+        with patch("metaxy.entrypoints.importlib.metadata.requires", side_effect=mock_requires):
+            allowed = _get_allowed_distributions("proj")
+            assert allowed is not None
+            assert "unconditional-dep" in allowed
+            assert "extras-only-dep" not in allowed
+            assert "another-extras-dep" not in allowed
+
+    def test_includes_deps_matching_current_environment(self) -> None:
+        """Dependencies with environment markers that match the current env are included."""
+        import sys
+
+        def mock_requires(name: str) -> list[str] | None:
+            if name == "proj":
+                return [
+                    f"env-dep ; python_version >= '{sys.version_info.major}.{sys.version_info.minor}'",
+                    "impossible-dep ; python_version < '2.0'",
+                ]
+            return None
+
+        with patch("metaxy.entrypoints.importlib.metadata.requires", side_effect=mock_requires):
+            allowed = _get_allowed_distributions("proj")
+            assert allowed is not None
+            assert "env-dep" in allowed
+            assert "impossible-dep" not in allowed
+
+
+class TestFilterEntryPointsByDistribution:
+    """Tests for _filter_entry_points_by_distribution."""
+
+    def _make_ep(self, dist_name: str | None) -> MagicMock:
+        ep = MagicMock(spec=["dist", "name", "value", "load"])
+        if dist_name is None:
+            ep.dist = None
+        else:
+            ep.dist = MagicMock()
+            ep.dist.name = dist_name
+        return ep
+
+    def test_filters_to_allowed(self) -> None:
+        ep_a = self._make_ep("package-a")
+        ep_b = self._make_ep("package-b")
+        ep_c = self._make_ep("package-c")
+
+        result = _filter_entry_points_by_distribution(
+            [ep_a, ep_b, ep_c],
+            frozenset({canonicalize_name("package-a"), canonicalize_name("package-c")}),
+        )
+        assert result == [ep_a, ep_c]
+
+    def test_includes_eps_with_no_dist(self) -> None:
+        ep_no_dist = self._make_ep(None)
+        ep_allowed = self._make_ep("allowed")
+
+        result = _filter_entry_points_by_distribution(
+            [ep_no_dist, ep_allowed],
+            frozenset({canonicalize_name("allowed")}),
+        )
+        assert result == [ep_no_dist, ep_allowed]
+
+    def test_canonicalizes_dist_names(self) -> None:
+        ep = self._make_ep("My_Package")
+        result = _filter_entry_points_by_distribution([ep], frozenset({canonicalize_name("my-package")}))
+        assert result == [ep]
+
+    def test_empty_input(self) -> None:
+        result = _filter_entry_points_by_distribution([], frozenset({canonicalize_name("any")}))
+        assert result == []
+
+
+class TestLoadPackageEntrypointsFiltering:
+    """Tests for filter_project parameter in load_package_entrypoints."""
+
+    def test_filters_by_project_dependencies(self, graph: FeatureGraph) -> None:
+        """Only entry points from project dependencies are loaded."""
+        allowed_ep = MagicMock()
+        allowed_ep.name = "dep_plugin"
+        allowed_ep.value = "dep_plugin.features"
+        allowed_ep.dist = MagicMock()
+        allowed_ep.dist.name = "my-dep"
+
+        def load_allowed():
+            class AllowedFeature(
+                BaseFeature,
+                spec=SampleFeatureSpec(
+                    key=FeatureKey(["allowed", "feature"]),
+                    fields=[FieldSpec(key=FieldKey(["default"]), code_version="1")],
+                ),
+            ):
+                pass
+
+        allowed_ep.load = load_allowed
+
+        blocked_ep = MagicMock()
+        blocked_ep.name = "other_plugin"
+        blocked_ep.value = "other_plugin.features"
+        blocked_ep.dist = MagicMock()
+        blocked_ep.dist.name = "unrelated-pkg"
+
+        def load_blocked():
+            class BlockedFeature(
+                BaseFeature,
+                spec=SampleFeatureSpec(
+                    key=FeatureKey(["blocked", "feature"]),
+                    fields=[FieldSpec(key=FieldKey(["default"]), code_version="1")],
+                ),
+            ):
+                pass
+
+        blocked_ep.load = load_blocked
+
+        with (
+            patch("metaxy.entrypoints.entry_points") as mock_entry_points,
+            patch(
+                "metaxy.entrypoints.importlib.metadata.requires",
+                return_value=["my-dep>=1.0"],
+            ),
+        ):
+            mock_eps = MagicMock()
+            mock_eps.select.return_value = [allowed_ep, blocked_ep]
+            mock_entry_points.return_value = mock_eps
+
+            load_package_entrypoints(graph=graph, filter_project="my-project")
+
+            assert FeatureKey(["allowed", "feature"]) in graph.feature_definitions_by_key
+            assert FeatureKey(["blocked", "feature"]) not in graph.feature_definitions_by_key
+
+    def test_no_filtering_without_filter_project(self, graph: FeatureGraph) -> None:
+        """All entry points loaded when filter_project is not set."""
+        ep = MagicMock()
+        ep.name = "any_plugin"
+        ep.value = "any.features"
+        ep.dist = MagicMock()
+        ep.dist.name = "any-package"
+
+        def mock_load():
+            class AnyFeature(
+                BaseFeature,
+                spec=SampleFeatureSpec(
+                    key=FeatureKey(["any", "feature"]),
+                    fields=[FieldSpec(key=FieldKey(["default"]), code_version="1")],
+                ),
+            ):
+                pass
+
+        ep.load = mock_load
+
+        with patch("metaxy.entrypoints.entry_points") as mock_entry_points:
+            mock_eps = MagicMock()
+            mock_eps.select.return_value = [ep]
+            mock_entry_points.return_value = mock_eps
+
+            load_package_entrypoints(graph=graph)
+
+            assert FeatureKey(["any", "feature"]) in graph.feature_definitions_by_key
+
+    def test_extras_deps_not_in_allowed_set(self, graph: FeatureGraph) -> None:
+        """Entry points from extras-only dependencies are filtered out."""
+        # ep_extras comes from a package that is only an extras dep of the project
+        ep_extras = MagicMock()
+        ep_extras.name = "extras_plugin"
+        ep_extras.value = "extras_plugin.features"
+        ep_extras.dist = MagicMock()
+        ep_extras.dist.name = "extras-only-pkg"
+
+        def load_extras():
+            class ExtrasFeature(
+                BaseFeature,
+                spec=SampleFeatureSpec(
+                    key=FeatureKey(["extras", "feature"]),
+                    fields=[FieldSpec(key=FieldKey(["default"]), code_version="1")],
+                ),
+            ):
+                pass
+
+        ep_extras.load = load_extras
+
+        def mock_requires(name: str) -> list[str] | None:
+            if name == "my-project":
+                return [
+                    "real-dep>=1.0",
+                    'extras-only-pkg ; extra == "dev"',
+                ]
+            return None
+
+        with (
+            patch("metaxy.entrypoints.entry_points") as mock_entry_points,
+            patch(
+                "metaxy.entrypoints.importlib.metadata.requires",
+                side_effect=mock_requires,
+            ),
+        ):
+            mock_eps = MagicMock()
+            mock_eps.select.return_value = [ep_extras]
+            mock_entry_points.return_value = mock_eps
+
+            load_package_entrypoints(graph=graph, filter_project="my-project")
+
+            assert FeatureKey(["extras", "feature"]) not in graph.feature_definitions_by_key
+
+    def test_no_filtering_when_package_not_installed(self, graph: FeatureGraph) -> None:
+        """All entry points loaded when filter_project package is not installed."""
+        ep = MagicMock()
+        ep.name = "plugin"
+        ep.value = "plugin.features"
+        ep.dist = MagicMock()
+        ep.dist.name = "some-package"
+
+        def mock_load():
+            class SomeFeature(
+                BaseFeature,
+                spec=SampleFeatureSpec(
+                    key=FeatureKey(["some", "feature"]),
+                    fields=[FieldSpec(key=FieldKey(["default"]), code_version="1")],
+                ),
+            ):
+                pass
+
+        ep.load = mock_load
+
+        with (
+            patch("metaxy.entrypoints.entry_points") as mock_entry_points,
+            patch(
+                "metaxy.entrypoints._get_allowed_distributions",
+                return_value=None,
+            ),
+        ):
+            mock_eps = MagicMock()
+            mock_eps.select.return_value = [ep]
+            mock_entry_points.return_value = mock_eps
+
+            load_package_entrypoints(graph=graph, filter_project="not-installed-pkg")
+
+            assert FeatureKey(["some", "feature"]) in graph.feature_definitions_by_key


### PR DESCRIPTION
## Motivation

This fix removes the need to run `metaxy lock` with `uv run --isolated` in `uv` workspaces.

## Changelog

`metaxy lock` now avoids loading feature definitions from `metaxy.project` entrypoints of Python packages that aren't dependencies (direct or transitive) of the current Python package when creating the lock file. 