### PR TITLE
fix: avoid emitting a missing lock file warning when `metaxy_lock_path` is not configured

### DIFF
--- a/src/metaxy/cli/lock.py
+++ b/src/metaxy/cli/lock.py
@@ -74,7 +74,7 @@ def lock(
     elif config.lock_file:
         output_path = config.lock_file
     else:
-        output_path = Path.cwd() / config.metaxy_lock_path
+        output_path = Path.cwd() / (config.metaxy_lock_path or "metaxy.lock")
 
     metadata_store = context.get_store(store)
     relative_path = output_path.relative_to(Path.cwd()) if output_path.is_relative_to(Path.cwd()) else output_path

--- a/src/metaxy/config/models/metaxy_config.py
+++ b/src/metaxy/config/models/metaxy_config.py
@@ -3,6 +3,7 @@ import warnings
 from collections.abc import Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
+from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, TypeVar, overload
 
@@ -219,9 +220,9 @@ class MetaxyConfig(BaseSettings):
         description="Extra features to load from the metadata store when calling [`sync_external_features`][metaxy.sync_external_features]. Each entry is a [`FeatureSelection`][metaxy.FeatureSelection]. All entries are combined together. Learn more [here](/guide/concepts/definitions/external-features.md/#loading-extra-features).",
     )
 
-    metaxy_lock_path: str = PydanticField(
-        default="metaxy.lock",
-        description="Relative or absolute path to the lock file, resolved from the config file's location.",
+    metaxy_lock_path: str | None = PydanticField(
+        default=None,
+        description="Relative or absolute path to the lock file, resolved from the config file's location. Defaults to `metaxy.lock` next to the config file.",
     )
 
     # Private attribute to track which config file was used (set by load())
@@ -235,21 +236,30 @@ class MetaxyConfig(BaseSettings):
         """
         return self._config_file
 
-    @property
+    @cached_property
     def lock_file(self) -> Path | None:
         """The resolved lock file path.
 
-        Returns the absolute path if `metaxy_lock_path` is absolute, otherwise
-        resolves it relative to the config file's directory.
+        When ``metaxy_lock_path`` is set, returns the resolved path (absolute
+        paths are returned directly, relative paths are resolved from the
+        config file's directory).
 
-        Returns `None` if the path is relative and no config file is set.
+        When ``metaxy_lock_path`` is ``None`` (the default), checks for
+        ``metaxy.lock`` next to the config file.
+
+        Returns ``None`` if no config file is set and the path is relative.
         """
-        lock_path = Path(self.metaxy_lock_path)
-        if lock_path.is_absolute():
-            return lock_path
+        if self.metaxy_lock_path is not None:
+            lock_path = Path(self.metaxy_lock_path)
+            if lock_path.is_absolute():
+                return lock_path
+            if self._config_file is None:
+                return None
+            return self._config_file.parent / lock_path
+
         if self._config_file is None:
             return None
-        return self._config_file.parent / lock_path
+        return self._config_file.parent / "metaxy.lock"
 
     def _load_plugins(self) -> None:
         """Load enabled plugins. Must be called after config is set."""

--- a/src/metaxy/utils/lock_file.py
+++ b/src/metaxy/utils/lock_file.py
@@ -81,16 +81,16 @@ def load_lock_file(config: MetaxyConfig) -> list[FeatureDefinition]:
 
     lock_path = config.lock_file
     if lock_path is None:
-        import warnings
-
-        warnings.warn(
-            "Cannot load lock file: no config file path available and metaxy_lock_path is relative. "
-            "External features from metaxy.lock will not be loaded.",
-            stacklevel=2,
-        )
         return []
 
     if not lock_path.exists():
+        if config.metaxy_lock_path is not None:
+            warnings.warn(
+                f"Lock file not found at {lock_path}. "
+                "External features from the lock file will not be loaded. "
+                "Run `metaxy lock` to generate it.",
+                stacklevel=2,
+            )
         return []
 
     lock_file = LockFile.from_toml(lock_path.read_text())

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,6 @@
 """Tests for configuration system."""
 
+import warnings
 from pathlib import Path
 
 import pytest
@@ -860,14 +861,14 @@ def test_config_file_attribute_none_when_created_directly() -> None:
 
 
 def test_metaxy_lock_path_default() -> None:
-    """Test that metaxy_lock_path defaults to 'metaxy.lock'."""
+    """Test that metaxy_lock_path defaults to None."""
     config = MetaxyConfig()
 
-    assert config.metaxy_lock_path == "metaxy.lock"
+    assert config.metaxy_lock_path is None
 
 
-def test_lock_file_with_config_file_relative_path(tmp_path: Path) -> None:
-    """Test lock_file resolves relative path from config file directory."""
+def test_lock_file_convention_with_config_file(tmp_path: Path) -> None:
+    """Test lock_file checks metaxy.lock next to config file when metaxy_lock_path is None."""
     config_file = tmp_path / "metaxy.toml"
     config_file.write_text('project = "test"')
 
@@ -888,18 +889,37 @@ def test_lock_file_with_config_file_custom_relative_path(tmp_path: Path) -> None
 
 def test_lock_file_with_absolute_path(tmp_path: Path) -> None:
     """Test lock_file returns absolute path directly when metaxy_lock_path is absolute."""
-    # Use an actual absolute path that works on any platform
     absolute_lock_path = tmp_path / "metaxy.lock"
     config = MetaxyConfig(metaxy_lock_path=str(absolute_lock_path))
 
     assert config.lock_file == absolute_lock_path
 
 
-def test_lock_file_none_when_no_config_file_and_relative_path() -> None:
-    """Test lock_file returns None when no config file and path is relative."""
+def test_lock_file_none_when_no_config_file() -> None:
+    """Test lock_file returns None when no config file and metaxy_lock_path is not set."""
     config = MetaxyConfig()
 
     assert config.lock_file is None
+
+
+def test_lock_file_none_when_no_config_file_and_relative_path() -> None:
+    """Test lock_file returns None when no config file and metaxy_lock_path is relative."""
+    config = MetaxyConfig(metaxy_lock_path="custom.lock")
+
+    assert config.lock_file is None
+
+
+def test_load_lock_file_no_warning_for_default_config() -> None:
+    """load_lock_file does not warn when config has no config file and default lock path."""
+    from metaxy.utils.lock_file import load_lock_file
+
+    config = MetaxyConfig()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        result = load_lock_file(config)
+
+    assert result == []
 
 
 def test_get_store_error_includes_config_file_path(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

<!-- Brief description of the changes -->

## Changelog

<!--
User-facing changelog details, rendered below the commit title in CHANGELOG.md.
Delete this section if there are no user-facing changes.
-->

## Test Plan

<!-- How was this tested? -->
