### PR TITLE
fix: do not validate incomplete MetaxyConfig when `extend` is set

### DIFF
--- a/src/metaxy/_toml_source.py
+++ b/src/metaxy/_toml_source.py
@@ -1,0 +1,184 @@
+"""TOML configuration source for pydantic-settings with extend chain resolution."""
+
+import os
+import re
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+import tomli
+from pydantic_settings import BaseSettings, PydanticBaseSettingsSource
+
+# Pattern for ${VAR} or ${VAR:-default} syntax
+_ENV_VAR_PATTERN = re.compile(r"\$\{([^}:]+)(?::-([^}]*))?\}")
+
+
+def _expand_env_vars(value: Any) -> Any:
+    """Recursively expand ``${VAR}`` and ``${VAR:-default}`` in strings."""
+    if isinstance(value, str):
+
+        def _replace(match: re.Match[str]) -> str:
+            var_name = match.group(1)
+            default = match.group(2)
+            env_value = os.environ.get(var_name)
+            if env_value is not None:
+                return env_value
+            if default is not None:
+                return default
+            return ""
+
+        return _ENV_VAR_PATTERN.sub(_replace, value)
+    if isinstance(value, Mapping):
+        return {k: _expand_env_vars(v) for k, v in value.items()}
+    if isinstance(value, Sequence):
+        return [_expand_env_vars(item) for item in value]
+    return value
+
+
+def _pyproject_has_metaxy(path: Path) -> bool:
+    """Check if a pyproject.toml contains a ``[tool.metaxy]`` section."""
+    with open(path, "rb") as f:
+        data = tomli.load(f)
+    return bool(data.get("tool", {}).get("metaxy"))
+
+
+def _discover_config_in_dir(directory: Path) -> Path | None:
+    """Find a metaxy config file in *directory*.
+
+    Prefers ``metaxy.toml``. Falls back to ``pyproject.toml`` only when it
+    contains a ``[tool.metaxy]`` section.
+    """
+    metaxy_toml = directory / "metaxy.toml"
+    if metaxy_toml.exists():
+        return metaxy_toml
+
+    pyproject_toml = directory / "pyproject.toml"
+    if pyproject_toml.exists() and _pyproject_has_metaxy(pyproject_toml):
+        return pyproject_toml
+
+    return None
+
+
+def discover_config_with_parents(start_dir: Path | None = None) -> Path | None:
+    """Search *start_dir* and its ancestors for a metaxy config file."""
+    current = start_dir or Path.cwd()
+
+    while True:
+        found = _discover_config_in_dir(current)
+        if found is not None:
+            return found
+
+        parent = current.parent
+        if parent == current:
+            break
+        current = parent
+
+    return None
+
+
+def _read_toml(path: Path) -> dict[str, Any]:
+    """Read a TOML file and extract the metaxy config section."""
+    with open(path, "rb") as f:
+        data = tomli.load(f)
+
+    if path.name == "pyproject.toml":
+        return data.get("tool", {}).get("metaxy", {})
+    return data
+
+
+def _merge_toml(parent: dict[str, Any], child: dict[str, Any]) -> dict[str, Any]:
+    """Merge *child* on top of *parent* (raw dicts, pre-validation).
+
+    - Scalars: child wins.
+    - Dicts: shallow-merged (parent keys preserved, child keys override).
+    - Lists: appended (parent + child).
+    - Keys only in parent are preserved.
+    """
+    merged = dict(parent)
+    for key, child_value in child.items():
+        parent_value = parent.get(key)
+        if isinstance(child_value, dict) and isinstance(parent_value, dict):
+            merged[key] = {**parent_value, **child_value}
+        elif isinstance(child_value, list) and isinstance(parent_value, list):
+            merged[key] = parent_value + child_value
+        else:
+            merged[key] = child_value
+    return merged
+
+
+def _resolve_extend(
+    data: dict[str, Any],
+    config_file: Path,
+    seen: set[Path],
+) -> dict[str, Any]:
+    """Recursively resolve the ``extend`` chain, returning a fully merged dict."""
+    extend_raw = data.pop("extend", None)
+    if extend_raw is None:
+        return data
+
+    extend_path = Path(extend_raw)
+    if not extend_path.is_absolute():
+        extend_path = (config_file.parent / extend_path).resolve()
+    else:
+        extend_path = extend_path.resolve()
+
+    if not extend_path.exists():
+        from metaxy.config import InvalidConfigError
+
+        raise InvalidConfigError(
+            f"Config file referenced by 'extend' does not exist: {extend_path}",
+            config_file=config_file,
+        )
+
+    if extend_path in seen:
+        from metaxy.config import InvalidConfigError
+
+        chain = " -> ".join(str(p) for p in seen)
+        raise InvalidConfigError(
+            f"Circular config inheritance detected: {chain} -> {extend_path}",
+            config_file=config_file,
+        )
+
+    seen.add(extend_path)
+    parent_data = _read_toml(extend_path)
+    parent_data = _resolve_extend(parent_data, extend_path, seen)
+
+    return _merge_toml(parent_data, data)
+
+
+class MetaxyTomlSource(PydanticBaseSettingsSource):
+    """Pydantic-settings source that loads TOML config with ``extend`` inheritance.
+
+    Resolves the full inheritance chain at the raw-dict level so that
+    pydantic only ever validates the final merged configuration.
+    """
+
+    def __init__(
+        self,
+        settings_cls: type[BaseSettings],
+        config_file: Path | None,
+    ):
+        super().__init__(settings_cls)
+        self._config_file = config_file
+        self._data = self._load()
+
+    @property
+    def config_file(self) -> Path | None:
+        return self._config_file
+
+    def _load(self) -> dict[str, Any]:
+        if self._config_file is None:
+            return {}
+
+        data = _read_toml(self._config_file)
+        seen: set[Path] = {self._config_file.resolve()}
+        data = _resolve_extend(data, self._config_file, seen)
+        return _expand_env_vars(data)
+
+    # --- PydanticBaseSettingsSource interface ---
+
+    def get_field_value(self, field: Any, field_name: str) -> tuple[Any, str, bool]:
+        return self._data.get(field_name), field_name, False
+
+    def __call__(self) -> dict[str, Any]:
+        return self._data

