### PR TITLE
refactor: rename and move _collect_to_arrow to `metaxy._utils.collect_to_arrow`

### DIFF
--- a/src/metaxy/_utils.py
+++ b/src/metaxy/_utils.py
@@ -1,5 +1,8 @@
 import warnings
-from typing import Any, TypeAlias, cast, overload
+from typing import TYPE_CHECKING, Any, TypeAlias, cast, overload
+
+if TYPE_CHECKING:
+    import pyarrow as pa
 
 import narwhals as nw
 import polars as pl
@@ -58,7 +61,7 @@ def has_polars_map_columns(df: pl.DataFrame | pl.LazyFrame) -> bool:
 
 @public
 def collect_to_polars(frame: PolarsCompatibleFrame) -> pl.DataFrame:
-    """Helper to convert a Narwhals frame into an eager Polars DataFrame.
+    """Helper to convert a frame into an eager Polars DataFrame.
 
     Preserves `polars_map.Map` columns when `MetaxyConfig.enable_map_datatype` is set.
 
@@ -90,6 +93,28 @@ def collect_to_polars(frame: PolarsCompatibleFrame) -> pl.DataFrame:
     if isinstance(collected, pl.DataFrame):
         return collected
     return collected.to_polars()
+
+
+@public
+def collect_to_arrow(frame: PolarsCompatibleFrame) -> "pa.Table":
+    """Convert a frame into a PyArrow Table.
+
+    If the dataframe is a Polars dataframe, it converts `polars_map.Map`
+        extension columns to native Arrow `MapArray`.
+    """
+    import pyarrow as pa
+
+    nw_frame = nw.from_native(frame) if isinstance(frame, (pl.DataFrame, pl.LazyFrame)) else frame
+    collected = nw_frame.collect() if isinstance(nw_frame, nw.LazyFrame) else nw_frame
+    table: pa.Table = collected.to_arrow()
+
+    if collected.implementation == nw.Implementation.POLARS:
+        from metaxy.versioning._arrow_map import convert_extension_maps_to_native, has_extension_map_columns
+
+        if has_extension_map_columns(table):
+            table = convert_extension_maps_to_native(table)
+
+    return table
 
 
 def lazy_frame_to_polars(frame: nw.LazyFrame[Any]) -> pl.LazyFrame:
@@ -138,4 +163,4 @@ def switch_implementation_to_polars(frame: FrameT) -> FrameT:
     return result
 
 
-__all__ = ["collect_to_polars"]
+__all__ = ["collect_to_arrow", "collect_to_polars"]

--- a/tests/metadata_stores/shared/ibis_map.py
+++ b/tests/metadata_stores/shared/ibis_map.py
@@ -9,18 +9,13 @@ from __future__ import annotations
 from collections.abc import Iterator
 
 import ibis
-import narwhals as nw
 import pyarrow as pa
 import pytest
 
+from metaxy._utils import collect_to_arrow
 from metaxy.config import MetaxyConfig
 from metaxy.metadata_store import MetadataStore
 from metaxy.models.feature_definition import FeatureDefinition
-
-
-def _collect_to_arrow(frame: nw.LazyFrame | nw.DataFrame) -> pa.Table:
-    """Collect a Narwhals frame to a PyArrow Table."""
-    return (frame.collect() if isinstance(frame, nw.LazyFrame) else frame).to_arrow()
 
 
 class IbisMapTests:
@@ -66,7 +61,7 @@ class IbisMapTests:
         with store.open("r") as s:
             result = s.read(feature)
             assert result is not None
-            table = _collect_to_arrow(result).sort_by("sample_uid")
+            table = collect_to_arrow(result).sort_by("sample_uid")
 
         assert table.num_rows == 2
         assert table.column("sample_uid").to_pylist() == [1, 2]
@@ -91,7 +86,7 @@ class IbisMapTests:
         with store.open("r") as s:
             result = s.read(feature)
             assert result is not None
-            table = _collect_to_arrow(result).sort_by("sample_uid")
+            table = collect_to_arrow(result).sort_by("sample_uid")
 
         prov = table.column("metaxy_provenance_by_field")
         assert dict(prov[0].as_py()) == {"frames": "a1", "audio": "b1"}
@@ -113,7 +108,7 @@ class IbisMapTests:
         with store.open("r") as s:
             result = s.read(feature)
             assert result is not None
-            table = _collect_to_arrow(result)
+            table = collect_to_arrow(result)
 
         assert table.num_rows == 1
         assert table.column("sample_uid").to_pylist() == [1]
@@ -139,7 +134,7 @@ class IbisMapTests:
         with store.open("r") as s:
             result = s.read(feature)
             assert result is not None
