### PR TITLE
chore: adopt `git-cliff`

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,7 +1,7 @@
 name: PR Title
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, reopened]
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,26 @@ jobs:
             echo "stable=false" >> "$GITHUB_OUTPUT"
           fi
 
+  github-release:
+    runs-on: depot-ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: orhun/git-cliff-action@v4
+        id: cliff
+        with:
+          config: cliff.toml
+          args: --latest --strip header
+        env:
+          OUTPUT: CHANGES.md
+      - uses: softprops/action-gh-release@v2
+        with:
+          body_path: CHANGES.md
+          tag_name: ${{ github.ref_name }}
+
   docs:
     needs: check-stable-release
     if: needs.check-stable-release.outputs.is-stable == 'true'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,38 @@ We are using [Devenv](https://devenv.sh/) to manage the development environment,
 
 To reinstall Python dependencies, run `uv sync --all-extras`.
 
+## Commit Messages
+
+We use [Conventional Commits](https://www.conventionalcommits.org/). PRs are squash-merged, so the **PR title becomes the commit message** in `main`. This means the PR title must follow conventional commit format — individual commit messages on the branch don't matter. A CI check enforces this.
+
+```
+<type>(<optional scope>): <description>
+```
+
+| Type | Purpose |
+|------|---------|
+| `feat` | New feature |
+| `fix` | Bug fix |
+| `docs` | Documentation only |
+| `refactor` | Code change that neither fixes a bug nor adds a feature |
+| `perf` | Performance improvement |
+| `test` | Adding or updating tests |
+| `chore` | Maintenance (deps, CI, releases) |
+
+Append `!` after the type/scope for breaking changes.
+
+Examples:
+
+```
+feat: add BigQuery metadata store support
+feat(cli): add --format flag to metaxy inspect
+fix: resolve race condition in metadata write
+refactor: simplify version calculation logic
+fix!: rename MetadataStore.push to MetadataStore.sync
+```
+
+Types `chore`, `ci`, `build`, `test`, and `style` are excluded from the changelog.
+
 ## Testing
 
 We use `pytest` for testing.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,5 +1,27 @@
 # Releasing
 
+## Prerequisites
+
+Install [git-cliff](https://git-cliff.org/) for changelog generation:
+
+```bash
+brew install git-cliff
+```
+
+## Changelog
+
+Preview unreleased changelog entries:
+
+```bash
+just changelog-preview
+```
+
+Regenerate the full `CHANGELOG.md`:
+
+```bash
+just changelog
+```
+
 ## Pre-release
 
 ```bash
@@ -12,4 +34,6 @@ just release rc
 just release stable
 ```
 
-Then create a Release and the corresponding tag from GitHub's UI.
+The `release` recipe bumps the version, updates `_version.py`, and regenerates `CHANGELOG.md`.
+
+Then create a Release and the corresponding tag from GitHub's UI. The GitHub Release body is automatically populated by CI using git-cliff.

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,132 @@
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+commit_preprocessors = [
+  { pattern = '^\((\w+)\)!:', replace = "($1):" },
+]
+commit_parsers = [
+  { message = "^feat", group = "### :sparkles: Added" },
+  { message = "^fix", group = "### :bug: Fixes" },
+  { message = "^docs", group = "### :book: Docs" },
+  { message = "^refactor", group = "### :wrench: Changed" },
+  { message = "^perf", group = "### :zap: Performance" },
+  { message = "^chore", skip = true },
+  { message = "^ci", skip = true },
+  { message = "^build", skip = true },
+  { message = "^test", skip = true },
+  { message = "^style", skip = true },
+]
+tag_pattern = "v[0-9].*"
+sort_commits = "newest"
+
+[changelog]
+header = """
+<!-- --8<-- [start:header] -->
+# Changelog
+
+All notable user-facing Metaxy changes are to be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html), except for *experimental* features.
+
+While Metaxy's core functionality and versioning engine are **_stable_** and quite complete, the CLI and some of the more advanced APIs and integrations are considered **_experimental_**.
+
+!!! abstract
+
+    **_stable_** features are guaranteed to follow SemVer and won't receive breaking changes in between minor releases. Such changes will be announced with a deprecation warning.
+    A feature is considered *stable* if it's documented and doesn't have an `"Experimental"` badge.
+
+    **_experimental_** features may be changed or removed at any time without deprecation warnings. They may be documented and in this case must display an `"Experimental"` warning badge:
+
+    !!! warning "Experimental"
+        This functionality is experimental.
+
+<!-- --8<-- [end:header] -->
+<!-- --8<-- [start:releases] -->
+"""
+body = """
+{% for group, commits in commits | group_by(attribute="group") %}\
+{{ group | striptags | trim }}
+{% for commit in commits %}
+{%- if commit.body and commit.body is containing("## Changelog") -%}
+{%- set changelog_section = commit.body | split(pat="## Changelog") | last -%}
+{%- set lines = changelog_section | split(pat="\n") -%}
+{%- for line in lines -%}
+{%- set trimmed = line | trim -%}
+{%- if trimmed is starting_with("- ") or trimmed is starting_with("* ") %}
+{{ trimmed }}
+{%- endif -%}
+{%- endfor -%}
+{%- else %}
+- {{ commit.message | split(pat="\n") | first | trim }}
+{%- endif %}
+{%- endfor %}
+{% endfor %}\
+"""
+footer = """
+## 0.1.4
+
+### :bug: Fixes
+
+- Fixed a bug with `metaxy push` not re-pushing feature definitions on changes reverting them to a previous version.
+
+## 0.1.3
+
+### :sparkles: Added
+
+- `metaxy lock` now avoids loading feature definitions from metaxy.project entrypoints of Python packages that aren't dependencies (direct or transitive) of the current Python package when creating the lock file.
+
+### :wrench: Changed
+
+- Renamed `metaxy graph history` CLI command to `metaxy history`
+
+### :book: Docs
+
+- Added a section on inheritance with Metaxy features
+- Improved Dagster integration docs
+
+## 0.1.2
+
+### :sparkles: Added
+
+- A new `staleness_predicates` parameter has been added to [`resolve_update`][metaxy.MetadataStore.resolve_update]. It can be used to mark records as stale based on arbitrary Narwhals expressions, regardless of their Metaxy versions.
+- `MetadataStore.write` now fills `metaxy_data_version` and `metaxy_data_version_by_field` values in place of `Null`s on per-row basis instead of checking whether the whole column presence.
+- Added [Rebases](/guide/concepts/metadata-stores.md#rebasing-metadata-versions) functionality which allows backfilling metadata from historical feature versions. It's available via [CLI](/reference/cli.md#metaxy-metadata-rebase) or as [`MetadataStore.rebase`][metaxy.MetadataStore.rebase].
+
+## 0.1.1
+
+### :sparkles: Added
+
+- A new top-level [`extra_features`](/reference/configuration.md#metaxy.config.MetaxyConfig.extra_features) configuration option has been added. It can be used to register additional external feature definitions from the metadata store on the feature graph. Learn more [here](/guide/concepts/definitions/external-features.md/#loading-extra-features).
+- [DuckLake](/integrations/metadata-stores/storage/ducklake.md) integration has been revamped, tested, and documented. Thanks [@geoHeil](https://github.com/geoHeil)!
+
+### :bug: Fixes
+
+- Fixed `DuckDBMetadataStore` assuming `"community"` extension repo instead of `"core"` when loading extensions with unspecified repos
+- Fixed `/metaxy` skill and `metaxy` MCP server not being properly installed by the Claude plugin
+- (:boom: breaking) Fixed a bug where `MetadataStore` erroneously did not require being opened with `"w"` write mode before writing data
+- Fixed a bug where `MetadataStore` would not properly handle nested context manager calls
+
+## 0.1.0
+
+The first public Metaxy release :tada:!
+
+This release should be considered an *alpha* release: it is ready for production use and has been dogfooded internally at [Anam.ai](https://anam.ai), but we don't have any community feedback yet.
+
+### :sparkles: Added
+
+- [Feature Definitions](/guide/concepts/definitions/features.md) and related models
+- Metaxy [versioning engine](/guide/concepts/versioning.md) and [storage layout](/reference/system-columns.md)
+- [MetadataStore API](/guide/concepts/metadata-stores.md)
+- Integrations: [DeltaLake](/integrations/metadata-stores/storage/delta.md), [Dagster](/integrations/orchestration/dagster/index.md), [Ray](/integrations/compute/ray.md), [ClickHouse](/integrations/metadata-stores/databases/clickhouse.md), [MCP](/integrations/ai/mcp.md), [Claude](/integrations/ai/claude.md)
+
+### Experimental
+
+- [CLI](/reference/cli.md)
+- [`metaxy.lock`-based workflow](/guide/concepts/definitions/external-features.md/#metaxylock-file) for multi-environment setups
+- Integrations: [DuckDB](/integrations/metadata-stores/databases/duckdb.md), [BigQuery](/integrations/metadata-stores/databases/bigquery.md), [LanceDB](/integrations/metadata-stores/databases/lancedb.md), [SQLAlchemy](/integrations/plugins/sqlalchemy.md), [SQLModel](/integrations/plugins/sqlmodel.md)
+
+<!-- --8<-- [end:releases] -->
+"""
+trim = true

--- a/devenv.nix
+++ b/devenv.nix
@@ -34,6 +34,9 @@ in
     clickhouse
     postgresql
 
+    # Changelog generation
+    git-cliff
+
     # Visualization
     graphviz
 

--- a/justfile
+++ b/justfile
@@ -85,10 +85,21 @@ init-example name:
     uv add --project examples ./examples/{{name}}
     uv add --project ./examples/{{name}} . --editable
 
+# Preview unreleased changelog entries
+changelog-preview:
+    git fetch --tags
+    git cliff --unreleased --strip header
+
+# Generate full CHANGELOG.md
+changelog:
+    git fetch --tags
+    git cliff -o CHANGELOG.md
+
 # Bump version: dev, rc, stable, patch, minor, major
 release bump:
     uv version --bump {{bump}}
     echo "__version__ = \"$(uv version --short)\"" > src/metaxy/_version.py
+    git cliff -o CHANGELOG.md
 
 # Update snapshots for all examples or specific examples
 example-snapshot-update *EXAMPLES:


### PR DESCRIPTION
## Summary

Adopt conventional commits and start using [`git-cliff`](https://git-cliff.org/) to generate [CHANGELOG.md](http://CHANGELOG.md)