### PR TITLE
feat: config inheritance

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -45,6 +45,21 @@ Metaxy supports templating environment variables in configuration files using th
     root_path = "s3://my-bucket/${BRANCH_NAME}"
     ```
 
+### Configuration Inheritance
+
+A configuration file can inherit settings from another file using the [`extends`](#metaxy.config.MetaxyConfig.extends) field. This is especially useful in monorepos.
+
+```toml title="metaxy.toml"
+project = "my_project"
+extends = "../base.toml"
+```
+
+!!! note
+
+    Top-level dictionary fields are merged, while all other fields are overridden.
+
+The `extends` path can be either relative to the file that contains it or an absolute path.
+
 ## Configuration Options
 
 ::: metaxy-config

--- a/src/metaxy/config.py
+++ b/src/metaxy/config.py
@@ -368,6 +368,10 @@ class MetaxyConfig(BaseSettings):
 
         return data
 
+    extends: str | None = PydanticField(
+        default=None, description="A relative or absolute path to a Metaxy configuration file to inherit settings from."
+    )
+
     migrations_dir: str = PydanticField(
         default=".metaxy/migrations",
         description="Directory where migration files are stored",
@@ -633,30 +637,45 @@ class MetaxyConfig(BaseSettings):
             config = MetaxyConfig.load(auto_discovery_start=Path("/path/to/project"))
             ```
         """
-        # Search for config file if not explicitly provided
-
         if config_from_env := os.getenv("METAXY_CONFIG"):
             config_file = Path(config_from_env)
 
         if config_file is None and search_parents:
             config_file = cls._discover_config_with_parents(auto_discovery_start)
 
-        # For explicit file, temporarily patch the TomlConfigSettingsSource
-        # to use that file, then use normal instantiation
-        # This ensures env vars still work
+        config = cls._load(Path(config_file) if config_file else None)
 
-        if config_file:
-            # Create a custom settings source class for this file
-            toml_path = Path(config_file)
+        cls.set(config)
+
+        # Load plugins after config is set (plugins may access MetaxyConfig.get())
+        config._load_plugins()
+
+        return config
+
+    @classmethod
+    def _load(
+        cls,
+        config_file: Path | None,
+        *,
+        _seen=None,
+    ) -> "MetaxyConfig":
+        """Load config from file, resolving the inheritance chain.
+
+        Recursively loads parent configs referenced by ``extends``,
+        tracking visited paths in ``_seen`` to detect cycles.
+        """
+        if _seen is None:
+            _seen = set()
+
+        if config_file is not None:
+            toml_path = config_file
 
             class CustomTomlSource(TomlConfigSettingsSource):
                 def __init__(self, settings_cls: type[BaseSettings]):
-                    # Skip auto-discovery, use explicit file
                     super(TomlConfigSettingsSource, self).__init__(settings_cls)
                     self.toml_file = toml_path
                     self.toml_data = self._load_toml()
 
-            # Customize sources to use custom TOML file
             original_method = cls.settings_customise_sources
 
             @classmethod
@@ -668,29 +687,65 @@ class MetaxyConfig(BaseSettings):
                 dotenv_settings,
                 file_secret_settings,
             ):
-                toml_settings = CustomTomlSource(settings_cls)
-                return (init_settings, env_settings, toml_settings)
+                return (init_settings, env_settings, CustomTomlSource(settings_cls))
 
-            # Temporarily replace method
             cls.settings_customise_sources = custom_sources  # ty: ignore[invalid-assignment]
             try:
                 config = cls()
             finally:
                 cls.settings_customise_sources = original_method  # ty: ignore[invalid-assignment]
-            # Store the resolved config file path
+
             config._config_file = toml_path.resolve()
+            _seen.add(config._config_file)
         else:
-            # Use default sources (auto-discovery + env vars)
             config = cls()
-            # No config file used
             config._config_file = None
 
-        cls.set(config)
+        if config.extends is None:
+            return config
 
-        # Load plugins after config is set (plugins may access MetaxyConfig.get())
-        config._load_plugins()
+        # Resolve extends path relative to the child config file's directory
+        extends_path = Path(config.extends)
+        if not extends_path.is_absolute() and config._config_file is not None:
+            extends_path = (config._config_file.parent / extends_path).resolve()
+        else:
+            extends_path = extends_path.resolve()
 
-        return config
+        if not extends_path.exists():
+            raise InvalidConfigError(
+                f"Config file referenced by 'extends' does not exist: {extends_path}",
+                config_file=config._config_file,
+            )
+
+        if extends_path in _seen:
+            chain = " -> ".join(str(p) for p in _seen)
+            raise InvalidConfigError(
+                f"Circular config inheritance detected: {chain} -> {extends_path}",
+                config_file=config._config_file,
+            )
+
+        parent = cls._load(extends_path, _seen=_seen)
+        return cls._merge_configs(parent=parent, child=config)
+
+    @classmethod
+    def _merge_configs(cls, *, parent: "MetaxyConfig", child: "MetaxyConfig") -> "MetaxyConfig":
+        """Merge child config on top of parent.
+
+        Scalars and lists: child wins if explicitly set, otherwise parent value is kept.
+        Dicts (stores, ext): shallow-merged so parent-only keys are preserved.
+        """
+        child_update: dict[str, Any] = {}
+        for field_name in child.model_fields_set - {"extends"}:
+            child_value = getattr(child, field_name)
+            parent_value = getattr(parent, field_name)
+            if isinstance(child_value, dict) and isinstance(parent_value, dict):
+                child_update[field_name] = {**parent_value, **child_value}
+            else:
+                child_update[field_name] = child_value
+
+        merged = parent.model_copy(update=child_update, deep=True)
+        merged._config_file = child._config_file
+        return merged
 
     @staticmethod
     def _discover_config_with_parents(start_dir: Path | None = None) -> Path | None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1400,3 +1400,141 @@ class TestToToml:
         assert reloaded.migrations_dir == original.migrations_dir
         assert reloaded.entrypoints == original.entrypoints
         assert set(reloaded.stores.keys()) == set(original.stores.keys())
+
+
+class TestConfigInheritance:
+    """Tests for config inheritance via the `extends` field."""
+
+    STORE_TYPE = "metaxy.ext.metadata_stores.delta.DeltaMetadataStore"
+
+    def test_child_overrides_parent(self, tmp_path: Path) -> None:
+        parent = tmp_path / "parent.toml"
+        parent.write_text('project = "parent_proj"\nstore = "parent_store"\n')
+
+        child = tmp_path / "child.toml"
+        child.write_text('extends = "parent.toml"\nproject = "child_proj"\n')
+
+        config = MetaxyConfig.load(child)
+
+        assert config.project == "child_proj"
+        assert config.store == "parent_store"
+
+    def test_parent_provides_defaults(self, tmp_path: Path) -> None:
+        parent = tmp_path / "parent.toml"
+        parent.write_text('project = "base"\ntheme = "dark"\n')
+
+        child = tmp_path / "child.toml"
+        child.write_text('extends = "parent.toml"\n')
+
+        config = MetaxyConfig.load(child)
+
+        assert config.project == "base"
+        assert config.theme == "dark"
+
+    def test_stores_merged(self, tmp_path: Path) -> None:
+        parent = tmp_path / "parent.toml"
+        parent.write_text(
+            f'[stores.shared]\ntype = "{self.STORE_TYPE}"\n'
+            f'[stores.shared.config]\nroot_path = "/shared"\n'
+            f'[stores.parent_only]\ntype = "{self.STORE_TYPE}"\n'
+            f'[stores.parent_only.config]\nroot_path = "/parent"\n'
+        )
+
+        child = tmp_path / "child.toml"
+        child.write_text(
+            f'extends = "parent.toml"\n'
+            f'[stores.shared]\ntype = "{self.STORE_TYPE}"\n'
+            f'[stores.shared.config]\nroot_path = "/child"\n'
+        )
+
+        config = MetaxyConfig.load(child)
+
+        assert "shared" in config.stores
+        assert "parent_only" in config.stores
+        assert config.stores["shared"].config["root_path"] == "/child"
+        assert config.stores["parent_only"].config["root_path"] == "/parent"
+
+    def test_entrypoints_replaced_when_set(self, tmp_path: Path) -> None:
+        parent = tmp_path / "parent.toml"
+        parent.write_text('entrypoints = ["parent.module"]\n')
+
+        child = tmp_path / "child.toml"
+        child.write_text('extends = "parent.toml"\nentrypoints = ["child.module"]\n')
+
+        config = MetaxyConfig.load(child)
+
+        assert config.entrypoints == ["child.module"]
+
+    def test_entrypoints_inherited_when_unset(self, tmp_path: Path) -> None:
+        parent = tmp_path / "parent.toml"
+        parent.write_text('entrypoints = ["parent.module"]\n')
+
+        child = tmp_path / "child.toml"
+        child.write_text('extends = "parent.toml"\nproject = "child"\n')
+
+        config = MetaxyConfig.load(child)
+
+        assert config.entrypoints == ["parent.module"]
+
+    def test_config_file_points_to_child(self, tmp_path: Path) -> None:
+        parent = tmp_path / "parent.toml"
+        parent.write_text('project = "base"\n')
+
+        child = tmp_path / "child.toml"
+        child.write_text('extends = "parent.toml"\n')
+
+        config = MetaxyConfig.load(child)
+
+        assert config.config_file == child.resolve()
+
+    def test_relative_path_resolution(self, tmp_path: Path) -> None:
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        parent = tmp_path / "parent.toml"
+        parent.write_text('project = "base"\n')
+
+        child = sub / "child.toml"
+        child.write_text('extends = "../parent.toml"\n')
+
+        config = MetaxyConfig.load(child)
+
+        assert config.project == "base"
+        assert config.config_file == child.resolve()
+
+    def test_circular_inheritance(self, tmp_path: Path) -> None:
+        a = tmp_path / "a.toml"
+        b = tmp_path / "b.toml"
+        a.write_text('extends = "b.toml"\n')
+        b.write_text('extends = "a.toml"\n')
+
+        with pytest.raises(InvalidConfigError, match="Circular config inheritance"):
+            MetaxyConfig.load(a)
+
+    def test_multi_level_inheritance(self, tmp_path: Path) -> None:
+        grandparent = tmp_path / "grandparent.toml"
+        grandparent.write_text('project = "gp"\ntheme = "gp_theme"\nstore = "gp_store"\n')
+
+        parent = tmp_path / "parent.toml"
+        parent.write_text('extends = "grandparent.toml"\ntheme = "parent_theme"\n')
+
+        child = tmp_path / "child.toml"
+        child.write_text('extends = "parent.toml"\nstore = "child_store"\n')
+
+        config = MetaxyConfig.load(child)
+
+        assert config.project == "gp"
+        assert config.theme == "parent_theme"
+        assert config.store == "child_store"
+
+    def test_extends_only(self, tmp_path: Path) -> None:
+        parent = tmp_path / "parent.toml"
+        parent.write_text('project = "inherited"\nstore = "prod"\nentrypoints = ["mod.a"]\n')
+
+        child = tmp_path / "child.toml"
+        child.write_text('extends = "parent.toml"\n')
+
+        config = MetaxyConfig.load(child)
+
+        assert config.project == "inherited"
+        assert config.store == "prod"
+        assert config.entrypoints == ["mod.a"]


### PR DESCRIPTION
## Summary

Resolve #1061

<!-- Brief description of the changes -->

## Changelog

Configuration inheritance is now supported via a new `extend` config field.

<!--
User-facing changelog details, rendered below the commit title in CHANGELOG.md.
Delete this section if there are no user-facing changes.
-->

## Test Plan

Added tests.

<!-- How was this tested? -->