### PR TITLE
feat: add `FeatureSpec.unique` field

### DIFF
--- a/docs/guide/concepts/definitions/features.md
+++ b/docs/guide/concepts/definitions/features.md
@@ -58,6 +58,110 @@ That's it! Easy.
 
     You may now use `VideoFeature.spec()` class method to access the original feature spec: it's bound to the class.
 
+### Read-Time Uniqueness
+
+Use `FeatureSpec.unique` when multiple samples should appear once in the resolved
+read view. To collapse equal values, group by a content digest:
+
+```py
+class DocumentBlob(
+    mx.BaseFeature,
+    spec=mx.FeatureSpec(
+        key="documents/blobs",
+        id_columns=["blob_id"],
+        unique=mx.Unique(subset=["content_hash"]),
+    ),
+):
+    blob_id: str
+    content_hash: str
+    path: str
+```
+
+When the digest should also define a field's data identity, provide it through
+`metaxy_data_version_by_field`; Metaxy preserves caller-provided values on
+write. See [Data Versioning](../versioning.md).
+
+A content hash identifies a value: it changes when that value changes. An entity
+key instead identifies something whose payload may change. Keep the latest state
+for each entity by naming an explicit monotonic ordering column:
+
+```py
+class EntityBinding(
+    mx.BaseFeature,
+    spec=mx.FeatureSpec(
+        key="registry/entity_bindings",
+        id_columns=["entity_id", "revision"],
+        unique=mx.Unique(
+            subset=["entity_id"],
+            keep="latest",
+            order_by=["revision"],
+        ),
+    ),
+):
+    entity_id: str
+    revision: int
+    payload_digest: str
+    status: str
+```
+
+For `keep="latest"`, the `order_by` columns followed by the feature's
+`id_columns` must define a total logical order within each `subset` group. Rows
+tied on that full key should be identical re-appends. Metaxy resolves conflicting
+ties by physical metadata; rejecting them is currently the writer's
+responsibility. NULL order values sort before non-NULL values.
+
+Default reads first choose the physically current row for each `id_columns`
+group. `order_by` only breaks a physical timestamp tie at this stage. When a
+logical ordinal must dominate write order, include it in `id_columns`, as in
+`EntityBinding`. Each revision then reaches the uniqueness step, where
+`order_by` is the primary order.
+
+Do not use a content hash as the entity key: changing the payload would silently
+create a different entity. Re-appending an identical record leaves its
+user-defined values unchanged in the resolved view, but system audit columns
+may change: `metaxy_updated_at` is rewritten and
+`metaxy_materialization_id` may differ. Those columns are not
+re-append-stable watermarks.
+
+Metaxy soft deletes and domain tombstones have different contracts. Default
+current reads remove a Metaxy-soft-deleted sample before uniqueness. With
+`include_soft_deleted=True`, deleted current rows participate normally and may
+win. A domain tombstone is an ordinary highest-order record, such as
+`status="tombstone"`, removed by a user filter after uniqueness:
+
+<!-- skip next -->
+```py
+import narwhals as nw
+
+store.read(
+    EntityBinding,
+    filters=[nw.col("status") != "tombstone"],
+)
+```
+
+For downstream dependency resolution, place the same policy on the dependency
+edge because direct read filters are not inherited:
+
+<!-- skip next -->
+```py
+mx.FeatureDep(
+    feature=EntityBinding,
+    filters=["status != 'tombstone'"],
+)
+```
+
+Pass `apply_unique=False` when unresolved rows are needed. Raw history for a
+feature that is not registered in the current graph requires
+`with_feature_history=True`, `with_sample_history=True`, and
+`apply_unique=False`; Metaxy otherwise fails rather than silently skipping
+uniqueness.
+
+A latest-only retention process must keep Metaxy's current winner for every
+`(id_columns, feature_version)` group, including the same tie and soft-delete
+semantics. The default deduplicated view can be reconstructed from those rows;
+retaining a naive `max(metaxy_updated_at)` row is not the contract. Explicit
+history reads are outside this invariant.
+
 Now let's define a child feature.
 
 ```py

--- a/docs/reference/api/definitions/feature-spec.md
+++ b/docs/reference/api/definitions/feature-spec.md
@@ -9,6 +9,12 @@ Feature specs act as source of truth for all metadata related to features: their
 
 ::: metaxy.FeatureSpec
 
-# Feature Dependencies
+## Unique
+
+::: metaxy.Unique
+
+::: metaxy.UniqueKeep
+
+## Feature Dependencies
 
 ::: metaxy.FeatureDep

--- a/docs/reference/api/definitions/feature-spec.md
+++ b/docs/reference/api/definitions/feature-spec.md
@@ -9,6 +9,32 @@ Feature specs act as source of truth for all metadata related to features: their
 
 ::: metaxy.FeatureSpec
 
-# Feature Dependencies
+## Unique
+
+`FeatureSpec.unique` defines a read-time uniqueness constraint. `subset` groups
+records that represent the same value or entity. `keep="any"` selects a stable
+representative. `keep="latest"` requires `order_by`; the row with the
+lexicographically greatest values in those columns is selected, with the
+feature's ID columns providing final logical tie-breakers. Together they must
+define a total logical order; conflicting rows tied on the full key are invalid.
+NULL sorts before every non-NULL value. Repeated column names are ignored after
+their first occurrence. Physical metadata stabilizes selection among identical
+re-appends and resolves conflicting full-key ties; detecting those conflicts is
+currently the writer's responsibility.
+
+Default current reads resolve each `id_columns` group and remove soft-deleted
+samples before applying uniqueness. With `include_soft_deleted=True`,
+deleted current rows participate normally and may win. An unregistered history
+read cannot apply the feature contract. To read its raw rows, request both
+feature and sample history and set `apply_unique=False`.
+
+Dependency-provided columns are accepted but may produce a warn-only validation
+message because they are not part of the feature's declared schema.
+
+::: metaxy.Unique
+
+::: metaxy.UniqueKeep
+
+## Feature Dependencies
 
 ::: metaxy.FeatureDep

--- a/src/metaxy/__init__.py
+++ b/src/metaxy/__init__.py
@@ -30,6 +30,8 @@ from metaxy.models.feature_spec import (
     FeatureSpec,
     FeatureSpecWithIDColumns,
     IDColumns,
+    Unique,
+    UniqueKeep,
 )
 from metaxy.models.field import (
     FieldDep,
@@ -155,6 +157,8 @@ __all__ = [
     "graph",
     "FeatureSpec",
     "FeatureDep",
+    "Unique",
+    "UniqueKeep",
     "FeatureDepMetadata",
     "FeatureSpec",
     "FeatureSpecWithIDColumns",

--- a/src/metaxy/__init__.py
+++ b/src/metaxy/__init__.py
@@ -30,6 +30,8 @@ from metaxy.models.feature_spec import (
     FeatureSpec,
     FeatureSpecWithIDColumns,
     IDColumns,
+    Unique,
+    UniqueKeep,
 )
 from metaxy.models.field import (
     FieldDep,
@@ -155,8 +157,9 @@ __all__ = [
     "graph",
     "FeatureSpec",
     "FeatureDep",
+    "Unique",
+    "UniqueKeep",
     "FeatureDepMetadata",
-    "FeatureSpec",
     "FeatureSpecWithIDColumns",
     "AllFieldsMapping",
     "DefaultFieldsMapping",

--- a/src/metaxy/cli/metadata.py
+++ b/src/metaxy/cli/metadata.py
@@ -488,6 +488,7 @@ def _count_rows_to_delete(
                     with_feature_history=with_feature_history,
                     with_sample_history=False,  # matches delete default
                     allow_fallback=soft,  # soft deletes use fallback, hard deletes don't
+                    apply_unique=False,
                 )
                 # Pre-aggregate to count per feature
                 count_frame = lazy.select(nw.len().alias("count"))
@@ -594,7 +595,6 @@ def rebase(
     """
     from metaxy.cli.context import AppContext
     from metaxy.metadata_store.exceptions import FeatureNotFoundError
-    from metaxy.models.constants import METAXY_FEATURE_VERSION
 
     context = AppContext.get()
     metadata_store = context.get_store(store)
@@ -603,9 +603,10 @@ def rebase(
         try:
             existing = metadata_store.read(
                 feature,
+                feature_version=from_version,
                 with_feature_history=True,
-                filters=[nw.col(METAXY_FEATURE_VERSION) == from_version],
                 allow_fallback=False,
+                apply_unique=False,
             )
         except FeatureNotFoundError:
             console.print(f"[yellow]Warning:[/yellow] Feature '{feature}' not found in store.")

--- a/src/metaxy/ext/dagster/io_manager.py
+++ b/src/metaxy/ext/dagster/io_manager.py
@@ -206,6 +206,7 @@ class MetaxyIOManager(dg.ConfigurableIOManager):
                 mat_lazy_df = self.metadata_store.read(
                     feature,
                     filters=[nw.col(METAXY_MATERIALIZATION_ID) == context.run_id],
+                    apply_unique=False,
                 )
                 materialized_in_run = mat_lazy_df.select(feature.id_columns).unique().collect().to_native()
                 context.add_output_metadata({"metaxy/materialized_in_run": len(materialized_in_run)})

--- a/src/metaxy/ext/dagster/utils.py
+++ b/src/metaxy/ext/dagster/utils.py
@@ -371,6 +371,7 @@ def generate_materialize_results(
                     filters=[
                         nw.col(METAXY_MATERIALIZATION_ID) == store.materialization_id  # ty: ignore[unresolved-attribute]
                     ],
+                    apply_unique=False,
                 )
                 metadata["metaxy/materialized_in_run"] = mat_df.select(nw.len()).collect().item(0, 0)
 

--- a/src/metaxy/ext/ray/datasource.py
+++ b/src/metaxy/ext/ray/datasource.py
@@ -91,9 +91,12 @@ class MetaxyDatasource(Datasource):
         filters: Sequence of Narwhals filter expressions to apply.
         columns: Subset of columns to include. Metaxy's system columns are always included.
         allow_fallback: If `True`, check fallback stores on main store miss.
-        with_feature_history: If `True`, only return rows with current feature version.
+        with_feature_history: If `True`, include rows from historical feature versions.
+            If `False`, restrict results to the current feature version.
         feature_version: Explicit feature version to filter by (mutually exclusive with `with_feature_history=False`).
-        with_sample_history: Whether to deduplicate samples within `id_columns` groups ordered by `metaxy_created_at`.
+        with_sample_history: Whether to include historical materializations instead of selecting
+            the current row per `id_columns` group using
+            `coalesce(metaxy_deleted_at, metaxy_updated_at)`.
         include_soft_deleted: If `True`, include soft-deleted rows in the result.
     """
 

--- a/src/metaxy/ext/ray/datasource.py
+++ b/src/metaxy/ext/ray/datasource.py
@@ -89,12 +89,17 @@ class MetaxyDatasource(Datasource):
         staleness_predicates: Passed to [`resolve_update`][metaxy.MetadataStore.resolve_update]
             in incremental mode.
         filters: Sequence of Narwhals filter expressions to apply.
-        columns: Subset of columns to include. Metaxy's system columns are always included.
+        columns: Exact subset of columns to return. Columns needed to resolve the read are loaded
+            internally and omitted unless requested.
         allow_fallback: If `True`, check fallback stores on main store miss.
-        with_feature_history: If `True`, only return rows with current feature version.
+        with_feature_history: If `True`, include rows from historical feature versions.
+            If `False`, restrict results to the current feature version.
         feature_version: Explicit feature version to filter by (mutually exclusive with `with_feature_history=False`).
-        with_sample_history: Whether to deduplicate samples within `id_columns` groups ordered by `metaxy_created_at`.
+        with_sample_history: Whether to include historical materializations instead of selecting
+            the current row per `id_columns` group using
+            `coalesce(metaxy_deleted_at, metaxy_updated_at)`.
         include_soft_deleted: If `True`, include soft-deleted rows in the result.
+        apply_unique: If `True`, apply the feature's `FeatureSpec.unique` settings.
     """
 
     def __init__(
@@ -112,6 +117,7 @@ class MetaxyDatasource(Datasource):
         with_feature_history: bool = False,
         with_sample_history: bool = False,
         include_soft_deleted: bool = False,
+        apply_unique: bool = True,
     ):
         self.config = mx.init(config)
         self.store = store
@@ -124,6 +130,7 @@ class MetaxyDatasource(Datasource):
         self.with_feature_history = with_feature_history
         self.with_sample_history = with_sample_history
         self.include_soft_deleted = include_soft_deleted
+        self.apply_unique = apply_unique
 
         self._feature_key = mx.coerce_to_feature_key(feature)
 
@@ -141,6 +148,7 @@ class MetaxyDatasource(Datasource):
                 with_feature_history=self.with_feature_history,
                 with_sample_history=self.with_sample_history,
                 include_soft_deleted=self.include_soft_deleted,
+                apply_unique=self.apply_unique,
             )
 
     def _read_incremental_lazy(self) -> nw.LazyFrame[Any]:

--- a/src/metaxy/graph/diff/differ.py
+++ b/src/metaxy/graph/diff/differ.py
@@ -626,11 +626,14 @@ class GraphDiffer:
             feature_key_str = feature_key.to_string()
             feature_version = graph.get_feature_version(feature_key)
             field_versions = graph.get_feature_version_by_field(feature_key)
+            feature_spec = definition.spec.model_dump(mode="json")
+            if definition.spec.unique is None:
+                feature_spec.pop("unique", None)
 
             snapshot_data[feature_key_str] = {
                 "metaxy_feature_version": feature_version,
                 "fields": field_versions,
-                "feature_spec": definition.spec.model_dump(mode="json"),
+                "feature_spec": feature_spec,
                 "metaxy_definition_version": definition.feature_definition_version,
             }
 

--- a/src/metaxy/metadata_store/base.py
+++ b/src/metaxy/metadata_store/base.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import Iterator, Mapping, Sequence
+from collections.abc import Iterable, Iterator, Mapping, Sequence
 from contextlib import AbstractContextManager, contextmanager
 from datetime import datetime, timezone
 from types import TracebackType
@@ -439,7 +439,7 @@ class MetadataStore(ABC):
             *target_filter_list,
         ]
 
-        # Read current metadata with deduplication (with_sample_history=False by default)
+        # Read current metadata with uniqueness resolution (with_sample_history=False by default)
         # Use allow_fallback=False since we only want metadata from THIS store
         # to determine what needs to be updated locally
         try:
@@ -732,6 +732,7 @@ class MetadataStore(ABC):
         with_feature_history: bool = False,
         with_sample_history: bool = False,
         include_soft_deleted: bool = False,
+        apply_unique: bool = True,
         with_store_info: Literal[False] = False,
     ) -> nw.LazyFrame[Any]: ...
 
@@ -747,6 +748,7 @@ class MetadataStore(ABC):
         with_feature_history: bool = False,
         with_sample_history: bool = False,
         include_soft_deleted: bool = False,
+        apply_unique: bool = True,
         with_store_info: Literal[True],
     ) -> tuple[nw.LazyFrame[Any], MetadataStore]: ...
 
@@ -761,6 +763,7 @@ class MetadataStore(ABC):
         with_feature_history: bool = False,
         with_sample_history: bool = False,
         include_soft_deleted: bool = False,
+        apply_unique: bool = True,
         with_store_info: bool = False,
     ) -> nw.LazyFrame[Any] | tuple[nw.LazyFrame[Any], MetadataStore]:
         """
@@ -781,8 +784,12 @@ class MetadataStore(ABC):
             with_feature_history: If True, include rows from all historical feature versions.
                 By default (False), only returns rows with the currently registered feature version.
             with_sample_history: If True, include all historical materializations per sample.
-                By default (False), deduplicates samples within `id_columns` groups ordered by `metaxy_created_at`.
+                By default (False), deduplicates samples within `id_columns` groups ordered by
+                `coalesce(metaxy_deleted_at, metaxy_updated_at)`, keeping the row with the latest timestamp.
             include_soft_deleted: If `True`, include soft-deleted rows in the result. Previous historical materializations of the same feature version will be effectively removed from the output otherwise.
+            apply_unique: If `True`, apply `FeatureSpec.unique` within the selected feature-version
+                scope before sample-history resolution and soft-delete filtering. Set to `False`
+                to disable feature-level uniqueness for this read.
             with_store_info: If `True`, return a tuple of (LazyFrame, MetadataStore) where
                 the MetadataStore is the store that actually contained the feature (which
                 may be a fallback store if allow_fallback=True).
@@ -796,9 +803,10 @@ class MetadataStore(ABC):
             ValueError: If both feature_version and with_feature_history=False are provided
 
         !!! info
-            When this method is called with default arguments, it will return the latest (by `metaxy_created_at`)
-            metadata for the current feature version excluding soft-deleted rows. Therefore, it's perfectly suitable
-            for most use cases.
+            When this method is called with default arguments, it returns the current metadata for the
+            active feature version, excluding soft-deleted rows. The current row for each `id_columns`
+            group is selected by ordering on `coalesce(metaxy_deleted_at, metaxy_updated_at)` and keeping
+            the latest timestamp. Therefore, it's perfectly suitable for most use cases.
 
         !!! warning
             The order of rows is not guaranteed.
@@ -813,6 +821,7 @@ class MetadataStore(ABC):
 
         feature_key = self._resolve_feature_key(feature)
         is_system_table = self._is_system_table(feature_key)
+        feature_plan: FeaturePlan | None = None
 
         # Sync external features if auto-sync is enabled (default)
         # This call is a no-op most of the time and is very lightweight when it's not
@@ -830,9 +839,10 @@ class MetadataStore(ABC):
                 "Use with_feature_history=True with feature_version parameter."
             )
 
-        # Separate system filters (applied before dedup) from user filters (applied after dedup)
+        # Separate system filters (applied before read-mode resolution) from user filters
+        # (applied after read-mode resolution)
         # System filters like feature_version need to be applied early to reduce data volume
-        # User filters should see the deduplicated view of the data
+        # User filters should see the resolved view of the data
         system_filters: list[nw.Expr] = []
         user_filters = list(filters) if filters else []
 
@@ -849,17 +859,28 @@ class MetadataStore(ABC):
         if user_filters:
             read_columns = None
         elif columns and not is_system_table:
-            # Add only system columns that aren't already in the user's columns list
-            columns_set = set(columns)
-            missing_system_cols = [c for c in ALL_SYSTEM_COLUMNS if c not in columns_set]
-            read_columns = [*columns, *missing_system_cols]
+            additional_columns: Iterable[str] | None = None
+            if apply_unique or not with_sample_history:
+                graph = current_graph()
+                definition = graph.feature_definitions_by_key.get(feature_key)
+                if definition is not None:
+                    feature_plan = graph.get_feature_plan(feature_key)
+
+                extra: list[str] = []
+                if not with_sample_history and feature_plan is not None:
+                    extra.extend(feature_plan.feature.id_columns)
+                if apply_unique and feature_plan is not None and feature_plan.feature.unique is not None:
+                    extra.extend(feature_plan.feature.unique.subset)
+                    extra.extend(feature_plan.feature.id_columns)
+                additional_columns = extra or None
+            read_columns = self._internal_read_columns(columns, additional_columns=additional_columns)
         else:
             read_columns = None
 
         lazy_frame = None
         try:
             # Only pass system filters to _read_feature
-            # User filters will be applied after deduplication
+            # User filters will be applied after uniqueness resolution
             lazy_frame = self._read_feature(
                 feature, filters=system_filters if system_filters else None, columns=read_columns
             )
@@ -877,21 +898,27 @@ class MetadataStore(ABC):
             )
 
         if lazy_frame is not None and not is_system_table:
-            # Deduplicate first, then filter soft-deleted rows
-            if not with_sample_history:
-                id_cols = list(self._resolve_feature_plan(feature_key).feature.id_columns)
-                # Treat soft-deletes like hard deletes by ordering on the
-                # most recent lifecycle timestamp.
-                lazy_frame = self.versioning_engine_cls.keep_latest_by_group(
-                    df=lazy_frame,
-                    group_columns=id_cols,
-                    timestamp_columns=[METAXY_DELETED_AT, METAXY_UPDATED_AT],
-                )
+            resolved_feature_plan = feature_plan
+            if resolved_feature_plan is None and (apply_unique or not with_sample_history):
+                graph = current_graph()
+                if feature_key in graph.feature_definitions_by_key:
+                    resolved_feature_plan = graph.get_feature_plan(feature_key)
 
-            if filter_deleted:
+            if apply_unique and resolved_feature_plan is not None:
+                lazy_frame = self._apply_unique(lazy_frame, plan=resolved_feature_plan)
+
+            if not with_sample_history:
+                if resolved_feature_plan is None:
+                    raise RuntimeError(f"Failed to resolve feature plan for {feature_key.to_string()}.")
+                lazy_frame = self._apply_current_feature_view(
+                    lazy_frame,
+                    plan=resolved_feature_plan,
+                    filter_deleted=filter_deleted,
+                )
+            elif filter_deleted:
                 lazy_frame = lazy_frame.filter(nw.col(METAXY_DELETED_AT).is_null())
 
-            # Apply user filters AFTER deduplication so they see the latest version of each row
+            # Apply user filters AFTER read-mode resolution so they see the final row set.
             for user_filter in user_filters:
                 lazy_frame = lazy_frame.filter(user_filter)
 
@@ -926,6 +953,7 @@ class MetadataStore(ABC):
                                 with_feature_history=with_feature_history,
                                 with_sample_history=with_sample_history,
                                 include_soft_deleted=include_soft_deleted,
+                                apply_unique=apply_unique,
                                 with_store_info=True,
                             )
                         return store.read(
@@ -937,6 +965,7 @@ class MetadataStore(ABC):
                             with_feature_history=with_feature_history,
                             with_sample_history=with_sample_history,
                             include_soft_deleted=include_soft_deleted,
+                            apply_unique=apply_unique,
                         )
                 except FeatureNotFoundError:
                     # Try next fallback store
@@ -1450,6 +1479,76 @@ class MetadataStore(ABC):
         # Then get the plan
         graph = current_graph()
         return graph.get_feature_plan(feature_key)
+
+    @staticmethod
+    def _internal_read_columns(
+        columns: Sequence[str],
+        *,
+        additional_columns: Iterable[str] | None = None,
+    ) -> list[str]:
+        """Add internal columns required for read-time filtering and uniqueness resolution."""
+        normalized_columns = list(dict.fromkeys(columns))
+        columns_set = set(normalized_columns)
+        missing_system_columns = [column for column in ALL_SYSTEM_COLUMNS if column not in columns_set]
+        columns_set.update(missing_system_columns)
+        normalized_additional_columns = list(dict.fromkeys(additional_columns or ()))
+        missing_additional_columns = [column for column in normalized_additional_columns if column not in columns_set]
+        columns_set.update(missing_additional_columns)
+        return [*normalized_columns, *missing_system_columns, *missing_additional_columns]
+
+    def _apply_unique(
+        self,
+        lazy_frame: nw.LazyFrame[Any],
+        *,
+        plan: FeaturePlan,
+    ) -> nw.LazyFrame[Any]:
+        """Apply read-time uniqueness configured by FeatureSpec.unique."""
+        unique = plan.feature.unique
+        if unique is None:
+            return lazy_frame
+
+        subset = list(unique.subset)
+        if unique.keep == "latest":
+            return self.versioning_engine_cls.keep_latest_by_group(
+                df=lazy_frame,
+                group_columns=subset,
+                timestamp_columns=[METAXY_UPDATED_AT],
+            )
+
+        if unique.keep == "any":
+            order_by = list(
+                dict.fromkeys(
+                    [
+                        METAXY_DELETED_AT,
+                        METAXY_UPDATED_AT,
+                        METAXY_CREATED_AT,
+                        METAXY_MATERIALIZATION_ID,
+                        *plan.feature.id_columns,
+                    ]
+                )
+            )
+            return lazy_frame.unique(subset=subset, keep="last", order_by=order_by)
+
+        raise ValueError(f"Unsupported unique.keep value: {unique.keep!r}")
+
+    def _apply_current_feature_view(
+        self,
+        lazy_frame: nw.LazyFrame[Any],
+        *,
+        plan: FeaturePlan,
+        filter_deleted: bool,
+    ) -> nw.LazyFrame[Any]:
+        """Return the current-sample view for a feature read."""
+        current_rows = self.versioning_engine_cls.keep_latest_by_group(
+            df=lazy_frame,
+            group_columns=list(plan.feature.id_columns),
+            timestamp_columns=[METAXY_DELETED_AT, METAXY_UPDATED_AT],
+        )
+
+        if filter_deleted:
+            current_rows = current_rows.filter(nw.col(METAXY_DELETED_AT).is_null())
+
+        return current_rows
 
     # ========== Core CRUD Operations ==========
 

--- a/src/metaxy/metadata_store/base.py
+++ b/src/metaxy/metadata_store/base.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import Iterator, Mapping, Sequence
+from collections.abc import Iterable, Iterator, Mapping, Sequence
 from contextlib import AbstractContextManager, contextmanager
 from datetime import datetime, timezone
 from types import TracebackType
@@ -52,6 +52,7 @@ from metaxy.models.types import (
     FeatureKey,
     ValidatedFeatureKeyAdapter,
 )
+from metaxy.utils.constants import TEMP_TABLE_NAME
 from metaxy.utils.dataframes import switch_implementation_to_polars
 from metaxy.versioning import VersioningEngine
 from metaxy.versioning.types import HashAlgorithm, Increment, LazyIncrement
@@ -439,7 +440,7 @@ class MetadataStore(ABC):
             *target_filter_list,
         ]
 
-        # Read current metadata with deduplication (with_sample_history=False by default)
+        # Read physical current metadata so hidden duplicates do not reappear as new samples.
         # Use allow_fallback=False since we only want metadata from THIS store
         # to determine what needs to be updated locally
         try:
@@ -449,6 +450,7 @@ class MetadataStore(ABC):
                 allow_fallback=False,
                 with_feature_history=False,  # filters by current feature_version
                 with_sample_history=False,  # deduplicates by id_columns, keeping latest
+                apply_unique=False,
             )
         except FeatureNotFoundError:
             current_metadata = None
@@ -732,6 +734,7 @@ class MetadataStore(ABC):
         with_feature_history: bool = False,
         with_sample_history: bool = False,
         include_soft_deleted: bool = False,
+        apply_unique: bool = True,
         with_store_info: Literal[False] = False,
     ) -> nw.LazyFrame[Any]: ...
 
@@ -747,6 +750,7 @@ class MetadataStore(ABC):
         with_feature_history: bool = False,
         with_sample_history: bool = False,
         include_soft_deleted: bool = False,
+        apply_unique: bool = True,
         with_store_info: Literal[True],
     ) -> tuple[nw.LazyFrame[Any], MetadataStore]: ...
 
@@ -761,6 +765,7 @@ class MetadataStore(ABC):
         with_feature_history: bool = False,
         with_sample_history: bool = False,
         include_soft_deleted: bool = False,
+        apply_unique: bool = True,
         with_store_info: bool = False,
     ) -> nw.LazyFrame[Any] | tuple[nw.LazyFrame[Any], MetadataStore]:
         """
@@ -776,13 +781,24 @@ class MetadataStore(ABC):
             feature_version: Explicit feature_version to filter by (mutually exclusive with with_feature_history=False)
             filters: Sequence of Narwhals filter expressions to apply to this feature.
                 Example: `[nw.col("x") > 10, nw.col("y") < 5]`
-            columns: Subset of columns to include. Metaxy's system columns are always included.
+            columns: Exact subset of columns to return. Internal columns needed to resolve the
+                read are loaded automatically and omitted from the result.
             allow_fallback: Whether to allow fallback to upstream stores if the requested feature is not found in the current store.
             with_feature_history: If True, include rows from all historical feature versions.
                 By default (False), only returns rows with the currently registered feature version.
             with_sample_history: If True, include all historical materializations per sample.
-                By default (False), deduplicates samples within `id_columns` groups ordered by `metaxy_created_at`.
-            include_soft_deleted: If `True`, include soft-deleted rows in the result. Previous historical materializations of the same feature version will be effectively removed from the output otherwise.
+                By default (False), deduplicates samples within `id_columns` groups ordered by
+                `coalesce(metaxy_deleted_at, metaxy_updated_at)`, keeping the row with the latest
+                timestamp. Feature-history reads resolve each feature version independently. For
+                `unique.keep="latest"`, `unique.order_by` breaks physical timestamp ties.
+            include_soft_deleted: If `True`, include soft-deleted rows in the result. These rows
+                participate normally in `FeatureSpec.unique` and may be selected. Default current
+                reads resolve and remove soft-deleted samples before applying feature-level uniqueness.
+            apply_unique: If `True`, apply `FeatureSpec.unique` within the selected feature-version
+                scope. Default reads first resolve the current row and soft-delete state for each
+                sample; sample-history reads apply uniqueness across the selected history. Set to
+                `False` to return the read mode without feature-level uniqueness. A resolvable
+                feature definition is required when this option is enabled.
             with_store_info: If `True`, return a tuple of (LazyFrame, MetadataStore) where
                 the MetadataStore is the store that actually contained the feature (which
                 may be a fallback store if allow_fallback=True).
@@ -794,11 +810,14 @@ class MetadataStore(ABC):
             FeatureNotFoundError: If feature not found in any store
             SystemDataNotFoundError: When attempting to read non-existent Metaxy system data
             ValueError: If both feature_version and with_feature_history=False are provided
+            RuntimeError: If the feature plan needed for current-view or uniqueness resolution
+                is not registered.
 
         !!! info
-            When this method is called with default arguments, it will return the latest (by `metaxy_created_at`)
-            metadata for the current feature version excluding soft-deleted rows. Therefore, it's perfectly suitable
-            for most use cases.
+            When this method is called with default arguments, it returns the current metadata for the
+            active feature version, excluding soft-deleted rows. The current row for each `id_columns`
+            group is selected by ordering on `coalesce(metaxy_deleted_at, metaxy_updated_at)` and keeping
+            the latest timestamp. Therefore, it's perfectly suitable for most use cases.
 
         !!! warning
             The order of rows is not guaranteed.
@@ -813,6 +832,7 @@ class MetadataStore(ABC):
 
         feature_key = self._resolve_feature_key(feature)
         is_system_table = self._is_system_table(feature_key)
+        feature_plan: FeaturePlan | None = None
 
         # Sync external features if auto-sync is enabled (default)
         # This call is a no-op most of the time and is very lightweight when it's not
@@ -830,9 +850,10 @@ class MetadataStore(ABC):
                 "Use with_feature_history=True with feature_version parameter."
             )
 
-        # Separate system filters (applied before dedup) from user filters (applied after dedup)
+        # Separate system filters (applied before read-mode resolution) from user filters
+        # (applied after read-mode resolution)
         # System filters like feature_version need to be applied early to reduce data volume
-        # User filters should see the deduplicated view of the data
+        # User filters should see the resolved view of the data
         system_filters: list[nw.Expr] = []
         user_filters = list(filters) if filters else []
 
@@ -849,17 +870,31 @@ class MetadataStore(ABC):
         if user_filters:
             read_columns = None
         elif columns and not is_system_table:
-            # Add only system columns that aren't already in the user's columns list
-            columns_set = set(columns)
-            missing_system_cols = [c for c in ALL_SYSTEM_COLUMNS if c not in columns_set]
-            read_columns = [*columns, *missing_system_cols]
+            additional_columns: Iterable[str] | None = None
+            if apply_unique or not with_sample_history:
+                graph = current_graph()
+                definition = graph.feature_definitions_by_key.get(feature_key)
+                if definition is not None:
+                    feature_plan = graph.get_feature_plan(feature_key)
+
+                extra: list[str] = []
+                if not with_sample_history and feature_plan is not None:
+                    extra.extend(feature_plan.feature.id_columns)
+                    if feature_plan.feature.unique is not None and feature_plan.feature.unique.keep == "latest":
+                        extra.extend(feature_plan.feature.unique.order_by or ())
+                if apply_unique and feature_plan is not None and feature_plan.feature.unique is not None:
+                    extra.extend(feature_plan.feature.unique.subset)
+                    extra.extend(feature_plan.feature.unique.order_by or ())
+                    extra.extend(feature_plan.feature.id_columns)
+                additional_columns = extra or None
+            read_columns = self._internal_read_columns(columns, additional_columns=additional_columns)
         else:
             read_columns = None
 
         lazy_frame = None
         try:
             # Only pass system filters to _read_feature
-            # User filters will be applied after deduplication
+            # User filters will be applied after uniqueness resolution
             lazy_frame = self._read_feature(
                 feature, filters=system_filters if system_filters else None, columns=read_columns
             )
@@ -877,21 +912,46 @@ class MetadataStore(ABC):
             )
 
         if lazy_frame is not None and not is_system_table:
-            # Deduplicate first, then filter soft-deleted rows
-            if not with_sample_history:
-                id_cols = list(self._resolve_feature_plan(feature_key).feature.id_columns)
-                # Treat soft-deletes like hard deletes by ordering on the
-                # most recent lifecycle timestamp.
-                lazy_frame = self.versioning_engine_cls.keep_latest_by_group(
-                    df=lazy_frame,
-                    group_columns=id_cols,
-                    timestamp_columns=[METAXY_DELETED_AT, METAXY_UPDATED_AT],
+            resolved_feature_plan = feature_plan
+            if resolved_feature_plan is None and (apply_unique or not with_sample_history):
+                graph = current_graph()
+                if feature_key in graph.feature_definitions_by_key:
+                    resolved_feature_plan = graph.get_feature_plan(feature_key)
+
+            if resolved_feature_plan is None and apply_unique:
+                raise RuntimeError(
+                    f"Cannot apply FeatureSpec.unique for {feature_key.to_string()} without a registered "
+                    "feature plan. Register the feature or set apply_unique=False."
                 )
 
-            if filter_deleted:
+            if resolved_feature_plan is None and not with_sample_history:
+                raise RuntimeError(
+                    f"Failed to resolve feature plan for {feature_key.to_string()}. "
+                    "Register the feature or use with_sample_history=True."
+                )
+
+            if not with_sample_history:
+                assert resolved_feature_plan is not None
+                current_tie_breakers: Sequence[str] = ()
+                if (
+                    resolved_feature_plan.feature.unique is not None
+                    and resolved_feature_plan.feature.unique.keep == "latest"
+                ):
+                    current_tie_breakers = resolved_feature_plan.feature.unique.order_by or ()
+                lazy_frame = self._apply_current_feature_view(
+                    lazy_frame,
+                    plan=resolved_feature_plan,
+                    filter_deleted=filter_deleted,
+                    tie_breakers=current_tie_breakers,
+                    with_feature_history=with_feature_history,
+                )
+            elif filter_deleted:
                 lazy_frame = lazy_frame.filter(nw.col(METAXY_DELETED_AT).is_null())
 
-            # Apply user filters AFTER deduplication so they see the latest version of each row
+            if apply_unique and resolved_feature_plan is not None:
+                lazy_frame = self._apply_unique(lazy_frame, plan=resolved_feature_plan)
+
+            # Apply user filters AFTER read-mode resolution so they see the final row set.
             for user_filter in user_filters:
                 lazy_frame = lazy_frame.filter(user_filter)
 
@@ -926,6 +986,7 @@ class MetadataStore(ABC):
                                 with_feature_history=with_feature_history,
                                 with_sample_history=with_sample_history,
                                 include_soft_deleted=include_soft_deleted,
+                                apply_unique=apply_unique,
                                 with_store_info=True,
                             )
                         return store.read(
@@ -937,6 +998,7 @@ class MetadataStore(ABC):
                             with_feature_history=with_feature_history,
                             with_sample_history=with_sample_history,
                             include_soft_deleted=include_soft_deleted,
+                            apply_unique=apply_unique,
                         )
                 except FeatureNotFoundError:
                     # Try next fallback store
@@ -1451,6 +1513,131 @@ class MetadataStore(ABC):
         graph = current_graph()
         return graph.get_feature_plan(feature_key)
 
+    @staticmethod
+    def _internal_read_columns(
+        columns: Sequence[str],
+        *,
+        additional_columns: Iterable[str] | None = None,
+    ) -> list[str]:
+        """Add internal columns required for read-time filtering and uniqueness resolution."""
+        normalized_columns = list(dict.fromkeys(columns))
+        columns_set = set(normalized_columns)
+        missing_system_columns = [column for column in ALL_SYSTEM_COLUMNS if column not in columns_set]
+        columns_set.update(missing_system_columns)
+        normalized_additional_columns = list(dict.fromkeys(additional_columns or ()))
+        missing_additional_columns = [column for column in normalized_additional_columns if column not in columns_set]
+        columns_set.update(missing_additional_columns)
+        return [*normalized_columns, *missing_system_columns, *missing_additional_columns]
+
+    def _apply_unique(
+        self,
+        lazy_frame: nw.LazyFrame[Any],
+        *,
+        plan: FeaturePlan,
+    ) -> nw.LazyFrame[Any]:
+        """Apply read-time uniqueness configured by FeatureSpec.unique."""
+        unique = plan.feature.unique
+        if unique is None:
+            return lazy_frame
+
+        physical_tie_breakers = [
+            TEMP_TABLE_NAME,
+            METAXY_DELETED_AT,
+            METAXY_UPDATED_AT,
+            METAXY_DATA_VERSION,
+            METAXY_PROVENANCE,
+            METAXY_FEATURE_VERSION,
+            METAXY_PROJECT_VERSION,
+            METAXY_CREATED_AT,
+            METAXY_MATERIALIZATION_ID,
+        ]
+        if unique.keep == "latest":
+            if unique.order_by is None:
+                raise ValueError('unique.order_by is required when unique.keep="latest"')
+            order_by = list(
+                dict.fromkeys(
+                    [
+                        *unique.order_by,
+                        *plan.feature.id_columns,
+                        *physical_tie_breakers,
+                    ]
+                )
+            )
+        elif unique.keep == "any":
+            order_by = list(dict.fromkeys([*plan.feature.id_columns, *physical_tie_breakers]))
+        else:
+            raise ValueError(f"Unsupported unique.keep value: {unique.keep!r}")
+
+        return (
+            lazy_frame.with_columns(
+                nw.coalesce(
+                    nw.col(METAXY_DELETED_AT),
+                    nw.col(METAXY_UPDATED_AT),
+                ).alias(TEMP_TABLE_NAME)
+            )
+            .unique(
+                subset=list(unique.subset),
+                keep="last",
+                order_by=order_by,
+            )
+            .drop(TEMP_TABLE_NAME)
+        )
+
+    def _apply_current_feature_view(
+        self,
+        lazy_frame: nw.LazyFrame[Any],
+        *,
+        plan: FeaturePlan,
+        filter_deleted: bool,
+        tie_breakers: Sequence[str] = (),
+        with_feature_history: bool = False,
+    ) -> nw.LazyFrame[Any]:
+        """Return the current-sample view for a feature read."""
+        id_columns = list(
+            dict.fromkeys(
+                [
+                    *plan.feature.id_columns,
+                    *([METAXY_FEATURE_VERSION] if with_feature_history else []),
+                ]
+            )
+        )
+
+        order_by = list(
+            dict.fromkeys(
+                [
+                    TEMP_TABLE_NAME,
+                    *tie_breakers,
+                    METAXY_DELETED_AT,
+                    METAXY_UPDATED_AT,
+                    METAXY_DATA_VERSION,
+                    METAXY_PROVENANCE,
+                    METAXY_FEATURE_VERSION,
+                    METAXY_PROJECT_VERSION,
+                    METAXY_CREATED_AT,
+                    METAXY_MATERIALIZATION_ID,
+                ]
+            )
+        )
+        current_rows = (
+            lazy_frame.with_columns(
+                nw.coalesce(
+                    nw.col(METAXY_DELETED_AT),
+                    nw.col(METAXY_UPDATED_AT),
+                ).alias(TEMP_TABLE_NAME)
+            )
+            .unique(
+                subset=id_columns,
+                keep="last",
+                order_by=order_by,
+            )
+            .drop(TEMP_TABLE_NAME)
+        )
+
+        if filter_deleted:
+            current_rows = current_rows.filter(nw.col(METAXY_DELETED_AT).is_null())
+
+        return current_rows
+
     # ========== Core CRUD Operations ==========
 
     @contextmanager
@@ -1806,6 +1993,7 @@ class MetadataStore(ABC):
                 with_feature_history=with_feature_history,
                 with_sample_history=with_sample_history,
                 allow_fallback=True,
+                apply_unique=False,
             )
             with self._shared_transaction_timestamp(soft_delete=True) as ts:
                 soft_deletion_marked = lazy.with_columns(
@@ -1982,6 +2170,7 @@ class MetadataStore(ABC):
         lazy = self.read(
             feature,
             allow_fallback=False,
+            apply_unique=False,
         )
         return lazy.collect_schema()
 
@@ -2339,6 +2528,7 @@ class MetadataStore(ABC):
                     allow_fallback=False,
                     with_feature_history=with_feature_history,
                     with_sample_history=with_sample_history,
+                    apply_unique=False,
                 )
 
                 # Collect to narwhals DataFrame to get row count

--- a/src/metaxy/models/feature.py
+++ b/src/metaxy/models/feature.py
@@ -600,6 +600,8 @@ class FeatureGraph:
 
             feature_key_str = feature_key.to_string()
             feature_spec_dict = definition.spec.model_dump(mode="json")
+            if definition.spec.unique is None:
+                feature_spec_dict.pop("unique", None)
             feature_schema_dict = definition.feature_schema
             feature_version = self.get_feature_version(feature_key)
             definition_version = definition.feature_definition_version

--- a/src/metaxy/models/feature_definition.py
+++ b/src/metaxy/models/feature_definition.py
@@ -10,11 +10,12 @@ from collections.abc import Sequence
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Literal
 
-from pydantic import Field, Json, PrivateAttr, TypeAdapter, field_serializer, field_validator
+from pydantic import Field, Json, PrivateAttr, TypeAdapter, field_serializer, field_validator, model_validator
 
 from metaxy._decorators import public
 from metaxy._hashing import truncate_hash
 from metaxy.models.bases import FrozenBaseModel
+from metaxy.models.constants import ALL_SYSTEM_COLUMNS
 from metaxy.models.feature_spec import FeatureSpec
 from metaxy.models.types import CoercibleToFieldKey, FeatureKey, ValidatedFieldKeyAdapter
 
@@ -59,6 +60,24 @@ class FeatureDefinition(FrozenBaseModel):
     _provenance_by_field: dict[str, str] | None = PrivateAttr(default=None)
     _on_version_mismatch: Literal["warn", "error"] = PrivateAttr(default="warn")
     _source: str | None = PrivateAttr(default=None)
+
+    @model_validator(mode="after")
+    def validate_unique_columns(self) -> FeatureDefinition:
+        """Warn if unique.subset references columns not present in the definition schema."""
+        if self.spec.unique is None or not self.columns:
+            return self
+
+        available = set(self.columns) | set(ALL_SYSTEM_COLUMNS)
+        missing = set(self.spec.unique.subset) - available
+        if missing:
+            warnings.warn(
+                f"Feature '{self.key}': unique.subset columns {sorted(missing)} not found in "
+                f"feature columns or system columns. "
+                f"They must exist at read time or a ColumnNotFoundError will occur.",
+                UserWarning,
+                stacklevel=2,
+            )
+        return self
 
     @classmethod
     def from_feature_class(cls, feature_cls: type[BaseFeature]) -> FeatureDefinition:

--- a/src/metaxy/models/feature_definition.py
+++ b/src/metaxy/models/feature_definition.py
@@ -10,11 +10,12 @@ from collections.abc import Sequence
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Literal
 
-from pydantic import Field, Json, PrivateAttr, TypeAdapter, field_serializer, field_validator
+from pydantic import Field, Json, PrivateAttr, TypeAdapter, field_serializer, field_validator, model_validator
 
 from metaxy._decorators import public
 from metaxy._hashing import truncate_hash
 from metaxy.models.bases import FrozenBaseModel
+from metaxy.models.constants import ALL_SYSTEM_COLUMNS
 from metaxy.models.feature_spec import FeatureSpec
 from metaxy.models.types import CoercibleToFieldKey, FeatureKey, ValidatedFieldKeyAdapter
 
@@ -59,6 +60,29 @@ class FeatureDefinition(FrozenBaseModel):
     _provenance_by_field: dict[str, str] | None = PrivateAttr(default=None)
     _on_version_mismatch: Literal["warn", "error"] = PrivateAttr(default="warn")
     _source: str | None = PrivateAttr(default=None)
+
+    @model_validator(mode="after")
+    def validate_unique_columns(self) -> FeatureDefinition:
+        """Warn if uniqueness settings reference columns absent from the definition schema."""
+        if self.spec.unique is None or not self.columns:
+            return self
+
+        available = set(self.columns) | set(ALL_SYSTEM_COLUMNS)
+        missing_subset = set(self.spec.unique.subset) - available
+        missing_order_by = set(self.spec.unique.order_by or ()) - available
+        if missing_subset or missing_order_by:
+            missing = []
+            if missing_subset:
+                missing.append(f"unique.subset columns {sorted(missing_subset)}")
+            if missing_order_by:
+                missing.append(f"unique.order_by columns {sorted(missing_order_by)}")
+            warnings.warn(
+                f"Feature '{self.key}': {'; '.join(missing)} not found in feature columns or system columns. "
+                f"They must exist at read time or a ColumnNotFoundError will occur.",
+                UserWarning,
+                stacklevel=2,
+            )
+        return self
 
     @classmethod
     def from_feature_class(cls, feature_cls: type[BaseFeature]) -> FeatureDefinition:

--- a/src/metaxy/models/feature_spec.py
+++ b/src/metaxy/models/feature_spec.py
@@ -4,7 +4,7 @@ import hashlib
 import json
 from collections.abc import Mapping, Sequence
 from functools import cached_property
-from typing import TYPE_CHECKING, Annotated, Any, TypeAlias, overload
+from typing import TYPE_CHECKING, Annotated, Any, Literal, TypeAlias, overload
 
 import narwhals as nw
 import pydantic
@@ -171,13 +171,26 @@ class FeatureDep(pydantic.BaseModel):
 IDColumns: TypeAlias = Sequence[str]  # non-bound, should be used for feature specs with arbitrary id columns
 
 CoercibleToFeatureDep: TypeAlias = FeatureDep | type["BaseFeature"] | str | Sequence[str] | FeatureKey
+UniqueKeep: TypeAlias = Literal["any", "latest"]
 
 
 def _validate_id_columns(value: Any) -> tuple[str, ...]:
-    """Coerce id_columns to tuple."""
-    if isinstance(value, tuple):
-        return value
+    """Reject bare strings to prevent silent character splitting."""
+    if isinstance(value, str):
+        raise TypeError("id_columns must be a sequence of column names, not a bare string")
     return tuple(value)
+
+
+def _validate_unique_subset(value: Any) -> tuple[str, ...]:
+    """Validate unique.subset and preserve the user-provided column order."""
+    if isinstance(value, str):
+        raise ValueError("unique.subset must be a sequence of column names, not a bare string")
+    if isinstance(value, Mapping):
+        raise ValueError("unique.subset must be a sequence of column names, not a mapping")
+    try:
+        return tuple(dict.fromkeys(value))
+    except TypeError as exc:
+        raise ValueError("unique.subset must be a sequence of column names") from exc
 
 
 def _validate_deps(value: Any) -> list[FeatureDep]:
@@ -207,10 +220,40 @@ def _validate_deps(value: Any) -> list[FeatureDep]:
 
 
 @public
+class Unique(FrozenBaseModel):
+    """Read-time uniqueness settings for a feature."""
+
+    subset: Annotated[tuple[str, ...], BeforeValidator(_validate_unique_subset)] = pydantic.Field(
+        ...,
+        min_length=1,
+        description="Columns used to determine uniqueness. Records with identical values in these columns are considered duplicates.",
+    )
+    keep: UniqueKeep = pydantic.Field(
+        default="any",
+        description=(
+            "Strategy for choosing which row to keep among duplicates. "
+            '"any" picks a deterministic representative using Metaxy row ordering. '
+            '"latest" keeps the most recently updated row based on the update timestamp; when multiple rows '
+            "share the same timestamp, the chosen row is unspecified and may be non-deterministic."
+        ),
+    )
+
+    if TYPE_CHECKING:
+
+        def __init__(self, *, subset: Sequence[str], keep: UniqueKeep = "any") -> None: ...
+
+    @pydantic.field_serializer("subset")
+    @staticmethod
+    def _serialize_subset(value: tuple[str, ...]) -> list[str]:
+        return list(value)
+
+
+@public
 class FeatureSpec(FrozenBaseModel):
     key: Annotated[FeatureKey, BeforeValidator(FeatureKeyAdapter.validate_python)]
     id_columns: Annotated[tuple[str, ...], BeforeValidator(_validate_id_columns)] = pydantic.Field(
         ...,
+        min_length=1,
         description="Columns that uniquely identify a sample in this feature.",
     )
     deps: Annotated[list[FeatureDep], BeforeValidator(_validate_deps)] = pydantic.Field(default_factory=list)
@@ -232,6 +275,12 @@ class FeatureSpec(FrozenBaseModel):
         default=None,
         description="Human-readable description of this feature.",
     )
+    unique: Unique | None = pydantic.Field(
+        default=None,
+        description=(
+            "Read-time uniqueness settings. Applied before sample-history resolution and soft-deletion filtering."
+        ),
+    )
 
     if TYPE_CHECKING:
         # Overload for common case: list of FeatureDep instances
@@ -245,6 +294,7 @@ class FeatureSpec(FrozenBaseModel):
             fields: Sequence[str | FieldSpec] | None = None,
             metadata: dict[str, Any] | None = None,
             description: str | None = None,
+            unique: Unique | Mapping[str, Any] | None = None,
         ) -> None: ...
 
         # Overload for flexible case: list of coercible types
@@ -258,6 +308,7 @@ class FeatureSpec(FrozenBaseModel):
             fields: Sequence[str | FieldSpec] | None = None,
             metadata: dict[str, Any] | None = None,
             description: str | None = None,
+            unique: Unique | Mapping[str, Any] | None = None,
         ) -> None: ...
 
         # Implementation signature
@@ -270,6 +321,7 @@ class FeatureSpec(FrozenBaseModel):
             fields: Sequence[str | FieldSpec] | None = None,
             metadata: dict[str, Any] | None = None,
             description: str | None = None,
+            unique: Unique | Mapping[str, Any] | None = None,
         ) -> None: ...
 
     @cached_property
@@ -311,13 +363,6 @@ class FeatureSpec(FrozenBaseModel):
             seen_keys.add(key_tuple)
         return self
 
-    @pydantic.model_validator(mode="after")
-    def validate_id_columns(self) -> Self:
-        """Validate that id_columns is non-empty if specified."""
-        if self.id_columns is not None and len(self.id_columns) == 0:
-            raise ValueError("id_columns must be non-empty if specified. Use None for default.")
-        return self
-
     @property
     def feature_spec_version(self) -> str:
         """Compute SHA256 hash of the complete feature specification.
@@ -347,6 +392,8 @@ class FeatureSpec(FrozenBaseModel):
         # Use model_dump with mode="json" for deterministic serialization
         # This ensures all types (like FeatureKey) are properly serialized
         spec_dict = self.model_dump(mode="json")
+        if self.unique is None:
+            spec_dict.pop("unique", None)
 
         # Sort keys to ensure deterministic ordering
         spec_json = json.dumps(spec_dict, sort_keys=True)

--- a/src/metaxy/models/feature_spec.py
+++ b/src/metaxy/models/feature_spec.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import hashlib
 import json
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping, Sequence, Set
 from functools import cached_property
-from typing import TYPE_CHECKING, Annotated, Any, TypeAlias, overload
+from typing import TYPE_CHECKING, Annotated, Any, Literal, TypeAlias, overload
 
 import narwhals as nw
 import pydantic
@@ -171,13 +171,33 @@ class FeatureDep(pydantic.BaseModel):
 IDColumns: TypeAlias = Sequence[str]  # non-bound, should be used for feature specs with arbitrary id columns
 
 CoercibleToFeatureDep: TypeAlias = FeatureDep | type["BaseFeature"] | str | Sequence[str] | FeatureKey
+UniqueKeep: TypeAlias = Literal["any", "latest"]
+
+
+def _validate_column_sequence(value: Any, field_name: str) -> tuple[str, ...]:
+    """Validate column names and preserve the user-provided order."""
+    if isinstance(value, str):
+        raise ValueError(f"{field_name} must be a sequence of column names, not a bare string")
+    if isinstance(value, Mapping):
+        raise ValueError(f"{field_name} must be a sequence of column names, not a mapping")
+    if isinstance(value, Set):
+        raise ValueError(f"{field_name} must be an ordered sequence of column names, not a set")
+    try:
+        return tuple(dict.fromkeys(value))
+    except TypeError as exc:
+        raise ValueError(f"{field_name} must be a sequence of column names") from exc
 
 
 def _validate_id_columns(value: Any) -> tuple[str, ...]:
-    """Coerce id_columns to tuple."""
-    if isinstance(value, tuple):
-        return value
-    return tuple(value)
+    return _validate_column_sequence(value, "id_columns")
+
+
+def _validate_unique_subset(value: Any) -> tuple[str, ...]:
+    return _validate_column_sequence(value, "unique.subset")
+
+
+def _validate_unique_order_by(value: Any) -> tuple[str, ...]:
+    return _validate_column_sequence(value, "unique.order_by")
 
 
 def _validate_deps(value: Any) -> list[FeatureDep]:
@@ -207,10 +227,67 @@ def _validate_deps(value: Any) -> list[FeatureDep]:
 
 
 @public
+class Unique(FrozenBaseModel):
+    """Read-time uniqueness settings for a feature."""
+
+    subset: Annotated[tuple[str, ...], BeforeValidator(_validate_unique_subset)] = pydantic.Field(
+        ...,
+        min_length=1,
+        description=(
+            "Columns used to determine uniqueness. Records with identical values in these columns "
+            "are considered duplicates. Repeated column names are ignored after their first occurrence."
+        ),
+    )
+    keep: UniqueKeep = pydantic.Field(
+        default="any",
+        description=(
+            "Strategy for choosing which row to keep among duplicates. "
+            '"any" picks the row with the lexicographically greatest feature ID. '
+            '"latest" keeps the row with the lexicographically greatest order_by values.'
+        ),
+    )
+    order_by: Annotated[tuple[str, ...], BeforeValidator(_validate_unique_order_by)] | None = pydantic.Field(
+        default=None,
+        min_length=1,
+        description=(
+            'Columns defining the logical order of duplicates when keep="latest". '
+            "The lexicographically greatest values win, with feature ID columns as final logical tie-breakers. "
+            "NULL sorts before every non-NULL value. Physical metadata breaks remaining ties; rejecting "
+            "conflicting ties is the writer's responsibility. Repeated column names are ignored after "
+            "their first occurrence."
+        ),
+    )
+
+    @pydantic.model_validator(mode="after")
+    def validate_latest_has_order_by(self) -> Self:
+        if self.keep == "latest" and self.order_by is None:
+            raise ValueError('unique.order_by is required when unique.keep="latest"')
+        if self.keep == "any" and self.order_by is not None:
+            raise ValueError('unique.order_by is only supported when unique.keep="latest"')
+        return self
+
+    if TYPE_CHECKING:
+
+        def __init__(
+            self,
+            *,
+            subset: Sequence[str],
+            keep: UniqueKeep = "any",
+            order_by: Sequence[str] | None = None,
+        ) -> None: ...
+
+    @pydantic.field_serializer("subset", "order_by")
+    @staticmethod
+    def _serialize_columns(value: tuple[str, ...] | None) -> list[str] | None:
+        return list(value) if value is not None else None
+
+
+@public
 class FeatureSpec(FrozenBaseModel):
     key: Annotated[FeatureKey, BeforeValidator(FeatureKeyAdapter.validate_python)]
     id_columns: Annotated[tuple[str, ...], BeforeValidator(_validate_id_columns)] = pydantic.Field(
         ...,
+        min_length=1,
         description="Columns that uniquely identify a sample in this feature.",
     )
     deps: Annotated[list[FeatureDep], BeforeValidator(_validate_deps)] = pydantic.Field(default_factory=list)
@@ -232,6 +309,13 @@ class FeatureSpec(FrozenBaseModel):
         default=None,
         description="Human-readable description of this feature.",
     )
+    unique: Unique | None = pydantic.Field(
+        default=None,
+        description=(
+            "Read-time uniqueness settings applied within the selected feature-version candidate set, "
+            "after read-mode history and soft-deletion resolution and before user filters."
+        ),
+    )
 
     if TYPE_CHECKING:
         # Overload for common case: list of FeatureDep instances
@@ -245,6 +329,7 @@ class FeatureSpec(FrozenBaseModel):
             fields: Sequence[str | FieldSpec] | None = None,
             metadata: dict[str, Any] | None = None,
             description: str | None = None,
+            unique: Unique | Mapping[str, Any] | None = None,
         ) -> None: ...
 
         # Overload for flexible case: list of coercible types
@@ -258,6 +343,7 @@ class FeatureSpec(FrozenBaseModel):
             fields: Sequence[str | FieldSpec] | None = None,
             metadata: dict[str, Any] | None = None,
             description: str | None = None,
+            unique: Unique | Mapping[str, Any] | None = None,
         ) -> None: ...
 
         # Implementation signature
@@ -270,6 +356,7 @@ class FeatureSpec(FrozenBaseModel):
             fields: Sequence[str | FieldSpec] | None = None,
             metadata: dict[str, Any] | None = None,
             description: str | None = None,
+            unique: Unique | Mapping[str, Any] | None = None,
         ) -> None: ...
 
     @cached_property
@@ -311,13 +398,6 @@ class FeatureSpec(FrozenBaseModel):
             seen_keys.add(key_tuple)
         return self
 
-    @pydantic.model_validator(mode="after")
-    def validate_id_columns(self) -> Self:
-        """Validate that id_columns is non-empty if specified."""
-        if self.id_columns is not None and len(self.id_columns) == 0:
-            raise ValueError("id_columns must be non-empty if specified. Use None for default.")
-        return self
-
     @property
     def feature_spec_version(self) -> str:
         """Compute SHA256 hash of the complete feature specification.
@@ -347,6 +427,8 @@ class FeatureSpec(FrozenBaseModel):
         # Use model_dump with mode="json" for deterministic serialization
         # This ensures all types (like FeatureKey) are properly serialized
         spec_dict = self.model_dump(mode="json")
+        if self.unique is None:
+            spec_dict.pop("unique", None)
 
         # Sort keys to ensure deterministic ordering
         spec_json = json.dumps(spec_dict, sort_keys=True)

--- a/tests/ext/clickhouse/test_native.py
+++ b/tests/ext/clickhouse/test_native.py
@@ -18,6 +18,7 @@ from tests.metadata_stores.shared import (
     IbisMapTests,
     MapDtypeTests,
     ResolveUpdateTests,
+    UniqueTests,
     VersioningTests,
     WriteTests,
 )
@@ -46,6 +47,7 @@ class TestClickHouse(
     IbisMapTests,
     MapDtypeTests,
     ResolveUpdateTests,
+    UniqueTests,
     VersioningTests,
     WriteTests,
 ):

--- a/tests/ext/delta/test_native.py
+++ b/tests/ext/delta/test_native.py
@@ -20,6 +20,7 @@ from tests.metadata_stores.shared import (
     FilterTests,
     MapDtypeTests,
     ResolveUpdateTests,
+    UniqueTests,
     VersioningTests,
     WriteTests,
 )
@@ -50,6 +51,7 @@ class TestDelta(
     FilterTests,
     MapDtypeTests,
     ResolveUpdateTests,
+    UniqueTests,
     VersioningTests,
     WriteTests,
 ):

--- a/tests/ext/duckdb/test_ducklake.py
+++ b/tests/ext/duckdb/test_ducklake.py
@@ -15,6 +15,7 @@ from tests.metadata_stores.shared import (
     IbisMapTests,
     MapDtypeTests,
     ResolveUpdateTests,
+    UniqueTests,
     VersioningTests,
     WriteTests,
 )
@@ -32,6 +33,7 @@ class TestDuckDBDuckLake(
     IbisMapTests,
     MapDtypeTests,
     ResolveUpdateTests,
+    UniqueTests,
     VersioningTests,
     WriteTests,
 ):

--- a/tests/ext/duckdb/test_native.py
+++ b/tests/ext/duckdb/test_native.py
@@ -24,6 +24,7 @@ from tests.metadata_stores.shared import (
     IbisMapTests,
     MapDtypeTests,
     ResolveUpdateTests,
+    UniqueTests,
     VersioningTests,
     WriteTests,
 )
@@ -58,6 +59,7 @@ class TestDuckDB(
     IbisMapTests,
     MapDtypeTests,
     ResolveUpdateTests,
+    UniqueTests,
     VersioningTests,
     WriteTests,
 ):

--- a/tests/ext/postgres/test_native.py
+++ b/tests/ext/postgres/test_native.py
@@ -25,6 +25,7 @@ from tests.metadata_stores.shared import (
     DisplayTests,
     FilterTests,
     ResolveUpdateTests,
+    UniqueTests,
     VersioningTests,
     WriteTests,
 )
@@ -39,6 +40,7 @@ class TestPostgreSQL(
     DisplayTests,
     FilterTests,
     ResolveUpdateTests,
+    UniqueTests,
     VersioningTests,
     WriteTests,
 ):
@@ -1096,6 +1098,7 @@ def test_postgresql_read_missing_feature_schema_decodes_system_columns(
                 with_feature_history=True,
                 with_sample_history=True,
                 include_soft_deleted=True,
+                apply_unique=False,
             )
         ).sort("sample_uid")
 
@@ -1143,6 +1146,7 @@ def test_postgresql_read_missing_feature_schema_fails_fast_on_invalid_system_jso
                 with_feature_history=True,
                 with_sample_history=True,
                 include_soft_deleted=True,
+                apply_unique=False,
             )
 
 
@@ -1179,6 +1183,7 @@ def test_postgresql_read_missing_feature_schema_allows_all_null_system_json(
                 with_feature_history=True,
                 with_sample_history=True,
                 include_soft_deleted=True,
+                apply_unique=False,
             )
         ).sort("sample_uid")
 
@@ -1221,6 +1226,7 @@ def test_postgresql_read_missing_feature_schema_all_null_system_json_auto_cast_m
                 with_feature_history=True,
                 with_sample_history=True,
                 include_soft_deleted=True,
+                apply_unique=False,
             )
         ).sort("sample_uid")
         assert result["sample_uid"].to_list() == [1, 2]
@@ -1312,6 +1318,7 @@ def test_postgresql_read_missing_feature_schema_empty_result_returns_empty(
                 with_feature_history=True,
                 with_sample_history=True,
                 include_soft_deleted=True,
+                apply_unique=False,
             )
         )
         assert result.is_empty()
@@ -1350,6 +1357,7 @@ def test_postgresql_read_missing_feature_schema_filter_to_zero_rows_returns_empt
                 with_feature_history=True,
                 with_sample_history=True,
                 include_soft_deleted=True,
+                apply_unique=False,
             )
         )
         assert result.is_empty()
@@ -1379,6 +1387,7 @@ def test_postgresql_read_missing_required_system_columns_raises_schema_error(
                 with_feature_history=True,
                 with_sample_history=True,
                 include_soft_deleted=True,
+                apply_unique=False,
             )
 
 

--- a/tests/ext/ray/test_datasource.py
+++ b/tests/ext/ray/test_datasource.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import patch
 
 import metaxy as mx
 import narwhals as nw
@@ -168,6 +169,27 @@ def test_datasource_stores_config(
 
     assert datasource.store is delta_store
     assert datasource.config is ray_config
+
+
+def test_datasource_forwards_apply_unique(
+    ray_config: mx.MetaxyConfig,
+    delta_store: DeltaMetadataStore,
+):
+    """The Ray wrapper exposes MetadataStore.read's uniqueness escape hatch."""
+    from metaxy.ext.ray.datasource import MetaxyDatasource
+
+    lazy_frame = nw.from_native(pl.DataFrame({"sample_uid": []}).lazy())
+    datasource = MetaxyDatasource(
+        feature=FEATURE_KEY,
+        store=delta_store,
+        config=ray_config,
+        apply_unique=False,
+    )
+
+    with patch.object(delta_store, "read", return_value=lazy_frame) as read:
+        assert datasource._read_lazy() is lazy_frame
+
+    assert read.call_args.kwargs["apply_unique"] is False
 
 
 def test_datasource_with_filters(

--- a/tests/ext/sqlmodel/__snapshots__/test_native.ambr
+++ b/tests/ext/sqlmodel/__snapshots__/test_native.ambr
@@ -4,11 +4,11 @@
 # ---
 # name: test_composite_key_multiple_columns
   dict({
-    'id_columns': list([
+    'id_columns': tuple(
       'user_id',
       'session_id',
       'timestamp',
-    ]),
+    ),
     'metaxy_feature_version': '70c01863',
     'metaxy_provenance_by_field': dict({
       'event': '0e1c4ff5',

--- a/tests/ext/sqlmodel/test_native.py
+++ b/tests/ext/sqlmodel/test_native.py
@@ -30,6 +30,7 @@ from metaxy.ext.sqlmodel import BaseSQLModelFeature
 from metaxy.models.feature import FeatureGraph
 from metaxy.utils import collect_to_polars
 from metaxy_testing.models import SampleFeatureSpec
+from pydantic import ValidationError
 from sqlmodel import Field
 from syrupy.assertion import SnapshotAssertion
 
@@ -758,15 +759,11 @@ def test_basic_custom_id_columns() -> None:
         timestamp: int
 
     # Verify id_columns are set correctly
-    assert UserSessionFeature.spec().id_columns == ["user_id", "session_id"]
+    assert UserSessionFeature.spec().id_columns == ("user_id", "session_id")
 
     # Verify feature is registered
     graph = FeatureGraph.get_active()
     assert FeatureKey(["user", "session"]) in graph.feature_definitions_by_key
-
-    # Verify spec has custom id_columns
-    assert UserSessionFeature.spec().id_columns == ["user_id", "session_id"]
-    assert UserSessionFeature.spec().id_columns == ["user_id", "session_id"]
 
 
 def test_sqlmodel_duckdb_custom_id_columns(tmp_path: Path, snapshot: SnapshotAssertion) -> None:
@@ -957,7 +954,7 @@ def test_composite_key_multiple_columns(snapshot: SnapshotAssertion) -> None:
         metric: float
 
     # Verify 3-column composite key
-    assert MultiKeyFeature.spec().id_columns == ["user_id", "session_id", "timestamp"]
+    assert MultiKeyFeature.spec().id_columns == ("user_id", "session_id", "timestamp")
 
     # Verify feature version is deterministic
     version = MultiKeyFeature.feature_version()
@@ -1018,12 +1015,8 @@ def test_parent_child_different_id_columns() -> None:
         summary: str
 
     # Verify different ID columns
-    assert DetailedParentFeature.spec().id_columns == [
-        "user_id",
-        "session_id",
-        "device_id",
-    ]
-    assert AggregatedChildFeature.spec().id_columns == ["user_id", "session_id"]
+    assert DetailedParentFeature.spec().id_columns == ("user_id", "session_id", "device_id")
+    assert AggregatedChildFeature.spec().id_columns == ("user_id", "session_id")
 
     # Both should be registered
     graph = FeatureGraph.get_active()
@@ -1193,7 +1186,7 @@ def test_sqlmodel_empty_id_columns_raises() -> None:
     - Appropriate error message is raised
     """
 
-    with pytest.raises(ValueError, match="id_columns must be non-empty"):
+    with pytest.raises(ValidationError, match="at least 1 item"):
 
         class InvalidFeature(
             SQLModelFeature,

--- a/tests/ext/sqlmodel/test_native.py
+++ b/tests/ext/sqlmodel/test_native.py
@@ -30,6 +30,7 @@ from metaxy.ext.sqlmodel import BaseSQLModelFeature
 from metaxy.models.feature import FeatureGraph
 from metaxy.utils import collect_to_polars
 from metaxy_testing.models import SampleFeatureSpec
+from pydantic import ValidationError
 from sqlmodel import Field
 from syrupy.assertion import SnapshotAssertion
 
@@ -725,7 +726,7 @@ def test_sqlmodel_feature_with_duckdb_store(tmp_path: Path, snapshot: SnapshotAs
         assert all(v == VideoFeature.feature_version() for v in result_df["metaxy_feature_version"].to_list())
 
         # Snapshot result (exclude timestamps which vary between runs)
-        result_for_snapshot = result_df.drop("metaxy_created_at", "metaxy_updated_at").to_dicts()
+        result_for_snapshot = result_df.sort("sample_uid").drop("metaxy_created_at", "metaxy_updated_at").to_dicts()
         assert result_for_snapshot == snapshot
 
 
@@ -758,15 +759,11 @@ def test_basic_custom_id_columns() -> None:
         timestamp: int
 
     # Verify id_columns are set correctly
-    assert UserSessionFeature.spec().id_columns == ["user_id", "session_id"]
+    assert UserSessionFeature.spec().id_columns == ("user_id", "session_id")
 
     # Verify feature is registered
     graph = FeatureGraph.get_active()
     assert FeatureKey(["user", "session"]) in graph.feature_definitions_by_key
-
-    # Verify spec has custom id_columns
-    assert UserSessionFeature.spec().id_columns == ["user_id", "session_id"]
-    assert UserSessionFeature.spec().id_columns == ["user_id", "session_id"]
 
 
 def test_sqlmodel_duckdb_custom_id_columns(tmp_path: Path, snapshot: SnapshotAssertion) -> None:
@@ -957,7 +954,7 @@ def test_composite_key_multiple_columns(snapshot: SnapshotAssertion) -> None:
         metric: float
 
     # Verify 3-column composite key
-    assert MultiKeyFeature.spec().id_columns == ["user_id", "session_id", "timestamp"]
+    assert MultiKeyFeature.spec().id_columns == ("user_id", "session_id", "timestamp")
 
     # Verify feature version is deterministic
     version = MultiKeyFeature.feature_version()
@@ -1018,12 +1015,8 @@ def test_parent_child_different_id_columns() -> None:
         summary: str
 
     # Verify different ID columns
-    assert DetailedParentFeature.spec().id_columns == [
-        "user_id",
-        "session_id",
-        "device_id",
-    ]
-    assert AggregatedChildFeature.spec().id_columns == ["user_id", "session_id"]
+    assert DetailedParentFeature.spec().id_columns == ("user_id", "session_id", "device_id")
+    assert AggregatedChildFeature.spec().id_columns == ("user_id", "session_id")
 
     # Both should be registered
     graph = FeatureGraph.get_active()
@@ -1193,7 +1186,7 @@ def test_sqlmodel_empty_id_columns_raises() -> None:
     - Appropriate error message is raised
     """
 
-    with pytest.raises(ValueError, match="id_columns must be non-empty"):
+    with pytest.raises(ValidationError, match="at least 1 item"):
 
         class InvalidFeature(
             SQLModelFeature,

--- a/tests/metadata_stores/core/test_deduplicate_by.py
+++ b/tests/metadata_stores/core/test_deduplicate_by.py
@@ -1,0 +1,432 @@
+"""Tests for FeatureSpec.unique runtime deduplication in the read path."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import narwhals as nw
+import polars as pl
+import pytest
+from metaxy import FeatureGraph, FieldKey, FieldSpec, Unique
+from metaxy.ext.polars.handlers.delta import DeltaMetadataStore
+from metaxy.metadata_store.base import MetadataStore
+from metaxy.models.constants import (
+    ALL_SYSTEM_COLUMNS,
+    METAXY_CREATED_AT,
+    METAXY_DELETED_AT,
+    METAXY_MATERIALIZATION_ID,
+    METAXY_UPDATED_AT,
+)
+from metaxy.utils import collect_to_polars
+from metaxy_testing.models import SampleFeature, SampleFeatureSpec
+
+
+@contextmanager
+def fixed_transaction_time(store: MetadataStore, timestamp: datetime) -> Iterator[None]:
+    """Set a deterministic transaction timestamp for writes within this context."""
+    store._transaction_timestamp = timestamp  # noqa: SLF001
+    try:
+        yield
+    finally:
+        store._transaction_timestamp = None  # noqa: SLF001
+
+
+# ========== Fixtures ==========
+
+
+@pytest.fixture
+def feature_factory(graph: FeatureGraph) -> Callable[..., type[SampleFeature]]:
+    _ = graph
+
+    def build_feature(
+        *,
+        key: str,
+        unique: Unique | None = None,
+    ) -> type[SampleFeature]:
+        class TestFeature(
+            SampleFeature,
+            spec=SampleFeatureSpec(
+                key=key,
+                fields=[FieldSpec(key=FieldKey(["default"]), code_version="1")],
+                unique=unique,
+            ),
+        ):
+            content_hash: str | None = None
+
+        return TestFeature
+
+    return build_feature
+
+
+@pytest.fixture
+def dedup_feature(feature_factory: Callable[..., type[SampleFeature]]) -> type[SampleFeature]:
+    return feature_factory(key="test/deduplicated", unique=Unique(subset=("content_hash",)))
+
+
+@pytest.fixture
+def no_dedup_feature(feature_factory: Callable[..., type[SampleFeature]]) -> type[SampleFeature]:
+    return feature_factory(key="test/no_dedup")
+
+
+@pytest.fixture
+def delta_store(tmp_path: Path) -> DeltaMetadataStore:
+    return DeltaMetadataStore(root_path=tmp_path / "delta")
+
+
+def _make_data(rows: list[dict[str, Any]]) -> pl.DataFrame:
+    return pl.DataFrame(
+        [{**row, "metaxy_provenance_by_field": {"default": f"prov_{row['sample_uid']}"}} for row in rows]
+    )
+
+
+@pytest.fixture
+def data_factory() -> Callable[[list[dict[str, Any]]], pl.DataFrame]:
+    return _make_data
+
+
+@pytest.fixture
+def three_rows_data(data_factory: Callable[[list[dict[str, Any]]], pl.DataFrame]) -> pl.DataFrame:
+    return data_factory(
+        [
+            {"sample_uid": "s1", "content_hash": "aaa"},
+            {"sample_uid": "s2", "content_hash": "aaa"},
+            {"sample_uid": "s3", "content_hash": "bbb"},
+        ]
+    )
+
+
+@pytest.fixture
+def two_duplicate_rows_data(data_factory: Callable[[list[dict[str, Any]]], pl.DataFrame]) -> pl.DataFrame:
+    return data_factory(
+        [
+            {"sample_uid": "s1", "content_hash": "aaa"},
+            {"sample_uid": "s2", "content_hash": "aaa"},
+        ]
+    )
+
+
+def _write_and_read(
+    store: DeltaMetadataStore,
+    feature: type[SampleFeature],
+    data: pl.DataFrame,
+    /,
+    **read_kwargs: Any,
+) -> pl.DataFrame:
+    with store.open("w"):
+        store.write(feature, data)
+        return collect_to_polars(store.read(feature, **read_kwargs))
+
+
+# ========== _internal_read_columns unit tests ==========
+
+
+@pytest.mark.parametrize(
+    ("columns", "additional_columns", "target_column"),
+    [
+        pytest.param(["metaxy_feature_version"], None, "metaxy_feature_version", id="user-column-overlaps-system"),
+        pytest.param(["content_hash"], ["content_hash"], "content_hash", id="user-column-overlaps-unique"),
+        pytest.param(["col1"], ["metaxy_feature_version"], "metaxy_feature_version", id="unique-overlaps-system"),
+    ],
+)
+def test_internal_read_columns_avoids_duplicates(
+    columns: list[str],
+    additional_columns: list[str] | None,
+    target_column: str,
+) -> None:
+    result = MetadataStore._internal_read_columns(columns, additional_columns=additional_columns)
+    assert result.count(target_column) == 1
+
+
+class TestInternalReadColumns:
+    """Unit tests for MetadataStore._internal_read_columns."""
+
+    def test_adds_missing_system_columns(self) -> None:
+        result = MetadataStore._internal_read_columns(["col1"])
+        for sys_col in ALL_SYSTEM_COLUMNS:
+            assert sys_col in result
+
+    def test_preserves_user_column_order(self) -> None:
+        result = MetadataStore._internal_read_columns(["b", "a", "c"])
+        assert result[:3] == ["b", "a", "c"]
+
+    def test_adds_additional_columns(self) -> None:
+        result = MetadataStore._internal_read_columns(["col1"], additional_columns=["dedup_col"])
+        assert "dedup_col" in result
+
+    def test_none_additional_columns_equivalent_to_omitted(self) -> None:
+        assert MetadataStore._internal_read_columns(
+            ["col1"], additional_columns=None
+        ) == MetadataStore._internal_read_columns(["col1"])
+
+    def test_deduplicates_additional_columns_while_preserving_order(self) -> None:
+        result = MetadataStore._internal_read_columns(
+            ["col1"],
+            additional_columns=["sample_uid", "sample_uid", "dedup_col"],
+        )
+        assert result.count("sample_uid") == 1
+        assert result[-2:] == ["sample_uid", "dedup_col"]
+
+
+def test_apply_unique_preserves_subset_order_for_any(
+    graph: FeatureGraph,
+    delta_store: DeltaMetadataStore,
+) -> None:
+    class OrderedUniqueFeature(
+        SampleFeature,
+        spec=SampleFeatureSpec(
+            key="test/ordered_unique_any",
+            unique=Unique(subset=("secondary_key", "primary_key")),
+        ),
+    ):
+        primary_key: str | None = None
+        secondary_key: str | None = None
+
+    lazy_frame = nw.from_native(pl.DataFrame([{"sample_uid": "s1", "primary_key": "a", "secondary_key": "b"}]).lazy())
+    plan = graph.get_feature_plan(OrderedUniqueFeature.spec().key)
+    captured: dict[str, Any] = {}
+
+    def fake_unique(
+        self: nw.LazyFrame[Any],
+        subset: str | list[str] | None = None,
+        *,
+        keep: str = "any",
+        order_by: str | list[str] | None = None,
+    ) -> nw.LazyFrame[Any]:
+        captured["subset"] = subset
+        captured["keep"] = keep
+        captured["order_by"] = order_by
+        return self
+
+    with patch.object(type(lazy_frame), "unique", autospec=True, side_effect=fake_unique):
+        result = delta_store._apply_unique(lazy_frame, plan=plan)
+
+    assert result is lazy_frame
+    assert captured == {
+        "subset": ["secondary_key", "primary_key"],
+        "keep": "last",
+        "order_by": [
+            METAXY_DELETED_AT,
+            METAXY_UPDATED_AT,
+            METAXY_CREATED_AT,
+            METAXY_MATERIALIZATION_ID,
+            "sample_uid",
+        ],
+    }
+
+
+def test_apply_unique_preserves_subset_order_for_latest(
+    graph: FeatureGraph,
+    delta_store: DeltaMetadataStore,
+) -> None:
+    class OrderedLatestFeature(
+        SampleFeature,
+        spec=SampleFeatureSpec(
+            key="test/ordered_unique_latest",
+            unique=Unique(subset=("secondary_key", "primary_key"), keep="latest"),
+        ),
+    ):
+        primary_key: str | None = None
+        secondary_key: str | None = None
+
+    lazy_frame = nw.from_native(pl.DataFrame([{"sample_uid": "s1", "primary_key": "a", "secondary_key": "b"}]).lazy())
+    plan = graph.get_feature_plan(OrderedLatestFeature.spec().key)
+    captured: dict[str, Any] = {}
+
+    def fake_keep_latest_by_group(
+        df: nw.LazyFrame[Any],
+        group_columns: list[str],
+        timestamp_columns: list[str],
+    ) -> nw.LazyFrame[Any]:
+        captured["group_columns"] = group_columns
+        captured["timestamp_columns"] = timestamp_columns
+        return df
+
+    with patch.object(delta_store.versioning_engine_cls, "keep_latest_by_group", side_effect=fake_keep_latest_by_group):
+        result = delta_store._apply_unique(lazy_frame, plan=plan)
+
+    assert result is lazy_frame
+    assert captured == {
+        "group_columns": ["secondary_key", "primary_key"],
+        "timestamp_columns": [METAXY_UPDATED_AT],
+    }
+
+
+def test_apply_unique_rejects_unsupported_keep(delta_store: DeltaMetadataStore) -> None:
+    lazy_frame = nw.from_native(pl.DataFrame([{"sample_uid": "s1", "content_hash": "aaa"}]).lazy())
+    invalid_plan = SimpleNamespace(
+        feature=SimpleNamespace(unique=Unique.model_construct(subset=("content_hash",), keep="unsupported"))
+    )
+
+    with pytest.raises(ValueError, match="Unsupported unique.keep value"):
+        delta_store._apply_unique(lazy_frame, plan=invalid_plan)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+
+
+# ========== Integration tests ==========
+
+
+def test_unique_removes_content_duplicates(
+    dedup_feature: type[SampleFeature],
+    delta_store: DeltaMetadataStore,
+    three_rows_data: pl.DataFrame,
+) -> None:
+    result = _write_and_read(delta_store, dedup_feature, three_rows_data)
+
+    assert len(result) == 2
+    assert set(result["content_hash"].to_list()) == {"aaa", "bbb"}
+
+
+def test_unique_none_keeps_all_rows(
+    no_dedup_feature: type[SampleFeature],
+    delta_store: DeltaMetadataStore,
+    three_rows_data: pl.DataFrame,
+) -> None:
+    result = _write_and_read(delta_store, no_dedup_feature, three_rows_data)
+
+    assert len(result) == 3
+
+
+def test_unique_applied_with_sample_history(
+    dedup_feature: type[SampleFeature],
+    delta_store: DeltaMetadataStore,
+    two_duplicate_rows_data: pl.DataFrame,
+) -> None:
+    with delta_store.open("w"):
+        delta_store.write(dedup_feature, two_duplicate_rows_data)
+        result = collect_to_polars(delta_store.read(dedup_feature, with_sample_history=True))
+
+    assert len(result) == 1
+
+
+def test_unique_can_be_disabled_explicitly(
+    dedup_feature: type[SampleFeature],
+    delta_store: DeltaMetadataStore,
+    two_duplicate_rows_data: pl.DataFrame,
+) -> None:
+    with delta_store.open("w"):
+        delta_store.write(dedup_feature, two_duplicate_rows_data)
+        result = collect_to_polars(delta_store.read(dedup_feature, with_sample_history=True, apply_unique=False))
+
+    assert len(result) == 2
+
+
+def test_unique_applied_with_include_soft_deleted(
+    dedup_feature: type[SampleFeature],
+    delta_store: DeltaMetadataStore,
+    two_duplicate_rows_data: pl.DataFrame,
+) -> None:
+    """Unique is a feature property and is applied even when include_soft_deleted=True."""
+    result = _write_and_read(delta_store, dedup_feature, two_duplicate_rows_data, include_soft_deleted=True)
+
+    assert len(result) == 1
+
+
+def test_unique_stable_after_soft_delete(
+    feature_factory: Callable[..., type[SampleFeature]],
+    delta_store: DeltaMetadataStore,
+    data_factory: Callable[[list[dict[str, Any]]], pl.DataFrame],
+) -> None:
+    """Unique still collapses duplicates when one sample has been soft-deleted."""
+    feature = feature_factory(key="test/dedup_soft", unique=Unique(subset=("content_hash",)))
+
+    with delta_store.open("w"):
+        delta_store.write(
+            feature,
+            data_factory(
+                [
+                    {"sample_uid": "s1", "content_hash": "unique_hash"},
+                    {"sample_uid": "s2", "content_hash": "shared"},
+                    {"sample_uid": "s3", "content_hash": "shared"},
+                ]
+            ),
+        )
+        delta_store.delete(feature, filters=nw.col("sample_uid") == "s1", soft=True)
+        result = collect_to_polars(delta_store.read(feature))
+
+    assert len(result) == 1
+    assert result["content_hash"].to_list() == ["shared"]
+
+
+def test_unique_works_with_column_projection(
+    dedup_feature: type[SampleFeature],
+    delta_store: DeltaMetadataStore,
+    three_rows_data: pl.DataFrame,
+) -> None:
+    result = _write_and_read(delta_store, dedup_feature, three_rows_data, columns=["sample_uid"])
+
+    assert len(result) == 2
+    assert "content_hash" not in result.columns
+
+
+def test_unique_works_with_column_projection_excluding_id_columns(
+    dedup_feature: type[SampleFeature],
+    delta_store: DeltaMetadataStore,
+    three_rows_data: pl.DataFrame,
+) -> None:
+    result = _write_and_read(delta_store, dedup_feature, three_rows_data, columns=["content_hash"])
+
+    assert len(result) == 2
+    assert result.columns == ["content_hash"]
+    assert set(result["content_hash"].to_list()) == {"aaa", "bbb"}
+
+
+def test_unique_works_with_column_projection_and_sample_history(
+    dedup_feature: type[SampleFeature],
+    delta_store: DeltaMetadataStore,
+    two_duplicate_rows_data: pl.DataFrame,
+) -> None:
+    result = _write_and_read(
+        delta_store,
+        dedup_feature,
+        two_duplicate_rows_data,
+        with_sample_history=True,
+        columns=["sample_uid"],
+    )
+
+    assert len(result) == 1
+    assert result.columns == ["sample_uid"]
+
+
+def test_unique_works_with_column_projection_and_sample_history_without_id_columns(
+    dedup_feature: type[SampleFeature],
+    delta_store: DeltaMetadataStore,
+    two_duplicate_rows_data: pl.DataFrame,
+) -> None:
+    result = _write_and_read(
+        delta_store,
+        dedup_feature,
+        two_duplicate_rows_data,
+        with_sample_history=True,
+        columns=["content_hash"],
+    )
+
+    assert len(result) == 1
+    assert result.columns == ["content_hash"]
+
+
+def test_unique_keep_latest(
+    feature_factory: Callable[..., type[SampleFeature]],
+    delta_store: DeltaMetadataStore,
+    data_factory: Callable[[list[dict[str, Any]]], pl.DataFrame],
+) -> None:
+    latest_feature = feature_factory(
+        key="test/dedup_latest",
+        unique=Unique(subset=("content_hash",), keep="latest"),
+    )
+
+    t0 = datetime(2025, 1, 1, tzinfo=timezone.utc)
+
+    with delta_store.open("w"), fixed_transaction_time(delta_store, t0):
+        delta_store.write(latest_feature, data_factory([{"sample_uid": "s1", "content_hash": "aaa"}]))
+
+    with delta_store.open("w"), fixed_transaction_time(delta_store, t0 + timedelta(seconds=1)):
+        delta_store.write(latest_feature, data_factory([{"sample_uid": "s2", "content_hash": "aaa"}]))
+        result = collect_to_polars(delta_store.read(latest_feature))
+
+    assert len(result) == 1
+    assert result["sample_uid"].to_list() == ["s2"]

--- a/tests/metadata_stores/core/test_unique.py
+++ b/tests/metadata_stores/core/test_unique.py
@@ -1,0 +1,622 @@
+"""Tests for FeatureSpec.unique runtime behavior."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import narwhals as nw
+import polars as pl
+import pytest
+from metaxy import FeatureGraph, FieldKey, FieldSpec, Unique
+from metaxy.ext.polars.handlers.delta import DeltaMetadataStore
+from metaxy.metadata_store.base import MetadataStore
+from metaxy.models.constants import (
+    ALL_SYSTEM_COLUMNS,
+    METAXY_CREATED_AT,
+    METAXY_DATA_VERSION,
+    METAXY_DELETED_AT,
+    METAXY_FEATURE_VERSION,
+    METAXY_MATERIALIZATION_ID,
+    METAXY_PROJECT_VERSION,
+    METAXY_PROVENANCE,
+    METAXY_UPDATED_AT,
+)
+from metaxy.utils import collect_to_polars
+from metaxy.utils.constants import TEMP_TABLE_NAME
+from metaxy_testing.models import SampleFeature, SampleFeatureSpec
+
+# ========== Fixtures ==========
+
+
+@pytest.fixture
+def feature_factory(graph: FeatureGraph) -> Callable[..., type[SampleFeature]]:
+    _ = graph
+
+    def build_feature(
+        *,
+        key: str,
+        unique: Unique | None = None,
+    ) -> type[SampleFeature]:
+        class TestFeature(
+            SampleFeature,
+            spec=SampleFeatureSpec(
+                key=key,
+                fields=[FieldSpec(key=FieldKey(["default"]), code_version="1")],
+                unique=unique,
+            ),
+        ):
+            content_hash: str | None = None
+            ordinal: int | None = None
+            status: str | None = None
+            value: str | None = None
+
+        return TestFeature
+
+    return build_feature
+
+
+@pytest.fixture
+def dedup_feature(feature_factory: Callable[..., type[SampleFeature]]) -> type[SampleFeature]:
+    return feature_factory(key="test/deduplicated", unique=Unique(subset=("content_hash",)))
+
+
+@pytest.fixture
+def no_dedup_feature(feature_factory: Callable[..., type[SampleFeature]]) -> type[SampleFeature]:
+    return feature_factory(key="test/no_dedup")
+
+
+@pytest.fixture
+def delta_store(tmp_path: Path) -> DeltaMetadataStore:
+    return DeltaMetadataStore(root_path=tmp_path / "delta")
+
+
+def _make_data(rows: list[dict[str, Any]]) -> pl.DataFrame:
+    return pl.DataFrame(
+        [{**row, "metaxy_provenance_by_field": {"default": f"prov_{row['sample_uid']}"}} for row in rows]
+    )
+
+
+@pytest.fixture
+def data_factory() -> Callable[[list[dict[str, Any]]], pl.DataFrame]:
+    return _make_data
+
+
+@pytest.fixture
+def three_rows_data(data_factory: Callable[[list[dict[str, Any]]], pl.DataFrame]) -> pl.DataFrame:
+    return data_factory(
+        [
+            {"sample_uid": "s1", "content_hash": "aaa"},
+            {"sample_uid": "s2", "content_hash": "aaa"},
+            {"sample_uid": "s3", "content_hash": "bbb"},
+        ]
+    )
+
+
+@pytest.fixture
+def two_duplicate_rows_data(data_factory: Callable[[list[dict[str, Any]]], pl.DataFrame]) -> pl.DataFrame:
+    return data_factory(
+        [
+            {"sample_uid": "s1", "content_hash": "aaa"},
+            {"sample_uid": "s2", "content_hash": "aaa"},
+        ]
+    )
+
+
+def _write_and_read(
+    store: DeltaMetadataStore,
+    feature: type[SampleFeature],
+    data: pl.DataFrame,
+    /,
+    **read_kwargs: Any,
+) -> pl.DataFrame:
+    with store.open("w"):
+        store.write(feature, data)
+        return collect_to_polars(store.read(feature, **read_kwargs))
+
+
+# ========== _internal_read_columns unit tests ==========
+
+
+@pytest.mark.parametrize(
+    ("columns", "additional_columns", "target_column"),
+    [
+        pytest.param(["metaxy_feature_version"], None, "metaxy_feature_version", id="user-column-overlaps-system"),
+        pytest.param(["content_hash"], ["content_hash"], "content_hash", id="user-column-overlaps-unique"),
+        pytest.param(["col1"], ["metaxy_feature_version"], "metaxy_feature_version", id="unique-overlaps-system"),
+    ],
+)
+def test_internal_read_columns_avoids_duplicates(
+    columns: list[str],
+    additional_columns: list[str] | None,
+    target_column: str,
+) -> None:
+    result = MetadataStore._internal_read_columns(columns, additional_columns=additional_columns)
+    assert result.count(target_column) == 1
+
+
+class TestInternalReadColumns:
+    """Unit tests for MetadataStore._internal_read_columns."""
+
+    def test_adds_missing_system_columns(self) -> None:
+        result = MetadataStore._internal_read_columns(["col1"])
+        for sys_col in ALL_SYSTEM_COLUMNS:
+            assert sys_col in result
+
+    def test_preserves_user_column_order(self) -> None:
+        result = MetadataStore._internal_read_columns(["b", "a", "c"])
+        assert result[:3] == ["b", "a", "c"]
+
+    def test_adds_additional_columns(self) -> None:
+        result = MetadataStore._internal_read_columns(["col1"], additional_columns=["dedup_col"])
+        assert "dedup_col" in result
+
+    def test_none_additional_columns_equivalent_to_omitted(self) -> None:
+        assert MetadataStore._internal_read_columns(
+            ["col1"], additional_columns=None
+        ) == MetadataStore._internal_read_columns(["col1"])
+
+    def test_deduplicates_additional_columns_while_preserving_order(self) -> None:
+        result = MetadataStore._internal_read_columns(
+            ["col1"],
+            additional_columns=["sample_uid", "sample_uid", "dedup_col"],
+        )
+        assert result.count("sample_uid") == 1
+        assert result[-2:] == ["sample_uid", "dedup_col"]
+
+
+def test_apply_unique_preserves_subset_order_for_any(
+    graph: FeatureGraph,
+    delta_store: DeltaMetadataStore,
+) -> None:
+    class OrderedUniqueFeature(
+        SampleFeature,
+        spec=SampleFeatureSpec(
+            key="test/ordered_unique_any",
+            unique=Unique(subset=("secondary_key", "primary_key")),
+        ),
+    ):
+        primary_key: str | None = None
+        secondary_key: str | None = None
+
+    lazy_frame = nw.from_native(
+        pl.DataFrame(
+            [
+                {
+                    "sample_uid": "s1",
+                    "primary_key": "a",
+                    "secondary_key": "b",
+                    METAXY_DELETED_AT: None,
+                    METAXY_UPDATED_AT: datetime(2025, 1, 1, tzinfo=timezone.utc),
+                }
+            ]
+        ).lazy()
+    )
+    plan = graph.get_feature_plan(OrderedUniqueFeature.spec().key)
+    captured: dict[str, Any] = {}
+
+    def fake_unique(
+        self: nw.LazyFrame[Any],
+        subset: str | list[str] | None = None,
+        *,
+        keep: str = "any",
+        order_by: str | list[str] | None = None,
+    ) -> nw.LazyFrame[Any]:
+        captured["subset"] = subset
+        captured["keep"] = keep
+        captured["order_by"] = order_by
+        return self
+
+    with patch.object(type(lazy_frame), "unique", autospec=True, side_effect=fake_unique):
+        result = delta_store._apply_unique(lazy_frame, plan=plan)
+
+    assert TEMP_TABLE_NAME not in result.collect_schema().names()
+    assert captured == {
+        "subset": ["secondary_key", "primary_key"],
+        "keep": "last",
+        "order_by": [
+            "sample_uid",
+            TEMP_TABLE_NAME,
+            METAXY_DELETED_AT,
+            METAXY_UPDATED_AT,
+            METAXY_DATA_VERSION,
+            METAXY_PROVENANCE,
+            METAXY_FEATURE_VERSION,
+            METAXY_PROJECT_VERSION,
+            METAXY_CREATED_AT,
+            METAXY_MATERIALIZATION_ID,
+        ],
+    }
+
+
+def test_apply_unique_preserves_subset_order_for_latest(
+    graph: FeatureGraph,
+    delta_store: DeltaMetadataStore,
+) -> None:
+    class OrderedLatestFeature(
+        SampleFeature,
+        spec=SampleFeatureSpec(
+            key="test/ordered_unique_latest",
+            unique=Unique(
+                subset=("secondary_key", "primary_key"),
+                keep="latest",
+                order_by=("priority",),
+            ),
+        ),
+    ):
+        primary_key: str | None = None
+        secondary_key: str | None = None
+        priority: int | None = None
+
+    lazy_frame = nw.from_native(
+        pl.DataFrame(
+            [
+                {
+                    "sample_uid": "s1",
+                    "primary_key": "a",
+                    "secondary_key": "b",
+                    "priority": 1,
+                    METAXY_DELETED_AT: None,
+                    METAXY_UPDATED_AT: datetime(2025, 1, 1, tzinfo=timezone.utc),
+                }
+            ]
+        ).lazy()
+    )
+    plan = graph.get_feature_plan(OrderedLatestFeature.spec().key)
+    captured: dict[str, Any] = {}
+
+    def fake_unique(
+        self: nw.LazyFrame[Any],
+        subset: str | list[str] | None = None,
+        *,
+        keep: str = "any",
+        order_by: str | list[str] | None = None,
+    ) -> nw.LazyFrame[Any]:
+        captured["subset"] = subset
+        captured["keep"] = keep
+        captured["order_by"] = order_by
+        return self
+
+    with patch.object(type(lazy_frame), "unique", autospec=True, side_effect=fake_unique):
+        result = delta_store._apply_unique(lazy_frame, plan=plan)
+
+    assert TEMP_TABLE_NAME not in result.collect_schema().names()
+    assert captured == {
+        "subset": ["secondary_key", "primary_key"],
+        "keep": "last",
+        "order_by": [
+            "priority",
+            "sample_uid",
+            TEMP_TABLE_NAME,
+            METAXY_DELETED_AT,
+            METAXY_UPDATED_AT,
+            METAXY_DATA_VERSION,
+            METAXY_PROVENANCE,
+            METAXY_FEATURE_VERSION,
+            METAXY_PROJECT_VERSION,
+            METAXY_CREATED_AT,
+            METAXY_MATERIALIZATION_ID,
+        ],
+    }
+
+
+def test_apply_unique_rejects_unsupported_keep(delta_store: DeltaMetadataStore) -> None:
+    lazy_frame = nw.from_native(pl.DataFrame([{"sample_uid": "s1", "content_hash": "aaa"}]).lazy())
+    invalid_plan = SimpleNamespace(
+        feature=SimpleNamespace(
+            id_columns=("sample_uid",),
+            unique=Unique.model_construct(subset=("content_hash",), keep="unsupported"),
+        )
+    )
+
+    with pytest.raises(ValueError, match="Unsupported unique.keep value"):
+        delta_store._apply_unique(lazy_frame, plan=invalid_plan)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+
+
+# ========== Integration tests ==========
+
+
+def test_unique_removes_content_duplicates(
+    dedup_feature: type[SampleFeature],
+    delta_store: DeltaMetadataStore,
+    three_rows_data: pl.DataFrame,
+) -> None:
+    result = _write_and_read(delta_store, dedup_feature, three_rows_data)
+
+    assert len(result) == 2
+    assert set(result["content_hash"].to_list()) == {"aaa", "bbb"}
+
+
+def test_unique_none_keeps_all_rows(
+    no_dedup_feature: type[SampleFeature],
+    delta_store: DeltaMetadataStore,
+    three_rows_data: pl.DataFrame,
+) -> None:
+    result = _write_and_read(delta_store, no_dedup_feature, three_rows_data)
+
+    assert len(result) == 3
+
+
+def test_unique_applied_with_sample_history(
+    dedup_feature: type[SampleFeature],
+    delta_store: DeltaMetadataStore,
+    two_duplicate_rows_data: pl.DataFrame,
+) -> None:
+    with delta_store.open("w"):
+        delta_store.write(dedup_feature, two_duplicate_rows_data)
+        result = collect_to_polars(
+            delta_store.read(
+                dedup_feature,
+                with_feature_history=True,
+                with_sample_history=True,
+            )
+        )
+
+    assert len(result) == 1
+
+
+def test_unique_can_be_disabled_explicitly(
+    dedup_feature: type[SampleFeature],
+    delta_store: DeltaMetadataStore,
+    two_duplicate_rows_data: pl.DataFrame,
+) -> None:
+    with delta_store.open("w"):
+        delta_store.write(dedup_feature, two_duplicate_rows_data)
+        result = collect_to_polars(delta_store.read(dedup_feature, apply_unique=False))
+
+    assert len(result) == 2
+
+
+def test_unique_applied_with_include_soft_deleted(
+    dedup_feature: type[SampleFeature],
+    delta_store: DeltaMetadataStore,
+    two_duplicate_rows_data: pl.DataFrame,
+) -> None:
+    """Unique is a feature property and is applied even when include_soft_deleted=True."""
+    result = _write_and_read(delta_store, dedup_feature, two_duplicate_rows_data, include_soft_deleted=True)
+
+    assert len(result) == 1
+
+
+def test_live_duplicate_survives_soft_delete(
+    feature_factory: Callable[..., type[SampleFeature]],
+    delta_store: DeltaMetadataStore,
+    data_factory: Callable[[list[dict[str, Any]]], pl.DataFrame],
+) -> None:
+    feature = feature_factory(key="test/dedup_soft", unique=Unique(subset=("content_hash",)))
+
+    with delta_store.open("w"):
+        delta_store.write(
+            feature,
+            data_factory(
+                [
+                    {"sample_uid": "s1", "content_hash": "shared"},
+                    {"sample_uid": "s2", "content_hash": "shared"},
+                ]
+            ),
+        )
+        delta_store.delete(feature, filters=nw.col("sample_uid") == "s2", soft=True)
+        result = collect_to_polars(delta_store.read(feature))
+        historical = collect_to_polars(delta_store.read(feature, with_sample_history=True))
+        including_deleted = collect_to_polars(delta_store.read(feature, include_soft_deleted=True))
+
+    assert len(result) == 1
+    assert result["sample_uid"].to_list() == ["s1"]
+    assert result["content_hash"].to_list() == ["shared"]
+    assert len(historical) == 1
+    assert historical[METAXY_DELETED_AT].is_null().all()
+    assert including_deleted["sample_uid"].to_list() == ["s2"]
+    assert including_deleted[METAXY_DELETED_AT].is_not_null().all()
+
+
+@pytest.mark.parametrize(
+    "unique",
+    [
+        pytest.param(Unique(subset=("content_hash",)), id="any"),
+        pytest.param(
+            Unique(subset=("content_hash",), keep="latest", order_by=("ordinal",)),
+            id="latest",
+        ),
+    ],
+)
+def test_stale_materialization_cannot_hide_current_duplicate(
+    feature_factory: Callable[..., type[SampleFeature]],
+    delta_store: DeltaMetadataStore,
+    data_factory: Callable[[list[dict[str, Any]]], pl.DataFrame],
+    unique: Unique,
+) -> None:
+    feature = feature_factory(key=f"test/dedup_current_{unique.keep}", unique=unique)
+
+    with delta_store.open("w"):
+        delta_store.write(
+            feature,
+            data_factory([{"sample_uid": "s2", "content_hash": "aaa", "ordinal": 1}]),
+            materialization_id="a-first",
+        )
+        delta_store.write(
+            feature,
+            data_factory([{"sample_uid": "s1", "content_hash": "aaa", "ordinal": 2}]),
+            materialization_id="b-second",
+        )
+        delta_store.write(
+            feature,
+            data_factory([{"sample_uid": "s1", "content_hash": "ccc", "ordinal": 3}]),
+            materialization_id="c-third",
+        )
+        result = collect_to_polars(delta_store.read(feature))
+
+    assert dict(zip(result["sample_uid"], result["content_hash"], strict=True)) == {
+        "s1": "ccc",
+        "s2": "aaa",
+    }
+
+
+def test_unique_works_with_column_projection(
+    dedup_feature: type[SampleFeature],
+    delta_store: DeltaMetadataStore,
+    three_rows_data: pl.DataFrame,
+) -> None:
+    result = _write_and_read(delta_store, dedup_feature, three_rows_data, columns=["sample_uid"])
+
+    assert len(result) == 2
+    assert "content_hash" not in result.columns
+
+
+def test_unique_works_with_column_projection_excluding_id_columns(
+    dedup_feature: type[SampleFeature],
+    delta_store: DeltaMetadataStore,
+    three_rows_data: pl.DataFrame,
+) -> None:
+    result = _write_and_read(delta_store, dedup_feature, three_rows_data, columns=["content_hash"])
+
+    assert len(result) == 2
+    assert result.columns == ["content_hash"]
+    assert set(result["content_hash"].to_list()) == {"aaa", "bbb"}
+
+
+def test_unique_works_with_column_projection_and_sample_history(
+    dedup_feature: type[SampleFeature],
+    delta_store: DeltaMetadataStore,
+    two_duplicate_rows_data: pl.DataFrame,
+) -> None:
+    result = _write_and_read(
+        delta_store,
+        dedup_feature,
+        two_duplicate_rows_data,
+        with_sample_history=True,
+        columns=["sample_uid"],
+    )
+
+    assert len(result) == 1
+    assert result.columns == ["sample_uid"]
+
+
+def test_unique_works_with_column_projection_and_sample_history_without_id_columns(
+    dedup_feature: type[SampleFeature],
+    delta_store: DeltaMetadataStore,
+    two_duplicate_rows_data: pl.DataFrame,
+) -> None:
+    result = _write_and_read(
+        delta_store,
+        dedup_feature,
+        two_duplicate_rows_data,
+        with_sample_history=True,
+        columns=["content_hash"],
+    )
+
+    assert len(result) == 1
+    assert result.columns == ["content_hash"]
+
+
+def test_unique_latest_loads_order_by_for_exact_projection(
+    feature_factory: Callable[..., type[SampleFeature]],
+    delta_store: DeltaMetadataStore,
+    data_factory: Callable[[list[dict[str, Any]]], pl.DataFrame],
+) -> None:
+    feature = feature_factory(
+        key="test/dedup_latest_projection",
+        unique=Unique(subset=("content_hash",), keep="latest", order_by=("ordinal",)),
+    )
+    result = _write_and_read(
+        delta_store,
+        feature,
+        data_factory(
+            [
+                {"sample_uid": "s1", "content_hash": "aaa", "ordinal": 2, "value": "winner"},
+                {"sample_uid": "s2", "content_hash": "aaa", "ordinal": 1, "value": "older"},
+            ]
+        ),
+        columns=["value"],
+    )
+
+    assert result.columns == ["value"]
+    assert result["value"].to_list() == ["winner"]
+
+
+def test_unique_latest_applies_filters_after_selection(
+    feature_factory: Callable[..., type[SampleFeature]],
+    delta_store: DeltaMetadataStore,
+    data_factory: Callable[[list[dict[str, Any]]], pl.DataFrame],
+) -> None:
+    feature = feature_factory(
+        key="test/dedup_latest_filter",
+        unique=Unique(subset=("content_hash",), keep="latest", order_by=("ordinal",)),
+    )
+    result = _write_and_read(
+        delta_store,
+        feature,
+        data_factory(
+            [
+                {"sample_uid": "s1", "content_hash": "aaa", "ordinal": 1, "status": "active"},
+                {"sample_uid": "s2", "content_hash": "aaa", "ordinal": 2, "status": "deleted"},
+            ]
+        ),
+        filters=[nw.col("status") == "active"],
+    )
+
+    assert result.is_empty()
+
+
+def test_unique_latest_uses_user_order_before_write_time(
+    feature_factory: Callable[..., type[SampleFeature]],
+    delta_store: DeltaMetadataStore,
+    data_factory: Callable[[list[dict[str, Any]]], pl.DataFrame],
+) -> None:
+    latest_feature = feature_factory(
+        key="test/dedup_latest",
+        unique=Unique(subset=("content_hash",), keep="latest", order_by=("ordinal",)),
+    )
+
+    with delta_store.open("w"):
+        delta_store.write(
+            latest_feature,
+            data_factory([{"sample_uid": "s1", "content_hash": "aaa", "ordinal": 2}]),
+            materialization_id="a-first",
+        )
+
+    with delta_store.open("w"):
+        delta_store.write(
+            latest_feature,
+            data_factory([{"sample_uid": "s2", "content_hash": "aaa", "ordinal": 1}]),
+            materialization_id="z-later",
+        )
+        result = collect_to_polars(delta_store.read(latest_feature))
+
+    assert len(result) == 1
+    assert result["sample_uid"].to_list() == ["s1"]
+
+
+def test_unique_history_without_registered_feature_plan_requires_explicit_raw_read(
+    graph: FeatureGraph,
+    dedup_feature: type[SampleFeature],
+    delta_store: DeltaMetadataStore,
+    two_duplicate_rows_data: pl.DataFrame,
+) -> None:
+    with delta_store.open("w"):
+        delta_store.write(dedup_feature, two_duplicate_rows_data)
+        graph.remove_feature(dedup_feature.spec().key)
+
+        with pytest.raises(
+            RuntimeError,
+            match=r"Cannot apply FeatureSpec\.unique.*set apply_unique=False",
+        ):
+            delta_store.read(
+                dedup_feature.spec().key,
+                with_feature_history=True,
+                with_sample_history=True,
+            )
+
+        raw = collect_to_polars(
+            delta_store.read(
+                dedup_feature.spec().key,
+                with_feature_history=True,
+                with_sample_history=True,
+                apply_unique=False,
+            )
+        )
+
+    assert len(raw) == 2

--- a/tests/metadata_stores/shared/__init__.py
+++ b/tests/metadata_stores/shared/__init__.py
@@ -11,6 +11,7 @@ from .filters import FilterTests
 from .ibis_map import IbisMapTests
 from .map_dtype import MapDtypeTests
 from .resolve_update import ResolveUpdateTests
+from .unique import UniqueTests
 from .versioning import VersioningTests
 from .write import WriteTests
 
@@ -22,6 +23,7 @@ __all__ = [
     "IbisMapTests",
     "MapDtypeTests",
     "ResolveUpdateTests",
+    "UniqueTests",
     "VersioningTests",
     "WriteTests",
 ]

--- a/tests/metadata_stores/shared/unique.py
+++ b/tests/metadata_stores/shared/unique.py
@@ -1,0 +1,408 @@
+"""Shared FeatureSpec.unique tests."""
+
+import narwhals as nw
+import polars as pl
+import pytest
+from metaxy import BaseFeature, FeatureSpec, Unique
+from metaxy.metadata_store import MetadataStore
+from metaxy.models.constants import (
+    METAXY_DELETED_AT,
+    METAXY_FEATURE_VERSION,
+    METAXY_MATERIALIZATION_ID,
+    METAXY_PROJECT_VERSION,
+)
+from metaxy.utils import collect_to_polars
+
+
+def _metadata(rows: list[dict[str, object]]) -> pl.DataFrame:
+    return pl.DataFrame(
+        [
+            {
+                **row,
+                "metaxy_provenance_by_field": {"default": f"prov_{row['id']}"},
+            }
+            for row in rows
+        ]
+    )
+
+
+class UniqueTests:
+    """Backend contract for read-time uniqueness."""
+
+    def test_unique_any_uses_stable_feature_id_order(self, store: MetadataStore) -> None:
+        class StableAnyFeature(
+            BaseFeature,
+            spec=FeatureSpec(
+                key="test/shared_unique_any",
+                id_columns=("id",),
+                unique=Unique(subset=("group",)),
+            ),
+        ):
+            id: str
+            group: str
+            value: str
+
+        with store.open("w"):
+            store.write(
+                StableAnyFeature,
+                _metadata(
+                    [
+                        {"id": "z", "group": "g", "value": "stable-winner"},
+                        {"id": "a", "group": "g", "value": "physical-last"},
+                    ]
+                ),
+            )
+            result = collect_to_polars(
+                store.read(
+                    StableAnyFeature,
+                    columns=["id", "value"],
+                )
+            )
+
+        assert result.to_dicts() == [{"id": "z", "value": "stable-winner"}]
+
+    def test_unique_latest_uses_explicit_order(self, store: MetadataStore) -> None:
+        class OrderedFeature(
+            BaseFeature,
+            spec=FeatureSpec(
+                key="test/shared_unique_latest",
+                id_columns=("group", "ordinal"),
+                unique=Unique(
+                    subset=("group",),
+                    keep="latest",
+                    order_by=("ordinal",),
+                ),
+            ),
+        ):
+            id: str
+            group: str
+            ordinal: int
+            value: str
+
+        with store.open("w"):
+            store.write(
+                OrderedFeature,
+                _metadata(
+                    [
+                        {"id": "winner", "group": "g", "ordinal": 2, "value": "new"},
+                        {"id": "older", "group": "g", "ordinal": 1, "value": "old"},
+                    ]
+                ),
+            )
+            result = collect_to_polars(
+                store.read(
+                    OrderedFeature,
+                    columns=["id", "ordinal", "value"],
+                )
+            )
+            retained = collect_to_polars(
+                store.read(
+                    OrderedFeature,
+                    columns=["id", "ordinal", "value"],
+                    apply_unique=False,
+                )
+            )
+
+        assert result.to_dicts() == [{"id": "winner", "ordinal": 2, "value": "new"}]
+        assert sorted(retained["ordinal"].to_list()) == [1, 2]
+
+    def test_unique_latest_treats_null_order_as_older(self, store: MetadataStore) -> None:
+        class NullableOrderFeature(
+            BaseFeature,
+            spec=FeatureSpec(
+                key="test/shared_unique_latest_null",
+                id_columns=("id",),
+                unique=Unique(
+                    subset=("group",),
+                    keep="latest",
+                    order_by=("ordinal",),
+                ),
+            ),
+        ):
+            id: str
+            group: str
+            ordinal: int | None
+
+        with store.open("w"):
+            store.write(
+                NullableOrderFeature,
+                _metadata(
+                    [
+                        {"id": "ordered", "group": "g", "ordinal": 1},
+                        {"id": "missing", "group": "g", "ordinal": None},
+                    ]
+                ),
+            )
+            result = collect_to_polars(
+                store.read(
+                    NullableOrderFeature,
+                    columns=["id", "ordinal"],
+                )
+            )
+
+        assert result.to_dicts() == [{"id": "ordered", "ordinal": 1}]
+
+    def test_unique_latest_tie_keeps_whole_row(self, store: MetadataStore) -> None:
+        class TiedFeature(
+            BaseFeature,
+            spec=FeatureSpec(
+                key="test/shared_unique_latest_tie",
+                id_columns=("id",),
+                unique=Unique(
+                    subset=("group",),
+                    keep="latest",
+                    order_by=("ordinal",),
+                ),
+            ),
+        ):
+            id: str
+            group: str
+            ordinal: int
+            value: str
+            paired_value: str
+
+        with store.open("w"):
+            store.write(
+                TiedFeature,
+                _metadata(
+                    [
+                        {
+                            "id": "z",
+                            "group": "g",
+                            "ordinal": 1,
+                            "value": "z-value",
+                            "paired_value": "z-pair",
+                        },
+                        {
+                            "id": "a",
+                            "group": "g",
+                            "ordinal": 1,
+                            "value": "a-value",
+                            "paired_value": "a-pair",
+                        },
+                    ]
+                ),
+            )
+            result = collect_to_polars(
+                store.read(
+                    TiedFeature,
+                    columns=["id", "value", "paired_value"],
+                )
+            )
+
+        assert result.to_dicts() == [{"id": "z", "value": "z-value", "paired_value": "z-pair"}]
+
+    def test_current_view_tie_keeps_whole_explicitly_ordered_row(self, store: MetadataStore) -> None:
+        class CurrentTieFeature(
+            BaseFeature,
+            spec=FeatureSpec(
+                key="test/shared_unique_current_tie",
+                id_columns=("id",),
+                unique=Unique(
+                    subset=("group",),
+                    keep="latest",
+                    order_by=("ordinal",),
+                ),
+            ),
+        ):
+            id: str
+            group: str
+            ordinal: int
+            value: str
+            paired_value: str
+
+        with store.open("w"):
+            store.write(
+                CurrentTieFeature,
+                _metadata(
+                    [
+                        {
+                            "id": "same-id",
+                            "group": "g",
+                            "ordinal": 2,
+                            "value": "winner",
+                            "paired_value": "winner-pair",
+                        },
+                        {
+                            "id": "same-id",
+                            "group": "g",
+                            "ordinal": 1,
+                            "value": "physical-last",
+                            "paired_value": "physical-last-pair",
+                        },
+                    ]
+                ),
+            )
+            result = collect_to_polars(
+                store.read(
+                    CurrentTieFeature,
+                    columns=["ordinal", "value", "paired_value"],
+                )
+            )
+            retained = collect_to_polars(
+                store.read(
+                    CurrentTieFeature,
+                    columns=["value", "paired_value"],
+                    apply_unique=False,
+                )
+            )
+
+        assert result.to_dicts() == [
+            {
+                "ordinal": 2,
+                "value": "winner",
+                "paired_value": "winner-pair",
+            }
+        ]
+        assert retained.to_dicts() == [
+            {
+                "value": "winner",
+                "paired_value": "winner-pair",
+            }
+        ]
+
+    def test_unique_history_reappend_uses_recency_after_logical_key(self, store: MetadataStore) -> None:
+        class ReappendFeature(
+            BaseFeature,
+            spec=FeatureSpec(
+                key="test/shared_unique_reappend",
+                id_columns=("id",),
+                unique=Unique(subset=("group",)),
+            ),
+        ):
+            id: str
+            group: str
+            value: str
+
+        with store.open("w"):
+            data = _metadata([{"id": "same-id", "group": "g", "value": "same-value"}])
+            store.write(ReappendFeature, data, materialization_id="a-older")
+            store.write(ReappendFeature, data, materialization_id="z-latest")
+            result = collect_to_polars(
+                store.read(
+                    ReappendFeature,
+                    with_sample_history=True,
+                    columns=[METAXY_MATERIALIZATION_ID],
+                )
+            )
+
+        assert result[METAXY_MATERIALIZATION_ID].to_list() == ["z-latest"]
+
+    def test_unique_history_uses_versions_after_identical_logical_key(self, store: MetadataStore) -> None:
+        class VersionedHistoryFeature(
+            BaseFeature,
+            spec=FeatureSpec(
+                key="test/shared_unique_versioned_history",
+                id_columns=("id",),
+                unique=Unique(subset=("group",)),
+            ),
+        ):
+            id: str
+            group: str
+            value: str
+
+        with store.open("w"):
+            store.write(
+                VersionedHistoryFeature,
+                _metadata(
+                    [
+                        {
+                            "id": "same-id",
+                            "group": "g",
+                            "value": "same-value",
+                            METAXY_FEATURE_VERSION: "version-z",
+                            METAXY_PROJECT_VERSION: "project-z",
+                        },
+                        {
+                            "id": "same-id",
+                            "group": "g",
+                            "value": "same-value",
+                            METAXY_FEATURE_VERSION: "version-a",
+                            METAXY_PROJECT_VERSION: "project-a",
+                        },
+                    ]
+                ),
+                preserve_feature_version=True,
+            )
+            result = collect_to_polars(
+                store.read(
+                    VersionedHistoryFeature,
+                    with_feature_history=True,
+                    with_sample_history=True,
+                    columns=[METAXY_FEATURE_VERSION, METAXY_PROJECT_VERSION],
+                )
+            )
+            retained = collect_to_polars(
+                store.read(
+                    VersionedHistoryFeature,
+                    with_feature_history=True,
+                    apply_unique=False,
+                    columns=[METAXY_FEATURE_VERSION, METAXY_PROJECT_VERSION],
+                )
+            )
+
+        assert result.select(METAXY_FEATURE_VERSION, METAXY_PROJECT_VERSION).to_dicts() == [
+            {
+                METAXY_FEATURE_VERSION: "version-z",
+                METAXY_PROJECT_VERSION: "project-z",
+            }
+        ]
+        assert sorted(retained[METAXY_FEATURE_VERSION].to_list()) == [
+            "version-a",
+            "version-z",
+        ]
+
+    @pytest.mark.parametrize(
+        "unique",
+        [
+            pytest.param(Unique(subset=("group",)), id="any"),
+            pytest.param(
+                Unique(
+                    subset=("group",),
+                    keep="latest",
+                    order_by=("ordinal",),
+                ),
+                id="latest",
+            ),
+        ],
+    )
+    def test_unique_soft_delete_contract(self, store: MetadataStore, unique: Unique) -> None:
+        class SoftDeleteFeature(
+            BaseFeature,
+            spec=FeatureSpec(
+                key=f"test/shared_unique_soft_delete_{unique.keep}",
+                id_columns=("id",),
+                unique=unique,
+            ),
+        ):
+            id: str
+            group: str
+            ordinal: int
+
+        with store.open("w"):
+            store.write(
+                SoftDeleteFeature,
+                _metadata(
+                    [
+                        {"id": "a-live", "group": "g", "ordinal": 1},
+                        {"id": "z-deleted", "group": "g", "ordinal": 2},
+                    ]
+                ),
+            )
+            store.delete(
+                SoftDeleteFeature,
+                filters=nw.col("id") == "z-deleted",
+                soft=True,
+            )
+            result = collect_to_polars(store.read(SoftDeleteFeature, columns=["id"]))
+            including_deleted = collect_to_polars(
+                store.read(
+                    SoftDeleteFeature,
+                    columns=["id", METAXY_DELETED_AT],
+                    include_soft_deleted=True,
+                )
+            )
+
+        assert result["id"].to_list() == ["a-live"]
+        assert including_deleted["id"].to_list() == ["z-deleted"]
+        assert including_deleted[METAXY_DELETED_AT].is_not_null().all()

--- a/tests/metaxy_testing/src/metaxy_testing/models.py
+++ b/tests/metaxy_testing/src/metaxy_testing/models.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
         CoercibleToFeatureDep,
         FeatureDep,
         IDColumns,
+        Unique,
     )
     from metaxy.models.types import CoercibleToFeatureKey
     from pydantic.types import JsonValue
@@ -27,29 +28,32 @@ if TYPE_CHECKING:
 
 # Type aliases
 DefaultFeatureCols: TypeAlias = tuple[Literal["sample_uid"],]
-TestingUIDCols: TypeAlias = list[str]
+TestingUIDCols: TypeAlias = tuple[str, ...]
 
 
 def _validate_sample_feature_spec_id_columns(
     value: Any,
-) -> list[str]:
-    """Coerce id_columns to list for SampleFeatureSpec."""
+) -> tuple[str, ...]:
+    """Coerce id_columns to tuple for SampleFeatureSpec."""
     if value is None:
-        return ["sample_uid"]
-    if isinstance(value, list):
+        return ("sample_uid",)
+    if isinstance(value, tuple):
         return value
-    return list(value)
+    if isinstance(value, str):
+        return (value,)
+    return tuple(value)
 
 
 class SampleFeatureSpec(FeatureSpec):
     """A testing implementation of FeatureSpec that has a `sample_uid` ID column. Has to be moved to tests."""
 
     id_columns: Annotated[
-        pydantic.SkipValidation[list[str]],
+        tuple[str, ...],
         BeforeValidator(_validate_sample_feature_spec_id_columns),
     ] = pydantic.Field(
-        default_factory=lambda: ["sample_uid"],
-        description="List of columns that uniquely identify a row. They will be used by Metaxy in joins.",
+        default_factory=lambda: ("sample_uid",),
+        min_length=1,
+        description="Columns that uniquely identify a row. They will be used by Metaxy in joins.",
     )
 
     if TYPE_CHECKING:
@@ -63,6 +67,7 @@ class SampleFeatureSpec(FeatureSpec):
             deps: list[FeatureDep] | None = None,
             fields: Sequence[str | FieldSpec] | None = None,
             metadata: Mapping[str, JsonValue] | None = None,
+            unique: Unique | Mapping[str, Any] | None = None,
             **kwargs: Any,
         ) -> None: ...
 
@@ -75,6 +80,7 @@ class SampleFeatureSpec(FeatureSpec):
             deps: list[CoercibleToFeatureDep] | None = None,
             fields: Sequence[str | FieldSpec] | None = None,
             metadata: Mapping[str, JsonValue] | None = None,
+            unique: Unique | Mapping[str, Any] | None = None,
             **kwargs: Any,
         ) -> None: ...
 
@@ -87,6 +93,7 @@ class SampleFeatureSpec(FeatureSpec):
             deps: list[FeatureDep] | list[CoercibleToFeatureDep] | None = None,
             fields: Sequence[str | FieldSpec] | None = None,
             metadata: Mapping[str, JsonValue] | None = None,
+            unique: Unique | Mapping[str, Any] | None = None,
             **kwargs: Any,
         ) -> None: ...
 

--- a/tests/models/serialization/test_spec_version.py
+++ b/tests/models/serialization/test_spec_version.py
@@ -4,7 +4,7 @@ import hashlib
 import json
 from pathlib import Path
 
-from metaxy import FeatureDep, FeatureKey, FieldKey, FieldSpec
+from metaxy import FeatureDep, FeatureKey, FieldKey, FieldSpec, Unique
 from metaxy.ext.polars.handlers.delta import DeltaMetadataStore
 from metaxy.metadata_store.system import SystemTableStorage
 from metaxy_testing.models import SampleFeatureSpec
@@ -119,6 +119,53 @@ def test_feature_spec_version_changes_with_any_property() -> None:
     )
     assert spec_field_added.feature_spec_version != base_version
 
+    # Change unique
+    spec_unique_changed = SampleFeatureSpec(
+        key=FeatureKey(["base", "feature"]),
+        unique=Unique(subset=("content_hash",)),  # Added!
+        fields=[
+            FieldSpec(key=FieldKey(["default"]), code_version="1"),
+        ],
+    )
+    assert spec_unique_changed.feature_spec_version != base_version
+
+
+def test_feature_spec_version_ignores_inactive_unique_config() -> None:
+    base_spec = SampleFeatureSpec(
+        key=FeatureKey(["base", "feature"]),
+        fields=[
+            FieldSpec(key=FieldKey(["default"]), code_version="1"),
+        ],
+    )
+    explicit_default_spec = SampleFeatureSpec(
+        key=FeatureKey(["base", "feature"]),
+        unique=None,
+        fields=[
+            FieldSpec(key=FieldKey(["default"]), code_version="1"),
+        ],
+    )
+
+    assert explicit_default_spec.feature_spec_version == base_spec.feature_spec_version
+
+
+def test_feature_spec_version_changes_with_unique_subset_order() -> None:
+    first_spec = SampleFeatureSpec(
+        key=FeatureKey(["base", "feature"]),
+        unique=Unique(subset=("content_hash_1", "content_hash_2")),
+        fields=[
+            FieldSpec(key=FieldKey(["default"]), code_version="1"),
+        ],
+    )
+    second_spec = SampleFeatureSpec(
+        key=FeatureKey(["base", "feature"]),
+        unique=Unique(subset=("content_hash_2", "content_hash_1")),
+        fields=[
+            FieldSpec(key=FieldKey(["default"]), code_version="1"),
+        ],
+    )
+
+    assert first_spec.feature_spec_version != second_spec.feature_spec_version
+
 
 def test_feature_spec_version_consistent_ordering() -> None:
     """Test that feature_spec_version is consistent regardless of field order."""
@@ -168,6 +215,7 @@ def test_feature_spec_version_manual_verification() -> None:
 
     # Manually compute what it should be
     spec_dict = spec.model_dump(mode="json")
+    spec_dict.pop("unique", None)
     spec_json = json.dumps(spec_dict, sort_keys=True)
     expected_hash = hashlib.sha256(spec_json.encode("utf-8")).hexdigest()[:8]
 

--- a/tests/models/serialization/test_spec_version.py
+++ b/tests/models/serialization/test_spec_version.py
@@ -4,7 +4,7 @@ import hashlib
 import json
 from pathlib import Path
 
-from metaxy import FeatureDep, FeatureKey, FieldKey, FieldSpec
+from metaxy import FeatureDep, FeatureKey, FieldKey, FieldSpec, Unique
 from metaxy.ext.polars.handlers.delta import DeltaMetadataStore
 from metaxy.metadata_store.system import SystemTableStorage
 from metaxy_testing.models import SampleFeatureSpec
@@ -119,6 +119,66 @@ def test_feature_spec_version_changes_with_any_property() -> None:
     )
     assert spec_field_added.feature_spec_version != base_version
 
+    # Change unique
+    spec_unique_changed = SampleFeatureSpec(
+        key=FeatureKey(["base", "feature"]),
+        unique=Unique(subset=("content_hash",)),  # Added!
+        fields=[
+            FieldSpec(key=FieldKey(["default"]), code_version="1"),
+        ],
+    )
+    assert spec_unique_changed.feature_spec_version != base_version
+
+
+def test_feature_spec_version_ignores_inactive_unique_config() -> None:
+    base_spec = SampleFeatureSpec(
+        key=FeatureKey(["base", "feature"]),
+        fields=[
+            FieldSpec(key=FieldKey(["default"]), code_version="1"),
+        ],
+    )
+    explicit_default_spec = SampleFeatureSpec(
+        key=FeatureKey(["base", "feature"]),
+        unique=None,
+        fields=[
+            FieldSpec(key=FieldKey(["default"]), code_version="1"),
+        ],
+    )
+
+    assert explicit_default_spec.feature_spec_version == base_spec.feature_spec_version
+
+
+def test_feature_spec_version_changes_with_unique_subset_order() -> None:
+    first_spec = SampleFeatureSpec(
+        key=FeatureKey(["base", "feature"]),
+        unique=Unique(subset=("content_hash_1", "content_hash_2")),
+        fields=[
+            FieldSpec(key=FieldKey(["default"]), code_version="1"),
+        ],
+    )
+    second_spec = SampleFeatureSpec(
+        key=FeatureKey(["base", "feature"]),
+        unique=Unique(subset=("content_hash_2", "content_hash_1")),
+        fields=[
+            FieldSpec(key=FieldKey(["default"]), code_version="1"),
+        ],
+    )
+
+    assert first_spec.feature_spec_version != second_spec.feature_spec_version
+
+
+def test_feature_spec_version_changes_with_unique_order_by() -> None:
+    first_spec = SampleFeatureSpec(
+        key=FeatureKey(["base", "feature"]),
+        unique=Unique(subset=("entity_id",), keep="latest", order_by=("revision", "source_priority")),
+    )
+    second_spec = SampleFeatureSpec(
+        key=FeatureKey(["base", "feature"]),
+        unique=Unique(subset=("entity_id",), keep="latest", order_by=("source_priority", "revision")),
+    )
+
+    assert first_spec.feature_spec_version != second_spec.feature_spec_version
+
 
 def test_feature_spec_version_consistent_ordering() -> None:
     """Test that feature_spec_version is consistent regardless of field order."""
@@ -168,6 +228,7 @@ def test_feature_spec_version_manual_verification() -> None:
 
     # Manually compute what it should be
     spec_dict = spec.model_dump(mode="json")
+    spec_dict.pop("unique", None)
     spec_json = json.dumps(spec_dict, sort_keys=True)
     expected_hash = hashlib.sha256(spec_json.encode("utf-8")).hexdigest()[:8]
 

--- a/tests/models/test_feature_definition.py
+++ b/tests/models/test_feature_definition.py
@@ -49,6 +49,24 @@ def test_feature_definition_project_field():
     assert definition.project == "myproject"
 
 
+def test_feature_definition_warns_for_missing_unique_columns():
+    """FeatureDefinition validates unique.subset against its own schema."""
+    spec = FeatureSpec(
+        key=FeatureKey(["ns", "feat"]),
+        id_columns=("id",),
+        fields=[FieldSpec(key=FieldKey(["val"]))],
+        unique={"subset": ["missing"]},
+    )
+
+    with pytest.warns(UserWarning, match="unique.subset columns.*not found"):
+        _ = FeatureDefinition(
+            spec=spec,
+            feature_schema={"type": "object", "properties": {"id": {"type": "string"}, "val": {"type": "string"}}},
+            feature_class_path="myproject.features.MyFeature",
+            project="myproject",
+        )
+
+
 def test_feature_definition_convenience_properties():
     """Test key, table_name, id_columns properties."""
     spec = FeatureSpec(

--- a/tests/models/test_feature_definition.py
+++ b/tests/models/test_feature_definition.py
@@ -49,6 +49,42 @@ def test_feature_definition_project_field():
     assert definition.project == "myproject"
 
 
+def test_feature_definition_warns_for_missing_unique_columns():
+    """FeatureDefinition validates unique.subset against its own schema."""
+    spec = FeatureSpec(
+        key=FeatureKey(["ns", "feat"]),
+        id_columns=("id",),
+        fields=[FieldSpec(key=FieldKey(["val"]))],
+        unique={"subset": ["missing"]},
+    )
+
+    with pytest.warns(UserWarning, match="unique.subset columns.*not found"):
+        _ = FeatureDefinition(
+            spec=spec,
+            feature_schema={"type": "object", "properties": {"id": {"type": "string"}, "val": {"type": "string"}}},
+            feature_class_path="myproject.features.MyFeature",
+            project="myproject",
+        )
+
+
+def test_feature_definition_warns_for_missing_unique_order_columns():
+    """FeatureDefinition validates unique.order_by against its own schema."""
+    spec = FeatureSpec(
+        key=FeatureKey(["ns", "ordered_feat"]),
+        id_columns=("id",),
+        fields=[FieldSpec(key=FieldKey(["val"]))],
+        unique={"subset": ["id"], "keep": "latest", "order_by": ["missing_revision"]},
+    )
+
+    with pytest.warns(UserWarning, match="unique.order_by columns.*not found"):
+        _ = FeatureDefinition(
+            spec=spec,
+            feature_schema={"type": "object", "properties": {"id": {"type": "string"}, "val": {"type": "string"}}},
+            feature_class_path="myproject.features.MyFeature",
+            project="myproject",
+        )
+
+
 def test_feature_definition_convenience_properties():
     """Test key, table_name, id_columns properties."""
     spec = FeatureSpec(

--- a/tests/models/test_feature_spec_validation.py
+++ b/tests/models/test_feature_spec_validation.py
@@ -2,9 +2,11 @@
 
 import pytest
 from metaxy import BaseFeature
+from metaxy.models.feature_spec import FeatureDep, Unique
 from metaxy.models.field import FieldSpec
 from metaxy.models.types import FieldKey
 from metaxy_testing.models import SampleFeatureSpec
+from pydantic import ValidationError
 
 
 def test_duplicate_field_keys_raises_error():
@@ -131,9 +133,16 @@ def test_feature_spec_requires_id_columns():
     assert spec.id_columns == ("sample_uid",)
 
 
+def test_feature_spec_empty_id_columns_raises_validation_error():
+    """Test that FeatureSpec uses field constraints for empty id_columns."""
+    from metaxy.models.feature_spec import FeatureSpec
+
+    with pytest.raises(ValidationError, match="at least 1 item"):
+        FeatureSpec(key="test/feature", id_columns=[])
+
+
 def test_feature_dep_from_feature_class():
     """Test that FeatureDep can be created directly from a Feature class."""
-    from metaxy.models.feature_spec import FeatureDep
     from metaxy.models.types import FeatureKey
 
     # Create a parent feature
@@ -174,7 +183,7 @@ def test_feature_dep_from_feature_class():
 
 def test_feature_spec_deps_mixed_types():
     """Test that FeatureSpec.deps accepts all coercible types in a single list."""
-    from metaxy.models.feature_spec import FeatureDep, FeatureSpec
+    from metaxy.models.feature_spec import FeatureSpec
     from metaxy.models.types import FeatureKey
 
     # Create a Feature class
@@ -209,3 +218,117 @@ def test_feature_spec_deps_mixed_types():
     assert spec.deps[1].feature == FeatureKey(["my", "feature", "key"])
     assert spec.deps[2].feature == FeatureKey(["another", "key"])
     assert spec.deps[3].feature == FeatureKey(["very", "nice"])
+
+
+class TestUniqueValidation:
+    """Tests for the unique field on FeatureSpec."""
+
+    def test_unique_default_is_none(self) -> None:
+        spec = SampleFeatureSpec(key="test/feature")
+        assert spec.unique is None
+
+    def test_unique_model_round_trips(self) -> None:
+        spec = SampleFeatureSpec(key="test/feature", unique=Unique(subset=("col1", "col2")))
+        assert spec.unique == Unique(subset=("col1", "col2"))
+
+    def test_unique_dict_list_is_coerced(self) -> None:
+        spec = SampleFeatureSpec(key="test/feature", unique={"subset": ["col1"]})
+        assert spec.unique == Unique(subset=("col1",))
+
+    def test_unique_subset_bare_string_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            SampleFeatureSpec(key="test/feature", unique={"subset": "col1"})
+
+    def test_unique_subset_mapping_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            Unique(subset={"col1": True})  # ty: ignore[invalid-argument-type]
+
+    def test_unique_subset_non_sequence_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            Unique(subset=42)  # ty: ignore[invalid-argument-type]
+
+    def test_unique_subset_empty_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            Unique(subset=())
+
+    def test_unique_subset_duplicate_columns_deduplicates(self) -> None:
+        u = Unique(subset=("col2", "col1", "col2"))
+        assert u.subset == ("col2", "col1")
+
+    def test_unique_serializes_correctly(self) -> None:
+        spec = SampleFeatureSpec(key="test/feature", unique=Unique(subset=("content_hash_2", "content_hash_1")))
+        dumped = spec.model_dump(mode="json")
+        assert dumped["unique"] == {"subset": ["content_hash_2", "content_hash_1"], "keep": "any"}
+
+    def test_unique_none_serializes_correctly(self) -> None:
+        spec = SampleFeatureSpec(key="test/feature")
+        dumped = spec.model_dump(mode="json")
+        assert dumped["unique"] is None
+
+    def test_unique_missing_column_warns_on_feature(self) -> None:
+        with pytest.warns(UserWarning, match="unique.subset columns.*not found"):
+
+            class _BadFeature(
+                BaseFeature,
+                spec=SampleFeatureSpec(
+                    key="test/bad_dedup",
+                    unique=Unique(subset=("missing",)),
+                ),
+            ):
+                pass
+
+    def test_unique_current_feature_column_allowed(self) -> None:
+        class _Feature(
+            BaseFeature,
+            spec=SampleFeatureSpec(
+                key="test/current_feature_dedup",
+                unique=Unique(subset=("content_hash",)),
+            ),
+        ):
+            content_hash: str | None = None
+
+        assert _Feature.spec().unique == Unique(subset=("content_hash",))
+
+    def test_unique_system_column_allowed(self) -> None:
+        class _SysColFeature(
+            BaseFeature,
+            spec=SampleFeatureSpec(
+                key="test/sys_dedup",
+                unique=Unique(subset=("metaxy_data_version",)),
+            ),
+        ):
+            pass
+
+        assert _SysColFeature.spec().unique == Unique(subset=("metaxy_data_version",))
+
+    def test_unique_upstream_column_warns(self) -> None:
+        class _Parent(BaseFeature, spec=SampleFeatureSpec(key="test/dedup_parent")):
+            content_hash: str | None = None
+
+        with pytest.warns(UserWarning, match="unique.subset columns.*not found"):
+
+            class _Child(
+                BaseFeature,
+                spec=SampleFeatureSpec(
+                    key="test/dedup_child",
+                    deps=[FeatureDep(feature="test/dedup_parent", select=("content_hash",))],
+                    unique=Unique(subset=("content_hash",)),
+                ),
+            ):
+                pass
+
+    def test_unique_renamed_upstream_column_warns(self) -> None:
+        class _Parent(BaseFeature, spec=SampleFeatureSpec(key="test/dedup_rename_parent")):
+            content_hash: str | None = None
+
+        with pytest.warns(UserWarning, match="unique.subset columns.*not found"):
+
+            class _Child(
+                BaseFeature,
+                spec=SampleFeatureSpec(
+                    key="test/dedup_rename_child",
+                    deps=[FeatureDep(feature="test/dedup_rename_parent", rename={"content_hash": "chash"})],
+                    unique=Unique(subset=("chash",)),
+                ),
+            ):
+                pass

--- a/tests/models/test_feature_spec_validation.py
+++ b/tests/models/test_feature_spec_validation.py
@@ -2,9 +2,11 @@
 
 import pytest
 from metaxy import BaseFeature
+from metaxy.models.feature_spec import FeatureDep, FeatureSpec, Unique
 from metaxy.models.field import FieldSpec
 from metaxy.models.types import FieldKey
 from metaxy_testing.models import SampleFeatureSpec
+from pydantic import ValidationError
 
 
 def test_duplicate_field_keys_raises_error():
@@ -60,6 +62,20 @@ def test_unique_field_keys_pass_validation():
     assert spec.fields[0].key == FieldKey(["predictions"])
     assert spec.fields[1].key == FieldKey(["embeddings"])
     assert spec.fields[2].key == FieldKey(["metadata"])
+
+
+def test_id_columns_bare_string_raises_validation_error() -> None:
+    with pytest.raises(ValidationError, match="id_columns must be a sequence"):
+        FeatureSpec(key="test/feature", id_columns="sample_uid")
+
+
+def test_id_columns_preserve_order_and_deduplicate() -> None:
+    assert FeatureSpec(key="test/feature", id_columns=("b", "a", "b")).id_columns == ("b", "a")
+
+
+def test_id_columns_set_raises_validation_error() -> None:
+    with pytest.raises(ValidationError, match="ordered sequence"):
+        FeatureSpec(key="test/feature", id_columns={"a", "b"})  # ty: ignore[no-matching-overload]
 
 
 def test_default_field_is_unique():
@@ -131,9 +147,16 @@ def test_feature_spec_requires_id_columns():
     assert spec.id_columns == ("sample_uid",)
 
 
+def test_feature_spec_empty_id_columns_raises_validation_error():
+    """Test that FeatureSpec uses field constraints for empty id_columns."""
+    from metaxy.models.feature_spec import FeatureSpec
+
+    with pytest.raises(ValidationError, match="at least 1 item"):
+        FeatureSpec(key="test/feature", id_columns=[])
+
+
 def test_feature_dep_from_feature_class():
     """Test that FeatureDep can be created directly from a Feature class."""
-    from metaxy.models.feature_spec import FeatureDep
     from metaxy.models.types import FeatureKey
 
     # Create a parent feature
@@ -174,7 +197,7 @@ def test_feature_dep_from_feature_class():
 
 def test_feature_spec_deps_mixed_types():
     """Test that FeatureSpec.deps accepts all coercible types in a single list."""
-    from metaxy.models.feature_spec import FeatureDep, FeatureSpec
+    from metaxy.models.feature_spec import FeatureSpec
     from metaxy.models.types import FeatureKey
 
     # Create a Feature class
@@ -209,3 +232,198 @@ def test_feature_spec_deps_mixed_types():
     assert spec.deps[1].feature == FeatureKey(["my", "feature", "key"])
     assert spec.deps[2].feature == FeatureKey(["another", "key"])
     assert spec.deps[3].feature == FeatureKey(["very", "nice"])
+
+
+class TestUniqueValidation:
+    """Tests for the unique field on FeatureSpec."""
+
+    def test_unique_default_is_none(self) -> None:
+        spec = SampleFeatureSpec(key="test/feature")
+        assert spec.unique is None
+
+    def test_unique_model_round_trips(self) -> None:
+        spec = SampleFeatureSpec(key="test/feature", unique=Unique(subset=("col1", "col2")))
+        assert spec.unique == Unique(subset=("col1", "col2"))
+
+    def test_unique_dict_list_is_coerced(self) -> None:
+        spec = SampleFeatureSpec(key="test/feature", unique={"subset": ["col1"]})
+        assert spec.unique == Unique(subset=("col1",))
+
+    def test_unique_subset_bare_string_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            SampleFeatureSpec(key="test/feature", unique={"subset": "col1"})
+
+    def test_unique_subset_mapping_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            Unique(subset={"col1": True})  # ty: ignore[invalid-argument-type]
+
+    def test_unique_subset_set_raises(self) -> None:
+        with pytest.raises(ValidationError, match="ordered sequence"):
+            Unique(subset={"col1", "col2"})  # ty: ignore[invalid-argument-type]
+
+    def test_unique_subset_non_sequence_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            Unique(subset=42)  # ty: ignore[invalid-argument-type]
+
+    def test_unique_subset_empty_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            Unique(subset=())
+
+    def test_unique_subset_duplicate_columns_deduplicates(self) -> None:
+        u = Unique(subset=("col2", "col1", "col2"))
+        assert u.subset == ("col2", "col1")
+
+    def test_unique_latest_requires_order_by(self) -> None:
+        with pytest.raises(ValidationError, match="unique.order_by is required"):
+            Unique(subset=("entity_id",), keep="latest")
+
+    def test_unique_order_by_empty_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            Unique(subset=("entity_id",), keep="latest", order_by=())
+
+    def test_unique_any_rejects_order_by(self) -> None:
+        with pytest.raises(ValidationError, match="only supported"):
+            Unique(subset=("content_hash",), order_by=("revision",))
+
+    def test_unique_order_by_bare_string_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            Unique(subset=("entity_id",), keep="latest", order_by="revision")
+
+    def test_unique_order_by_set_raises(self) -> None:
+        with pytest.raises(ValidationError, match="ordered sequence"):
+            Unique(
+                subset=("entity_id",),
+                keep="latest",
+                order_by={"revision", "source_priority"},  # ty: ignore[invalid-argument-type]
+            )
+
+    def test_unique_order_by_preserves_order_and_deduplicates(self) -> None:
+        unique = Unique(
+            subset=("entity_id",),
+            keep="latest",
+            order_by=("revision", "source_priority", "revision"),
+        )
+        assert unique.order_by == ("revision", "source_priority")
+
+    def test_unique_serializes_correctly(self) -> None:
+        spec = SampleFeatureSpec(key="test/feature", unique=Unique(subset=("content_hash_2", "content_hash_1")))
+        dumped = spec.model_dump(mode="json")
+        assert dumped["unique"] == {
+            "subset": ["content_hash_2", "content_hash_1"],
+            "keep": "any",
+            "order_by": None,
+        }
+
+    def test_unique_latest_serializes_order_by(self) -> None:
+        spec = SampleFeatureSpec(
+            key="test/feature",
+            unique=Unique(subset=("entity_id",), keep="latest", order_by=("revision", "source_priority")),
+        )
+        dumped = spec.model_dump(mode="json")
+        assert dumped["unique"] == {
+            "subset": ["entity_id"],
+            "keep": "latest",
+            "order_by": ["revision", "source_priority"],
+        }
+
+    def test_unique_none_serializes_correctly(self) -> None:
+        spec = SampleFeatureSpec(key="test/feature")
+        dumped = spec.model_dump(mode="json")
+        assert dumped["unique"] is None
+
+    def test_unique_missing_column_warns_on_feature(self) -> None:
+        with pytest.warns(UserWarning, match="unique.subset columns.*not found"):
+
+            class _BadFeature(
+                BaseFeature,
+                spec=SampleFeatureSpec(
+                    key="test/bad_dedup",
+                    unique=Unique(subset=("missing",)),
+                ),
+            ):
+                pass
+
+    def test_unique_missing_order_by_column_warns_on_feature(self) -> None:
+        with pytest.warns(UserWarning, match="unique.order_by columns.*not found"):
+
+            class _BadOrderFeature(
+                BaseFeature,
+                spec=SampleFeatureSpec(
+                    key="test/bad_unique_order",
+                    unique=Unique(subset=("sample_uid",), keep="latest", order_by=("missing_revision",)),
+                ),
+            ):
+                pass
+
+    def test_unique_current_feature_column_allowed(self) -> None:
+        class _Feature(
+            BaseFeature,
+            spec=SampleFeatureSpec(
+                key="test/current_feature_dedup",
+                unique=Unique(subset=("content_hash",)),
+            ),
+        ):
+            content_hash: str | None = None
+
+        assert _Feature.spec().unique == Unique(subset=("content_hash",))
+
+    def test_unique_current_feature_order_by_column_allowed(self) -> None:
+        class _Feature(
+            BaseFeature,
+            spec=SampleFeatureSpec(
+                key="test/current_feature_unique_order",
+                unique=Unique(subset=("entity_id",), keep="latest", order_by=("revision",)),
+            ),
+        ):
+            entity_id: str
+            revision: int
+
+        assert _Feature.spec().unique == Unique(
+            subset=("entity_id",),
+            keep="latest",
+            order_by=("revision",),
+        )
+
+    def test_unique_system_column_allowed(self) -> None:
+        class _SysColFeature(
+            BaseFeature,
+            spec=SampleFeatureSpec(
+                key="test/sys_dedup",
+                unique=Unique(subset=("metaxy_data_version",)),
+            ),
+        ):
+            pass
+
+        assert _SysColFeature.spec().unique == Unique(subset=("metaxy_data_version",))
+
+    def test_unique_upstream_column_warns(self) -> None:
+        class _Parent(BaseFeature, spec=SampleFeatureSpec(key="test/dedup_parent")):
+            content_hash: str | None = None
+
+        with pytest.warns(UserWarning, match="unique.subset columns.*not found"):
+
+            class _Child(
+                BaseFeature,
+                spec=SampleFeatureSpec(
+                    key="test/dedup_child",
+                    deps=[FeatureDep(feature="test/dedup_parent", select=("content_hash",))],
+                    unique=Unique(subset=("content_hash",)),
+                ),
+            ):
+                pass
+
+    def test_unique_renamed_upstream_column_warns(self) -> None:
+        class _Parent(BaseFeature, spec=SampleFeatureSpec(key="test/dedup_rename_parent")):
+            content_hash: str | None = None
+
+        with pytest.warns(UserWarning, match="unique.subset columns.*not found"):
+
+            class _Child(
+                BaseFeature,
+                spec=SampleFeatureSpec(
+                    key="test/dedup_rename_child",
+                    deps=[FeatureDep(feature="test/dedup_rename_parent", rename={"content_hash": "chash"})],
+                    unique=Unique(subset=("chash",)),
+                ),
+            ):
+                pass

--- a/tests/models/test_id_columns.py
+++ b/tests/models/test_id_columns.py
@@ -18,6 +18,7 @@ from metaxy.models.plan import FeaturePlan
 from metaxy.models.types import FeatureKey, FieldKey
 from metaxy_testing.models import SampleFeature, SampleFeatureSpec
 from metaxy_testing.pytest_helpers import add_metaxy_system_columns
+from pydantic import ValidationError
 
 
 # Simple test joiner that uses VersioningEngine
@@ -83,11 +84,11 @@ class TestJoiner:
 
 
 def test_feature_spec_id_columns_default():
-    """Test that id_columns defaults to None and is interpreted as ["sample_uid"]."""
+    """Test that id_columns defaults to None and is normalized to ("sample_uid",)."""
     spec = SampleFeatureSpec(
         key=FeatureKey(["test"]),
     )
-    assert spec.id_columns == ["sample_uid"]
+    assert spec.id_columns == ("sample_uid",)
 
 
 def test_feature_spec_id_columns_custom():
@@ -96,12 +97,12 @@ def test_feature_spec_id_columns_custom():
         key=FeatureKey(["test"]),
         id_columns=["user_id", "session_id"],
     )
-    assert spec.id_columns == ["user_id", "session_id"]
+    assert spec.id_columns == ("user_id", "session_id")
 
 
 def test_feature_spec_id_columns_validation():
     """Test that empty id_columns raises validation error."""
-    with pytest.raises(ValueError, match="id_columns must be non-empty"):
+    with pytest.raises(ValidationError, match="at least 1 item"):
         SampleFeatureSpec(
             key=FeatureKey(["test"]),
             id_columns=[],  # Empty list should raise error
@@ -594,13 +595,13 @@ def test_backwards_compatibility_default_id_columns(graph: FeatureGraph, tmp_pat
         spec=SampleFeatureSpec(
             key=FeatureKey(["legacy"]),
             fields=[FieldSpec(key=FieldKey(["data"]), code_version="1")],
-            # No id_columns specified - should default to ["sample_uid"]
+            # No id_columns specified - should default to ("sample_uid",)
         ),
     ):
         pass
 
     # Verify id_columns returns default
-    assert LegacyFeature.spec().id_columns == ["sample_uid"]
+    assert LegacyFeature.spec().id_columns == ("sample_uid",)
 
     # Test with metadata store
     with DeltaMetadataStore(root_path=tmp_path / "delta_store").open("w") as store:

--- a/tests/models/test_typed_id_columns.py
+++ b/tests/models/test_typed_id_columns.py
@@ -18,6 +18,7 @@ from metaxy.models.plan import FeaturePlan
 from metaxy.models.types import FeatureKey, FieldKey
 from metaxy_testing.models import SampleFeature, SampleFeatureSpec
 from metaxy_testing.pytest_helpers import add_metaxy_system_columns
+from pydantic import ValidationError
 
 
 # Simple test joiner
@@ -63,36 +64,33 @@ class TestJoiner:
 
 
 def test_feature_spec_id_columns_list_only():
-    """Test that SampleFeatureSpec only accepts list of column names."""
-    # List of columns (only supported format now)
+    """Test that SampleFeatureSpec accepts list inputs and normalizes to tuple."""
     spec = SampleFeatureSpec(
         key=FeatureKey(["test"]),
         id_columns=["user_id", "timestamp"],
     )
-    assert spec.id_columns == ["user_id", "timestamp"]
-    assert spec.id_columns == ["user_id", "timestamp"]
+    assert spec.id_columns == ("user_id", "timestamp")
 
 
 def test_feature_spec_id_columns_backward_compat():
-    """Test backward compatibility with list-based id_columns."""
+    """Test backward compatibility with list inputs for id_columns."""
     # List format
     spec_list = SampleFeatureSpec(
         key=FeatureKey(["test"]),
         id_columns=["user_id", "session_id"],
     )
-    assert spec_list.id_columns == ["user_id", "session_id"]
-    assert spec_list.id_columns == ["user_id", "session_id"]
+    assert spec_list.id_columns == ("user_id", "session_id")
 
     # None (default) - should use sample_uid
     spec_none = SampleFeatureSpec(
         key=FeatureKey(["test"]),
     )
-    assert spec_none.id_columns == ["sample_uid"]
+    assert spec_none.id_columns == ("sample_uid",)
 
 
 def test_feature_spec_empty_list_validation():
     """Test that empty list for id_columns raises validation error."""
-    with pytest.raises(ValueError, match="id_columns must be non-empty"):
+    with pytest.raises(ValidationError, match="at least 1 item"):
         SampleFeatureSpec(
             key=FeatureKey(["test"]),
             id_columns=[],  # Empty list should raise error


### PR DESCRIPTION
resolves: #736
Related: #1231

## Summary

- add feature-level read-time uniqueness through `FeatureSpec.unique`
- support stable `keep="any"` and deterministic `keep="latest"` through required logical `order_by` columns
- resolve the selected current/lifecycle view before feature uniqueness, with `apply_unique=False` as the explicit raw-view escape hatch
- fail closed when a read requests uniqueness but the feature plan is not registered
- preserve exact projection while loading uniqueness/order columns internally, including Ray datasource parity
- document content-hash value identity separately from durable entity identity

## Semantics

Read order is: selected feature-version scope -> current sample/lifecycle resolution -> `FeatureSpec.unique` -> user filters -> requested projection.

For `keep="latest"`, `order_by` followed by feature ID columns defines the total logical order. NULL sorts below every non-NULL value. Physical system fields break remaining ties. Per-ID current resolution still prioritizes physical recency, so a logical ordinal that must dominate belongs in `id_columns` and then reaches the uniqueness step.

Default reads remove Metaxy-soft-deleted current samples before uniqueness. With `include_soft_deleted=True`, deleted rows participate normally and may win. Domain tombstones remain ordinary ordered rows; downstream filtering belongs on the `FeatureDep` edge.

Feature-history current reads retain one winner per `(id_columns, feature_version)`, preserving the rows needed to reconstruct the current deduplicated view. Raw history for an unregistered feature requires both history flags and `apply_unique=False`.

This provides the deterministic ordered-read and latest-only retention foundation related to #1231. Lifecycle pinning, compaction, conflict validation, snapshot watermarks, changed-key reads, and atomic commits remain separate follow-up work.

## Changelog

- Add `FeatureSpec.unique` with ordered `subset`, `keep`, and required `order_by` for `keep="latest"`.
- Add `MetadataStore.read(..., apply_unique=False)`.
- Serialized specs containing `unique` require a Metaxy version that supports this field.

## Test Plan

- `uv run pytest --tach -q` (1,335 passed, 1 skipped; 1,953 unaffected tests skipped)
- shared uniqueness contract on Delta, DuckDB, DuckLake, PostgreSQL, and ClickHouse (9 passed per backend)
- `uv run pytest -q tests/metadata_stores/core/test_unique.py` (27 passed)
- `uv run pytest -q docs/guide/concepts/definitions/features.md` (12 passed)
- `uv run --all-extras --group dev ty check`
- `uv run ruff check src/metaxy tests`
- `uv run --group docs --extra mcp mkdocs build --clean --strict`