--- a/src/metaxy/config.py
+++ b/src/metaxy/config.py
@@ -2,16 +2,14 @@
 # pyright: reportImportCycles=false
 
 import os
-import re
 import warnings
-from collections.abc import Iterator, Mapping, Sequence
+from collections.abc import Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
 from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, TypeAlias, TypeVar, overload
 
-import tomli
 import tomli_w
 from pydantic import Field as PydanticField
 from pydantic import PrivateAttr, field_validator, model_validator
@@ -23,6 +21,7 @@ from pydantic_settings import (
 from typing_extensions import Self
 
 from metaxy._decorators import public
+from metaxy._toml_source import MetaxyTomlSource, discover_config_with_parents
 from metaxy.models.feature_selection import FeatureSelection
 
 if TYPE_CHECKING:
@@ -31,9 +30,6 @@ if TYPE_CHECKING:
     )
 
 T = TypeVar("T")
-
-# Pattern for ${VAR} or ${VAR:-default} syntax
-_ENV_VAR_PATTERN = re.compile(r"\$\{([^}:]+)(?::-([^}]*))?\}")
 
 
 def _collect_dict_keys(d: dict[str, Any], prefix: str = "") -> list[str]:
@@ -86,99 +82,6 @@ class InvalidConfigError(Exception):
             An InvalidConfigError with context from the config.
         """
         return cls(message, config_file=config._config_file)
-
-
-def _expand_env_vars(value: Any) -> Any:
-    """Recursively expand environment variables in config values.
-
-    Supports:
-    - ${VAR} - substitutes with environment variable value, empty string if not set
-    - ${VAR:-default} - substitutes with environment variable value, or default if not set
-
-    Args:
-        value: The value to expand (can be string, dict, list, or other)
-
-    Returns:
-        The value with environment variables expanded
-    """
-    if isinstance(value, str):
-
-        def replace_match(match: re.Match[str]) -> str:
-            var_name = match.group(1)
-            default = match.group(2)  # None if no default specified
-            env_value = os.environ.get(var_name)
-            if env_value is not None:
-                return env_value
-            elif default is not None:
-                return default
-            else:
-                return ""
-
-        return _ENV_VAR_PATTERN.sub(replace_match, value)
-    elif isinstance(value, Mapping):
-        return {k: _expand_env_vars(v) for k, v in value.items()}
-    elif isinstance(value, Sequence):
-        return [_expand_env_vars(item) for item in value]
-    else:
-        return value
-
-
-class TomlConfigSettingsSource(PydanticBaseSettingsSource):
-    """Custom settings source for TOML configuration files.
-
-    Auto-discovers configuration in this order:
-    1. Explicit file path if provided
-    2. metaxy.toml in current directory (preferred)
-    3. pyproject.toml [tool.metaxy] section (fallback)
-    4. No config (returns empty dict)
-    """
-
-    def __init__(self, settings_cls: type[BaseSettings], toml_file: Path | None = None):
-        super().__init__(settings_cls)
-        self.toml_file = toml_file or self._discover_config_file()
-        self.toml_data = self._load_toml()
-
-    def _discover_config_file(self) -> Path | None:
-        """Auto-discover config file."""
-        # Prefer metaxy.toml
-        if Path("metaxy.toml").exists():
-            return Path("metaxy.toml")
-
-        # Fallback to pyproject.toml
-        if Path("pyproject.toml").exists():
-            return Path("pyproject.toml")
-
-        return None
-
-    def _load_toml(self) -> dict[str, Any]:
-        """Load TOML file and extract metaxy config.
-
-        Environment variables in the format ${VAR} or ${VAR:-default} are
-        expanded in string values.
-        """
-        if self.toml_file is None:
-            return {}
-
-        with open(self.toml_file, "rb") as f:
-            data = tomli.load(f)
-
-        # Extract [tool.metaxy] from pyproject.toml or root from metaxy.toml
-        if self.toml_file.name == "pyproject.toml":
-            config = data.get("tool", {}).get("metaxy", {})
-        else:
-            config = data
-
-        # Expand environment variables in config values
-        return _expand_env_vars(config)
-
-    def get_field_value(self, field: Any, field_name: str) -> tuple[Any, str, bool]:
-        """Get field value from TOML data."""
-        field_value = self.toml_data.get(field_name)
-        return field_value, field_name, False
-
-    def __call__(self) -> dict[str, Any]:
-        """Return all settings from TOML."""
-        return self.toml_data
 
 
 MetadataStoreT: TypeAlias = type["MetadataStore"]
@@ -277,6 +180,10 @@ PluginConfigT = TypeVar("PluginConfigT", bound=PluginConfig)
 # get() checks the ContextVar first, falling back to the global.
 _global_config: "MetaxyConfig | None" = None
 _config_override: ContextVar["MetaxyConfig | None"] = ContextVar("_config_override", default=None)
+
+# Used by load() to pass the config file path into settings_customise_sources
+# without monkey-patching the classmethod.
+_toml_file_override: ContextVar[Path | None] = ContextVar("_toml_file_override")
 
 
 BUILTIN_PLUGINS = {
@@ -529,9 +436,15 @@ class MetaxyConfig(BaseSettings):
         Priority (first wins):
         1. Init arguments
         2. Environment variables
-        3. TOML file
+        3. TOML file (with ``extend`` inheritance fully resolved)
         """
