### PR TITLE
fix/duckdb-extension-loading-from-community-repo

### DIFF
--- a/src/metaxy/ext/metadata_stores/duckdb.py
+++ b/src/metaxy/ext/metadata_stores/duckdb.py
@@ -1,6 +1,6 @@
 """DuckDB metadata store - thin wrapper around IbisMetadataStore."""
 
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -68,7 +68,7 @@ class DuckDBMetadataStoreConfig(IbisMetadataStoreConfig):
 
 
 def _normalise_extensions(
-    extensions: Iterable[str | ExtensionSpec],
+    extensions: Iterable[str | ExtensionSpec | Mapping[str, Any]],
 ) -> list[ExtensionSpec]:
     """Coerce extension inputs into ExtensionSpec instances."""
     normalised: list[ExtensionSpec] = []
@@ -77,6 +77,8 @@ def _normalise_extensions(
             normalised.append(ExtensionSpec(name=ext))
         elif isinstance(ext, ExtensionSpec):
             normalised.append(ext)
+        elif isinstance(ext, Mapping):
+            normalised.append(ExtensionSpec.model_validate(dict(ext)))
         else:
             raise TypeError(f"DuckDB extensions must be strings or ExtensionSpec instances, got {type(ext).__name__}.")
     return normalised

--- a/tests/metadata_stores/test_duckdb.py
+++ b/tests/metadata_stores/test_duckdb.py
@@ -368,6 +368,32 @@ def test_duckdb_config_with_extensions() -> None:
         assert store._is_open
 
 
+def test_duckdb_config_with_extension_specs() -> None:
+    """DuckDB store config should accept serialized ExtensionSpec mappings."""
+    from metaxy.config import MetaxyConfig, StoreConfig
+
+    config = MetaxyConfig(
+        stores={
+            "duckdb_store": StoreConfig(
+                type="metaxy.ext.metadata_stores.duckdb.DuckDBMetadataStore",
+                config={
+                    "database": ":memory:",
+                    "extensions": [
+                        {
+                            "name": "hashfuncs",
+                            "repository": "community",
+                        }
+                    ],
+                },
+            )
+        }
+    )
+
+    store = config.get_store("duckdb_store")
+    assert isinstance(store, DuckDBMetadataStore)
+    assert ("hashfuncs", "community") in [(ext.name, ext.repository) for ext in store.extensions]
+
+
 def test_duckdb_config_with_hash_algorithm() -> None:
     """Test DuckDB store config with specific hash algorithm."""
     from metaxy.config import MetaxyConfig, StoreConfig


### PR DESCRIPTION
extensions = [{ name = "hashfuncs", repository = "community" }],
  did not work because Metaxy’s from_config() path serializes config models to plain dicts, while
  _normalise_extensions() only accepted strings or ExtensionSpec instances. 
