### PR TITLE
ci: skip instead of fail docs

### DIFF
--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -27,6 +27,7 @@ on:
 
 jobs:
   docs:
+    if: ${{ github.ref_type != 'branch' || github.ref_name == 'main' }}
     runs-on: depot-ubuntu-latest
     environment: ${{ inputs.environment }}
 


### PR DESCRIPTION
## Summary

skip docs if not on main

## Changelog

currently CI fails for docs due to incomaptible deployment ENV, it is better to skip instead of failing

## Test Plan

executed CI