-        toml_settings = TomlConfigSettingsSource(settings_cls)
+        # load() sets _toml_file_override before calling cls().
+        # Bare MetaxyConfig() has no override → no TOML file.
+        try:
+            config_file = _toml_file_override.get()
+        except LookupError:
+            config_file = None
+        toml_settings = MetaxyTomlSource(settings_cls, config_file=config_file)
         return (init_settings, env_settings, toml_settings)
 
     @classmethod
@@ -640,9 +553,18 @@ class MetaxyConfig(BaseSettings):
             config_file = Path(config_from_env)
 
         if config_file is None and search_parents:
-            config_file = cls._discover_config_with_parents(auto_discovery_start)
+            config_file = discover_config_with_parents(auto_discovery_start)
 
-        config = cls._load(Path(config_file) if config_file else None)
+        resolved: Path | None = Path(config_file) if config_file else None
+
+        # Pass config file path to settings_customise_sources via ContextVar
+        token = _toml_file_override.set(resolved)
+        try:
+            config = cls()
+        finally:
+            _toml_file_override.reset(token)
+
+        config._config_file = resolved.resolve() if resolved else None
 
         cls.set(config)
 
@@ -650,141 +572,6 @@ class MetaxyConfig(BaseSettings):
         config._load_plugins()
 
         return config