-            table = _collect_to_arrow(result).sort_by("sample_uid")
+            table = collect_to_arrow(result).sort_by("sample_uid")
 
         assert table.num_rows == 2
         assert pa.types.is_map(table.schema.field("metaxy_provenance_by_field").type)

--- a/tests/test_collect_to_arrow.py
+++ b/tests/test_collect_to_arrow.py
@@ -1,0 +1,101 @@
+import narwhals as nw
+import pandas as pd
+import polars as pl
+import pyarrow as pa
+import pytest
+
+from metaxy._utils import collect_to_arrow
+
+
+def test_polars_dataframe() -> None:
+    df = pl.DataFrame({"id": [1, 2], "value": ["a", "b"]})
+
+    result = collect_to_arrow(df)
+
+    assert isinstance(result, pa.Table)
+    assert result.column("id").to_pylist() == [1, 2]
+    assert result.column("value").to_pylist() == ["a", "b"]
+
+
+def test_polars_lazyframe() -> None:
+    result = collect_to_arrow(pl.DataFrame({"id": [1, 2]}).lazy())
+
+    assert isinstance(result, pa.Table)
+    assert result.column("id").to_pylist() == [1, 2]
+
+
+def test_narwhals_polars_dataframe() -> None:
+    df = pl.DataFrame({"id": [1, 2], "value": ["a", "b"]})
+
+    result = collect_to_arrow(nw.from_native(df))
+
+    assert isinstance(result, pa.Table)
+    assert result.column("id").to_pylist() == [1, 2]
+
+
+def test_narwhals_polars_lazyframe() -> None:
+    nw_lazy = nw.from_native(pl.DataFrame({"id": [1, 2]}).lazy(), eager_only=False)
+
+    result = collect_to_arrow(nw_lazy)
+
+    assert isinstance(result, pa.Table)
+    assert result.column("id").to_pylist() == [1, 2]
+
+
+def test_narwhals_pandas_dataframe() -> None:
+    nw_df = nw.from_native(pd.DataFrame({"id": [1, 2], "value": ["a", "b"]}))
+
+    result = collect_to_arrow(nw_df)
+
+    assert isinstance(result, pa.Table)
+    assert result.column("id").to_pylist() == [1, 2]
+    assert result.column("value").to_pylist() == ["a", "b"]
+
+
+@pytest.fixture
+def polars_map_df() -> pl.DataFrame:
+    """Build a Polars DataFrame with a polars_map.Map column from a native Arrow map."""
+    pytest.importorskip("polars_map")
+    from metaxy.versioning._arrow_map import convert_maps_to_polars_map
+
+    arrow_table = pa.table(
+        {
+            "id": [1, 2],
+            "tags": pa.array(
+                [[("a", "x"), ("b", "y")], [("c", "z")]],
+                type=pa.map_(pa.string(), pa.string()),
+            ),
+        }
+    )
+    df: pl.DataFrame = pl.from_arrow(arrow_table)  # ty: ignore[invalid-assignment]
+    return convert_maps_to_polars_map(df, columns=["tags"])
+
+
+def test_polars_map_columns_become_native_arrow_map(polars_map_df: pl.DataFrame) -> None:
+    result = collect_to_arrow(polars_map_df)
+
+    assert pa.types.is_map(result.schema.field("tags").type)
+    assert dict(result.column("tags")[0].as_py()) == {"a": "x", "b": "y"}
+    assert dict(result.column("tags")[1].as_py()) == {"c": "z"}
+
+
+def test_polars_map_columns_from_lazyframe(polars_map_df: pl.DataFrame) -> None:
+    result = collect_to_arrow(polars_map_df.lazy())
+
+    assert pa.types.is_map(result.schema.field("tags").type)
+    assert dict(result.column("tags")[0].as_py()) == {"a": "x", "b": "y"}
+
+
+def test_non_polars_map_columns_unaffected() -> None:
+    """Arrow map columns from non-Polars backends stay as-is (already native)."""
+    arrays = [
+        pa.array([1, 2]),
+        pa.array([[("a", "x")], [("b", "y")]], type=pa.map_(pa.string(), pa.string())),
+    ]
+    table = pa.table({"id": arrays[0], "tags": arrays[1]})
+    nw_df = nw.from_native(table)
+
+    result = collect_to_arrow(nw_df)
+
+    assert pa.types.is_map(result.schema.field("tags").type)
+    assert dict(result.column("tags")[0].as_py()) == {"a": "x"}


### PR DESCRIPTION
## Summary

<!-- Brief description of the changes -->

## Changelog

<!--
User-facing changelog details, rendered below the commit title in CHANGELOG.md.
Delete this section if there are no user-facing changes.
-->

## Test Plan

<!-- How was this tested? -->
