### PR TITLE
ci: upgrade gha actions

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -10,7 +10,7 @@ runs:
   using: composite
   steps:
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7.5.0
 
     - name: Build package
       shell: bash

--- a/.github/actions/setup-devenv/action.yml
+++ b/.github/actions/setup-devenv/action.yml
@@ -11,7 +11,7 @@ runs:
   using: composite
   steps:
     - name: Install Nix
-      uses: cachix/install-nix-action@v31
+      uses: cachix/install-nix-action@v31.10.1
       with:
         nix_path: nixpkgs=channel:nixpkgs-unstable
 
@@ -21,7 +21,7 @@ runs:
         name: devenv
 
     - name: Setup Magic Nix Cache
-      uses: DeterminateSystems/magic-nix-cache-action@main
+      uses: DeterminateSystems/magic-nix-cache-action@v13
 
     - name: Install devenv
       shell: bash

--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -5,6 +5,9 @@ permissions:
   pages: write
   id-token: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 on:
   workflow_call:
     inputs:
@@ -32,14 +35,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup devenv
         uses: ./.github/actions/setup-devenv
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.1.3
         with:
           bun-version: 1.3.1
 

--- a/.github/workflows/_qa.yml
+++ b/.github/workflows/_qa.yml
@@ -3,6 +3,9 @@ name: _QA (reusable)
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 on:
   workflow_call:
     inputs:
@@ -41,8 +44,8 @@ jobs:
       claude-plugin: ${{ steps.filter.outputs.claude-plugin }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+        uses: actions/checkout@v6.0.2
+      - uses: dorny/paths-filter@v4.0.0
         id: filter
         with:
           filters: |
@@ -69,9 +72,9 @@ jobs:
     runs-on: depot-ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6.0.2
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v7.5.0
         with:
           enable-cache: true
       - name: Run Ruff
@@ -81,9 +84,9 @@ jobs:
     runs-on: depot-ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6.0.2
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v7.5.0
         with:
           enable-cache: true
       - uses: dprint/check@v2.3
@@ -104,7 +107,7 @@ jobs:
         python-version: ${{ fromJSON(inputs.python-versions) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6.0.2
       - name: Setup devenv
         uses: ./.github/actions/setup-devenv
       - name: Run ty
@@ -129,7 +132,7 @@ jobs:
         python-version: ${{ fromJSON(inputs.python-versions) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6.0.2
       - name: Setup devenv
         uses: ./.github/actions/setup-devenv
 
@@ -167,7 +170,7 @@ jobs:
 
       - name: Upload Coverage to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v5.5.2
         with:
           slug: anam-org/metaxy
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -183,7 +186,7 @@ jobs:
 
       - name: Upload Test Results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v5.5.2
         with:
           report_type: test_results
           slug: anam-org/metaxy
@@ -205,9 +208,9 @@ jobs:
       sessions: ${{ steps.sessions.outputs.sessions }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6.0.2
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v7.5.0
         with:
           enable-cache: true
       - name: Generate nox session matrix
@@ -226,7 +229,7 @@ jobs:
         session: ${{ fromJSON(needs.generate-nox-matrix.outputs.sessions) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6.0.2
       - name: Setup devenv
         uses: ./.github/actions/setup-devenv
       - name: Run ${{ matrix.session }}
@@ -247,15 +250,15 @@ jobs:
         python-version: ${{ fromJSON(inputs.python-versions) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v7.5.0
         with:
           enable-cache: true
 
@@ -290,15 +293,15 @@ jobs:
         python-version: ${{ fromJSON(inputs.python-versions) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v7.5.0
         with:
           enable-cache: true
 
@@ -327,11 +330,11 @@ jobs:
       DEVENV_PYTHON_VERSION: "3.10"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6.0.2
       - name: Setup devenv
         uses: ./.github/actions/setup-devenv
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.1.3
         with:
           bun-version: 1.3.1
       - name: Build Docs
@@ -348,9 +351,9 @@ jobs:
     if: ${{ inputs.run-all-checks || needs.filter.outputs.claude-plugin == 'true' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6.0.2
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.3.0
         with:
           node-version: 'lts/*'
       - name: Install Claude Code CLI
@@ -416,7 +419,7 @@ jobs:
     steps:
       - name: All Green
         if: always()
-        uses: re-actors/alls-green@release/v1
+        uses: re-actors/alls-green@v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}
           allowed-skips: test-linux, generate-nox-matrix, text-nox, test-windows, test-macos, typecheck, docs, claude-plugin

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -4,6 +4,9 @@ on:
   pull_request_target:
     types: [opened, edited, reopened]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   pull-requests: read
 
@@ -12,7 +15,7 @@ jobs:
     name: Conventional PR Title
     runs-on: depot-ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/publication.yaml
+++ b/.github/workflows/publication.yaml
@@ -15,6 +15,10 @@ on:
       - 'publications/2026-introducing-metaxy/paper.md'
       - 'publications/2026-introducing-metaxy/paper.bib'
       - 'publications/2026-introducing-metaxy/assets/**'
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   paper:
     permissions:
@@ -24,14 +28,14 @@ jobs:
     name: Paper Draft
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6.0.2
       - name: TeX and PDF
         uses: docker://openjournals/paperdraft:latest
         with:
           journal: joss
           args: '-k ./publications/2026-introducing-metaxy/paper.md'
       - name: Upload PDF to Artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: generated-paper
           path: ./publications/2026-introducing-metaxy/*.pdf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
@@ -44,7 +47,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - uses: ./.github/actions/publish
         with:
           environment: testpypi
@@ -57,7 +60,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - uses: ./.github/actions/publish
         with:
           environment: pypi
@@ -86,17 +89,17 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
-      - uses: orhun/git-cliff-action@v4
+      - uses: orhun/git-cliff-action@v4.7.1
         id: cliff
         with:
           config: cliff.toml
           args: --latest --strip header
         env:
           OUTPUT: CHANGES.md
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@v2.5.0
         with:
           body_path: CHANGES.md
           tag_name: ${{ github.ref_name }}

--- a/.github/workflows/slides.yaml
+++ b/.github/workflows/slides.yaml
@@ -26,6 +26,9 @@ permissions:
   pages: write
   id-token: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   build:
     name: Build slides and render PDF
@@ -36,9 +39,9 @@ jobs:
         file: ${{ fromJSON(github.event.inputs.slides_json || '["introducing-metaxy.md"]') }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6.0.2
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@v2.1.3
         with:
           bun-version: 1.3.1
 
@@ -58,7 +61,7 @@ jobs:
           echo "safe=$safe" >> "$GITHUB_OUTPUT"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: slides-${{ steps.safename.outputs.safe }}
           path: slides/2026-introducing-metaxy/*-export.pdf
@@ -69,7 +72,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/upload-artifact/merge@v4
+      - uses: actions/upload-artifact/merge@v7.0.0
         with:
           name: slide-pdfs
           pattern: slides-*


### PR DESCRIPTION
## Summary

Various Node 20 out of service warnings are addressed by upgrading our GHA actions, now using Node24

## Changelog

upgraded GHA actions

## Test Plan

executed CI