-
-    @classmethod
-    def _load(
-        cls,
-        config_file: Path | None,
-        *,
-        _seen=None,
-    ) -> "MetaxyConfig":
-        """Load config from file, resolving the inheritance chain.
-
-        Recursively loads parent configs referenced by ``extend``,
-        tracking visited paths in ``_seen`` to detect cycles.
-        """
-        if _seen is None:
-            _seen = set()
-
-        if config_file is not None:
-            toml_path = config_file
-
-            class CustomTomlSource(TomlConfigSettingsSource):
-                def __init__(self, settings_cls: type[BaseSettings]):
-                    super(TomlConfigSettingsSource, self).__init__(settings_cls)
-                    self.toml_file = toml_path
-                    self.toml_data = self._load_toml()
-
-            original_method = cls.settings_customise_sources
-
-            @classmethod
-            def custom_sources(
-                cls_inner,
-                settings_cls,
-                init_settings,
-                env_settings,
-                dotenv_settings,
-                file_secret_settings,
-            ):
-                return (init_settings, env_settings, CustomTomlSource(settings_cls))
-
-            cls.settings_customise_sources = custom_sources  # ty: ignore[invalid-assignment]
-            try:
-                config = cls()
-            finally:
-                cls.settings_customise_sources = original_method  # ty: ignore[invalid-assignment]
-
-            config._config_file = toml_path.resolve()
-            _seen.add(config._config_file)
-        else:
-            config = cls()
-            config._config_file = None
-
-        if config.extend is None:
-            return config
-
-        # Resolve extend path relative to the child config file's directory
-        extend_path = Path(config.extend)
-        if not extend_path.is_absolute() and config._config_file is not None:
-            extend_path = (config._config_file.parent / extend_path).resolve()
-        else:
-            extend_path = extend_path.resolve()
-
-        if not extend_path.exists():
-            raise InvalidConfigError(
-                f"Config file referenced by 'extend' does not exist: {extend_path}",
-                config_file=config._config_file,
-            )
-
-        if extend_path in _seen:
-            chain = " -> ".join(str(p) for p in _seen)
-            raise InvalidConfigError(
-                f"Circular config inheritance detected: {chain} -> {extend_path}",
-                config_file=config._config_file,
-            )
-
-        parent = cls._load(extend_path, _seen=_seen)
-        return cls._merge_configs(parent=parent, child=config)
-
-    # Fields that are shallow-merged (dicts) or appended (lists) during
-    # config inheritance instead of being replaced by the child value.
-    @classmethod
-    def _merge_configs(cls, *, parent: "MetaxyConfig", child: "MetaxyConfig") -> "MetaxyConfig":
-        """Merge child config on top of parent.
-
-        Scalars: child replaces parent.
-        Dicts: shallow-merged (parent-only keys preserved, shared keys use child's value).
-        Lists: appended (parent entries + child entries).
-        """
-        child_update: dict[str, Any] = {}
-        for field_name in child.model_fields_set - {"extend"}:
-            child_value = getattr(child, field_name)
-            parent_value = getattr(parent, field_name)
-            if isinstance(child_value, dict) and isinstance(parent_value, dict):
-                child_update[field_name] = {**parent_value, **child_value}
-            elif isinstance(child_value, list) and isinstance(parent_value, list):
-                child_update[field_name] = parent_value + child_value
-            else:
-                child_update[field_name] = child_value
-
-        merged = parent.model_copy(update=child_update, deep=True)
-        merged._config_file = child._config_file
-        return merged
-
-    @staticmethod
-    def _discover_config_with_parents(start_dir: Path | None = None) -> Path | None:
-        """Discover config file by searching current and parent directories.
-
-        Searches for metaxy.toml or pyproject.toml in start directory,
-        then iteratively searches parent directories.
-
-        Args:
-            start_dir: Directory to start search from (defaults to cwd)
-
-        Returns:
-            Path to config file if found, None otherwise
-        """
-        current = start_dir or Path.cwd()
-
-        while True:
-            # Check for metaxy.toml (preferred)
-            metaxy_toml = current / "metaxy.toml"
-            if metaxy_toml.exists():
-                return metaxy_toml
-
-            # Check for pyproject.toml
-            pyproject_toml = current / "pyproject.toml"
-            if pyproject_toml.exists():
-                return pyproject_toml
-
-            # Move to parent
-            parent = current.parent
-            if parent == current:
-                # Reached roothash_tru
-                break
-            current = parent
-
-        return None
 
     @overload
     def get_store(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -94,6 +94,17 @@ def test_metaxy_config_default() -> None:
     assert config.stores == {}
 
 
+def test_bare_construction_does_not_auto_discover_toml(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """MetaxyConfig() should not pick up a metaxy.toml from cwd."""
+    (tmp_path / "metaxy.toml").write_text('project = "should-not-load"\nstore = "sneaky"\n')
+    monkeypatch.chdir(tmp_path)
+
+    config = MetaxyConfig()
+
+    assert config.project is None
+    assert config.store == "dev"
+
+
 def test_metaxy_config_from_dict(tmp_path: Path) -> None:
     config = MetaxyConfig(
         store="staging",
@@ -1583,3 +1594,24 @@ class TestConfigInheritance:
         assert config.ext["myplugin"].model_extra
         assert config.ext["myplugin"].model_extra["custom_setting"] is True
         assert "otherplugin" in config.ext
+
+
+def test_env_var_store_config_merged_with_parent_via_extend(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Env var providing store config fields should merge with parent's store type via extend."""
+    store_type = "metaxy.ext.metadata_stores.delta.DeltaMetadataStore"
+    parent = tmp_path / "parent.toml"
+    parent.write_text(f'[stores.prod]\ntype = "{store_type}"\n[stores.prod.config]\nroot_path = "/default"\n')
+
+    child = tmp_path / "child.toml"
+    child.write_text('extend = "parent.toml"\nproject = "child"\n')
+
+    monkeypatch.setenv("METAXY_STORES__PROD__CONFIG__ROOT_PATH", "/from-env")
+
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        config = MetaxyConfig.load(child)
+
+    assert config.stores["prod"].type == store_type
+    assert config.stores["prod"].config["root_path"] == "/from-env"

--- a/tests/test_toml_source.py
+++ b/tests/test_toml_source.py
@@ -1,0 +1,214 @@
+"""Tests for MetaxyTomlSource."""
+
+from pathlib import Path
+
+import pytest
+from pydantic_settings import BaseSettings
+
+from metaxy._toml_source import MetaxyTomlSource, _discover_config_in_dir
+
+
+class _DummySettings(BaseSettings):
+    pass
+
+
+STORE_TYPE = "metaxy.ext.metadata_stores.delta.DeltaMetadataStore"
+
+
+# --- Basic loading ---
+
+
+def test_load_metaxy_toml(tmp_path: Path) -> None:
+    config_file = tmp_path / "metaxy.toml"
+    config_file.write_text('project = "test"\nstore = "dev"\n')
+
+    source = MetaxyTomlSource(_DummySettings, config_file=config_file)
+    data = source()
+
+    assert data["project"] == "test"
+    assert data["store"] == "dev"
+
+
+def test_load_pyproject_toml(tmp_path: Path) -> None:
+    config_file = tmp_path / "pyproject.toml"
+    config_file.write_text('[project]\nname = "foo"\n\n[tool.metaxy]\nproject = "from-pyproject"\n')
+
+    source = MetaxyTomlSource(_DummySettings, config_file=config_file)
+    data = source()
+
+    assert data["project"] == "from-pyproject"
+    assert "tool" not in data
+
+
+def test_env_var_expansion(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TEST_DB_HOST", "prod.db.example.com")
+    config_file = tmp_path / "metaxy.toml"
+    config_file.write_text('[stores.prod.config]\nhost = "${TEST_DB_HOST}"\n')
+
+    source = MetaxyTomlSource(_DummySettings, config_file=config_file)
+    data = source()
+
+    assert data["stores"]["prod"]["config"]["host"] == "prod.db.example.com"
+
+
+def test_no_config_file_returns_empty() -> None:
+    source = MetaxyTomlSource(_DummySettings, config_file=None)
+    assert source() == {}
+
+
+# --- Extend chain resolution ---
+
+
+def test_extend_child_overrides_parent(tmp_path: Path) -> None:
+    parent = tmp_path / "parent.toml"
+    parent.write_text('project = "parent"\nstore = "parent_store"\n')
+
+    child = tmp_path / "child.toml"
+    child.write_text('extend = "parent.toml"\nproject = "child"\n')
+
+    source = MetaxyTomlSource(_DummySettings, config_file=child)
+    data = source()
+
+    assert data["project"] == "child"
+    assert data["store"] == "parent_store"
+    assert "extend" not in data
+
+
+def test_extend_stores_merged(tmp_path: Path) -> None:
+    parent = tmp_path / "parent.toml"
+    parent.write_text(
+        f'[stores.prod]\ntype = "{STORE_TYPE}"\n[stores.prod.config]\nroot_path = "/prod"\n'
+        f'[stores.parent_only]\ntype = "{STORE_TYPE}"\n'
+    )
+    child = tmp_path / "child.toml"
+    child.write_text(
+        f'extend = "parent.toml"\n[stores.prod]\ntype = "{STORE_TYPE}"\n[stores.prod.config]\nroot_path = "/override"\n'
+    )
+
+    source = MetaxyTomlSource(_DummySettings, config_file=child)
+    data = source()
+
+    assert data["stores"]["prod"]["config"]["root_path"] == "/override"
+    assert "parent_only" in data["stores"]
+
+
+def test_extend_entrypoints_appended(tmp_path: Path) -> None:
+    parent = tmp_path / "parent.toml"
+    parent.write_text('entrypoints = ["parent.mod"]\n')
+    child = tmp_path / "child.toml"
+    child.write_text('extend = "parent.toml"\nentrypoints = ["child.mod"]\n')
+
+    source = MetaxyTomlSource(_DummySettings, config_file=child)
+    data = source()
+
+    assert data["entrypoints"] == ["parent.mod", "child.mod"]
+
+
+def test_extend_circular_raises(tmp_path: Path) -> None:
+    a = tmp_path / "a.toml"
+    a.write_text('extend = "b.toml"\n')
+    b = tmp_path / "b.toml"
+    b.write_text('extend = "a.toml"\n')
+
+    from metaxy.config import InvalidConfigError
+
+    with pytest.raises(InvalidConfigError, match="Circular"):
+        MetaxyTomlSource(_DummySettings, config_file=a)
+
+
+def test_extend_multi_level(tmp_path: Path) -> None:
+    gp = tmp_path / "grandparent.toml"
+    gp.write_text('project = "gp"\nstore = "gp_store"\ntheme = "gp_theme"\n')
+    parent = tmp_path / "parent.toml"
+    parent.write_text('extend = "grandparent.toml"\ntheme = "parent_theme"\n')
+    child = tmp_path / "child.toml"
+    child.write_text('extend = "parent.toml"\nstore = "child_store"\n')
+
+    source = MetaxyTomlSource(_DummySettings, config_file=child)
+    data = source()
+
+    assert data["project"] == "gp"
+    assert data["store"] == "child_store"
+    assert data["theme"] == "parent_theme"
+
+
+def test_extend_missing_parent_raises(tmp_path: Path) -> None:
+    child = tmp_path / "child.toml"
+    child.write_text('extend = "nonexistent.toml"\n')
+
+    from metaxy.config import InvalidConfigError
+
+    with pytest.raises(InvalidConfigError, match="does not exist"):
+        MetaxyTomlSource(_DummySettings, config_file=child)
+
+
+def test_extend_relative_path_resolution(tmp_path: Path) -> None:
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    parent = tmp_path / "parent.toml"
+    parent.write_text('project = "base"\n')
+
+    child = sub / "child.toml"
+    child.write_text('extend = "../parent.toml"\n')
+
+    source = MetaxyTomlSource(_DummySettings, config_file=child)
+    data = source()
+
+    assert data["project"] == "base"
+
+
+# --- Config file discovery ---
+
+
+def test_discover_metaxy_toml(tmp_path: Path) -> None:
+    (tmp_path / "metaxy.toml").write_text('project = "discovered"\n')
+
+    assert _discover_config_in_dir(tmp_path) == tmp_path / "metaxy.toml"
+
+
+def test_discover_skips_pyproject_without_metaxy(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text('[project]\nname = "unrelated"\n')
+
+    assert _discover_config_in_dir(tmp_path) is None
+
+
+def test_discover_uses_pyproject_with_metaxy(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text('[tool.metaxy]\nproject = "from-pyproject"\n')
+
+    assert _discover_config_in_dir(tmp_path) == tmp_path / "pyproject.toml"
+
+
+def test_discover_prefers_metaxy_toml_over_pyproject(tmp_path: Path) -> None:
+    (tmp_path / "metaxy.toml").write_text('project = "from-metaxy"\n')
+    (tmp_path / "pyproject.toml").write_text('[tool.metaxy]\nproject = "from-pyproject"\n')
+
+    assert _discover_config_in_dir(tmp_path) == tmp_path / "metaxy.toml"
+
+
+def test_discover_empty_dir(tmp_path: Path) -> None:
+    assert _discover_config_in_dir(tmp_path) is None
+
+
+def test_config_file_property(tmp_path: Path) -> None:
+    config_file = tmp_path / "metaxy.toml"
+    config_file.write_text('project = "test"\n')
+
+    source = MetaxyTomlSource(_DummySettings, config_file=config_file)
+
+    assert source.config_file == config_file
+
+
+def test_config_file_none_when_no_file() -> None:
+    source = MetaxyTomlSource(_DummySettings, config_file=None)
+    assert source.config_file is None
+
+
+def test_config_file_points_to_child_not_parent(tmp_path: Path) -> None:
+    parent = tmp_path / "parent.toml"
+    parent.write_text('project = "base"\n')
+    child = tmp_path / "child.toml"
+    child.write_text('extend = "parent.toml"\n')
+
+    source = MetaxyTomlSource(_DummySettings, config_file=child)
+
+    assert source.config_file == child


### PR DESCRIPTION
## Summary

<!-- Brief description of the changes -->

## Changelog

<!--
User-facing changelog details, rendered below the commit title in CHANGELOG.md.
Delete this section if there are no user-facing changes.
-->

## Test Plan

<!-- How was this tested? -->
