### PR TITLE
chore(deltalake, iceberg): deprecate importing DeltaLake and Iceberg stores from `metaxy.ext.polars`

### DIFF
--- a/.claude-plugin/skills/metaxy/SKILL.md
+++ b/.claude-plugin/skills/metaxy/SKILL.md
@@ -54,7 +54,7 @@ To configure a metadata store, create a `metaxy.toml` file or use programmatic c
 ```python
 config = mx.MetaxyConfig(
     stores={"dev": mx.StoreConfig(
-        type="metaxy.ext.polars.DeltaMetadataStore",
+        type="metaxy.ext.polars.handlers.delta.DeltaMetadataStore",
         config={"root_path": "/tmp/metaxy"},
     )}
 )
@@ -104,7 +104,7 @@ def metaxy_env(tmp_path):
     with mx.FeatureGraph().use():
         with mx.MetaxyConfig(
             stores={"test": mx.StoreConfig(
-                type="metaxy.ext.polars.DeltaMetadataStore",
+                type="metaxy.ext.polars.handlers.delta.DeltaMetadataStore",
                 config={"root_path": str(tmp_path / "delta_test")},
             )}
         ).use() as config:

--- a/.claude-plugin/skills/metaxy/examples/configuration.md
+++ b/.claude-plugin/skills/metaxy/examples/configuration.md
@@ -21,13 +21,13 @@ entrypoints = ["src/my_project/features"]
 
 # Development store
 [stores.dev]
-type = "metaxy.ext.polars.DeltaMetadataStore"
+type = "metaxy.ext.polars.handlers.delta.DeltaMetadataStore"
 [stores.dev.config]
 root_path = "${HOME}/.metaxy/metadata"
 
 # Production store with S3
 [stores.prod]
-type = "metaxy.ext.polars.DeltaMetadataStore"
+type = "metaxy.ext.polars.handlers.delta.DeltaMetadataStore"
 [stores.prod.config]
 root_path = "s3://my-bucket/metadata"
 ```
@@ -40,7 +40,7 @@ store = "dev"
 entrypoints = ["src/my_project/features"]
 
 [tool.metaxy.stores.dev]
-type = "metaxy.ext.polars.DeltaMetadataStore"
+type = "metaxy.ext.polars.handlers.delta.DeltaMetadataStore"
 [tool.metaxy.stores.dev.config]
 root_path = "/tmp/metaxy/metadata"
 ```
@@ -49,7 +49,7 @@ root_path = "/tmp/metaxy/metadata"
 
 ```toml
 [stores.branch]
-type = "metaxy.ext.polars.DeltaMetadataStore"
+type = "metaxy.ext.polars.handlers.delta.DeltaMetadataStore"
 [stores.branch.config]
 root_path = "s3://my-bucket/${BRANCH_NAME}/metadata"
 ```
@@ -92,7 +92,7 @@ import metaxy as mx
 
 with mx.MetaxyConfig(
     stores={"dev": mx.StoreConfig(
-        type="metaxy.ext.polars.DeltaMetadataStore",
+        type="metaxy.ext.polars.handlers.delta.DeltaMetadataStore",
         config={"root_path": "/tmp/metaxy"},
     )}
 ).use() as config:

--- a/.claude-plugin/skills/metaxy/examples/testing.md
+++ b/.claude-plugin/skills/metaxy/examples/testing.md
@@ -37,7 +37,7 @@ import metaxy as mx
 def test_with_custom_config(tmp_path):
     with mx.MetaxyConfig(
         stores={"test": mx.StoreConfig(
-            type="metaxy.ext.polars.DeltaMetadataStore",
+            type="metaxy.ext.polars.handlers.delta.DeltaMetadataStore",
             config={"root_path": str(tmp_path / "delta_test")},
         )}
     ).use() as config:
@@ -57,7 +57,7 @@ def metaxy_env(tmp_path):
     with mx.FeatureGraph().use():
         with mx.MetaxyConfig(
             stores={"test": mx.StoreConfig(
-                type="metaxy.ext.polars.DeltaMetadataStore",
+                type="metaxy.ext.polars.handlers.delta.DeltaMetadataStore",
                 config={"root_path": str(tmp_path / "delta_test")},
             )}
         ).use() as config:

--- a/devenv.lock
+++ b/devenv.lock
@@ -3,11 +3,11 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1774475276,
-        "narHash": "sha256-z4erC+oMEuBHtox+B46FCv77IPvNy4SyXw/EeBxsD4I=",
+        "lastModified": 1775673122,
+        "narHash": "sha256-zVHWCQ0kCkaNIubCVv5fZyrPYfI4EGEPLRFRARwGSl8=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "f8ca2c061ec2feceee1cf1c5e52c92f58b6aec9c",
+        "rev": "010a22c855d22b127c6fb007868b2f3fc09bc2c8",
         "type": "github"
       },
       "original": {
@@ -17,69 +17,13 @@
         "type": "github"
       }
     },
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1767039857,
-        "owner": "NixOS",
-        "repo": "flake-compat",
-        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "git-hooks": {
-      "inputs": {
-        "flake-compat": "flake-compat",
-        "gitignore": "gitignore",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1775036584,
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "rev": "4e0eb042b67d863b1b34b3f64d52ceb9cd926735",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "git-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1762808025,
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "cb5e3fdca1de58ccbc3ef53de65bd372b48f567c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1774388614,
-        "narHash": "sha256-tFwzTI0DdDzovdE9+Ras6CUss0yn8P9XV4Ja6RjA+nU=",
+        "lastModified": 1775595990,
+        "narHash": "sha256-OEf7YqhF9IjJFYZJyuhAypgU+VsRB5lD4DuiMws5Ltc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1073dad219cb244572b74da2b20c7fe39cb3fa9e",
+        "rev": "4e92bbcdb030f3b4782be4751dc08e6b6cb6ccf2",
         "type": "github"
       },
       "original": {
@@ -92,11 +36,7 @@
     "root": {
       "inputs": {
         "devenv": "devenv",
-        "git-hooks": "git-hooks",
-        "nixpkgs": "nixpkgs",
-        "pre-commit-hooks": [
-          "git-hooks"
-        ]
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/docs/guide/concepts/lifecycle/deployment.md
+++ b/docs/guide/concepts/lifecycle/deployment.md
@@ -35,12 +35,12 @@ For example:
 
 ```toml title="metaxy.toml"
 [stores.branch]
-type = "metaxy.ext.polars.DeltaMetadataStore"
+type = "metaxy.ext.polars.handlers.delta.DeltaMetadataStore"
 root_path = "s3://branch-bucket/${PULL_REQUEST_ID}"
 fallback_stores = ["prod"]
 
 [stores.prod] title="metaxy.toml"
-type = "metaxy.ext.polars.DeltaMetadataStore"
+type = "metaxy.ext.polars.handlers.delta.DeltaMetadataStore"
 root_path = "s3://my-prod-bucket/metaxy"
 ```
 

--- a/docs/guide/concepts/lifecycle/development.md
+++ b/docs/guide/concepts/lifecycle/development.md
@@ -16,7 +16,7 @@ It all starts from the [metadata store](../metadata-stores.md). The default meta
 
 ```toml title="metaxy.toml"
 [stores.dev]
-type = "metaxy.ext.polars.DeltaMetadataStore"
+type = "metaxy.ext.polars.handlers.delta.DeltaMetadataStore"
 root_path = "${HOME}/.metaxy/dev"
 ```
 
@@ -44,11 +44,11 @@ You'll probably want to configure the `dev` store to [pull missing data from pro
 
 ```toml title="metaxy.toml"
 [stores.dev]
-type = "metaxy.ext.polars.DeltaMetadataStore"
+type = "metaxy.ext.polars.handlers.delta.DeltaMetadataStore"
 root_path = "${HOME}/.metaxy/dev"
 fallback_stores = ["prod"]
 
 [stores.prod]
-type = "metaxy.ext.polars.DeltaMetadataStore"
+type = "metaxy.ext.polars.handlers.delta.DeltaMetadataStore"
 root_path = "s3://my-prod-bucket/metaxy"
 ```

--- a/docs/guide/concepts/metadata-stores.md
+++ b/docs/guide/concepts/metadata-stores.md
@@ -33,7 +33,7 @@ There are generally two ways to create a `MetadataStore`. We are going to demons
 
     ```toml title="metaxy.toml"
     [stores.dev]
-    type = "metaxy.ext.polars.DeltaMetadataStore"
+    type = "metaxy.ext.polars.handlers.delta.DeltaMetadataStore"
     root_path = "/path/to/directory"
     ```
 
@@ -275,12 +275,12 @@ Example Metaxy configuration:
 
 ```toml title="metaxy.toml"
 [stores.dev]
-type = "metaxy.ext.polars.DeltaMetadataStore"
+type = "metaxy.ext.polars.handlers.delta.DeltaMetadataStore"
 root_path = "${HOME}/.metaxy/dev"
 fallback_stores = ["prod"]
 
 [stores.prod]
-type = "metaxy.ext.polars.DeltaMetadataStore"
+type = "metaxy.ext.polars.handlers.delta.DeltaMetadataStore"
 root_path = "s3://my-prod-bucket/metaxy"
 ```
 

--- a/docs/integrations/metadata-stores/storage/delta.md
+++ b/docs/integrations/metadata-stores/storage/delta.md
@@ -5,7 +5,7 @@ description: "Learn how to use Delta Lake to store Metaxy metadata."
 
 # Metaxy + Delta Lake
 
-[Delta Lake](https://delta.io/) is an open-source lakehouse storage format with ACID transactions and schema enforcement. To use Metaxy with Delta Lake, configure [`DeltaMetadataStore`][metaxy.ext.polars.DeltaMetadataStore]. It persists metadata as Delta tables and uses an in-memory Polars engine for versioning computations.
+[Delta Lake](https://delta.io/) is an open-source lakehouse storage format with ACID transactions and schema enforcement. To use Metaxy with Delta Lake, configure [`DeltaMetadataStore`][metaxy.ext.polars.handlers.delta.DeltaMetadataStore]. It persists metadata as Delta tables and uses an in-memory Polars engine for versioning computations.
 
 It supports the local filesystem and remote object stores.
 
@@ -33,7 +33,7 @@ pip install 'metaxy[delta]'
       show_root_heading: true
       heading_level: 2
 
-::: metaxy.ext.polars.DeltaMetadataStore
+::: metaxy.ext.polars.handlers.delta.DeltaMetadataStore
     options:
       members: false
       heading_level: 2

--- a/docs/integrations/metadata-stores/storage/iceberg.md
+++ b/docs/integrations/metadata-stores/storage/iceberg.md
@@ -5,7 +5,7 @@ description: "Learn how to use Apache Iceberg to store Metaxy metadata."
 
 # Metaxy + Apache Iceberg
 
-[Apache Iceberg](https://iceberg.apache.org/) is an open table format for large analytic datasets supporting ACID transactions and schema evolution. Use [`IcebergMetadataStore`][metaxy.ext.polars.IcebergMetadataStore] to read and write Metaxy metadata from and to Iceberg tables. This metadata store is built on top of [PyIceberg](https://py.iceberg.apache.org/) and uses the in-memory Polars versioning engine for versioning computations.
+[Apache Iceberg](https://iceberg.apache.org/) is an open table format for large analytic datasets supporting ACID transactions and schema evolution. Use [`IcebergMetadataStore`][metaxy.ext.polars.handlers.iceberg.IcebergMetadataStore] to read and write Metaxy metadata from and to Iceberg tables. This metadata store is built on top of [PyIceberg](https://py.iceberg.apache.org/) and uses the in-memory Polars versioning engine for versioning computations.
 
 !!! note
     By default, it uses a SQLite-backed SQL catalog for local development. You can configure any PyIceberg-supported catalog (REST, Glue, Hive) via [`catalog_properties`](#metaxy.ext.polars.handlers.iceberg.IcebergMetadataStoreConfig.catalog_properties).
@@ -29,7 +29,7 @@ pip install 'metaxy[iceberg]'
       show_root_heading: true
       heading_level: 2
 
-::: metaxy.ext.polars.IcebergMetadataStore
+::: metaxy.ext.polars.handlers.iceberg.IcebergMetadataStore
     options:
       members: false
       heading_level: 2

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -17,7 +17,7 @@ Either TOML-based or environment-based configuration is **required** to use the 
     project = "my_package"
 
     [stores.dev]
-    type = "metaxy.ext.polars.DeltaMetadataStore"
+    type = "metaxy.ext.polars.handlers.delta.DeltaMetadataStore"
     [stores.dev.config]
     root_path = "${HOME}/.metaxy/metadata"
     ```

--- a/examples/example-aggregation/metaxy.toml
+++ b/examples/example-aggregation/metaxy.toml
@@ -3,7 +3,7 @@ entrypoints = ["example_aggregation.features"]
 auto_create_tables = true # Enable for development/examples
 
 [stores.dev]
-type = "metaxy.ext.polars.DeltaMetadataStore"
+type = "metaxy.ext.polars.handlers.delta.DeltaMetadataStore"
 
 [stores.dev.config]
 root_path = "/tmp/example_aggregation"

--- a/examples/example-basic/metaxy.toml
+++ b/examples/example-basic/metaxy.toml
@@ -3,7 +3,7 @@ entrypoints = ["example_basic.__entrypoint__"]
 auto_create_tables = true # Enable for development/examples
 
 [stores.dev]
-type = "metaxy.ext.polars.DeltaMetadataStore"
+type = "metaxy.ext.polars.handlers.delta.DeltaMetadataStore"
 
 [stores.dev.config]
 root_path = "/tmp/example_basic"

--- a/examples/example-dagster/metaxy.toml
+++ b/examples/example-dagster/metaxy.toml
@@ -3,7 +3,7 @@ entrypoints = ["example_dagster.definitions"]
 auto_create_tables = true # Enable for development/examples
 
 [stores.dev]
-type = "metaxy.ext.polars.DeltaMetadataStore"
+type = "metaxy.ext.polars.handlers.delta.DeltaMetadataStore"
 
 [stores.dev.config]
 root_path = "/tmp/example_dagster"

--- a/examples/example-expansion/metaxy.toml
+++ b/examples/example-expansion/metaxy.toml
@@ -3,7 +3,7 @@ entrypoints = ["example_expansion.features"]
 auto_create_tables = true # Enable for development/examples
 
 [stores.dev]
-type = "metaxy.ext.polars.DeltaMetadataStore"
+type = "metaxy.ext.polars.handlers.delta.DeltaMetadataStore"
 
 [stores.dev.config]
 root_path = "/tmp/example_expansion"

--- a/examples/example-overview/.example.result.json
+++ b/examples/example-overview/.example.result.json
@@ -206,7 +206,7 @@
         "command": "metaxy push",
         "returncode": 0,
         "stdout": "2f02765d\n",
-        "stderr": "Recorded at: {'name': 'dev', 'display': \n'DeltaMetadataStore(path=/tmp/pytest-of-dan/pytest-1922/test_example_snapshot_ex\nample_3/example-overview)', 'resolved_from': {'name': 'dev', 'type': \n'metaxy.ext.polars.DeltaMetadataStore', 'display': \n'DeltaMetadataStore(path=/tmp/pytest-of-dan/pytest-1922/test_example_snapshot_ex\nample_3/example-overview)', 'uri': \n'/tmp/pytest-of-dan/pytest-1922/test_example_snapshot_example_3/example-overview\n/metaxy-system/feature_versions.delta'}}\n✓ Snapshot already recorded (no changes)\n",
+        "stderr": "Recorded at: {'name': 'dev', 'display': \n'DeltaMetadataStore(path=/tmp/pytest-of-dan/pytest-1922/test_example_snapshot_ex\nample_3/example-overview)', 'resolved_from': {'name': 'dev', 'type': \n'metaxy.ext.polars.handlers.delta.DeltaMetadataStore', 'display': \n'DeltaMetadataStore(path=/tmp/pytest-of-dan/pytest-1922/test_example_snapshot_ex\nample_3/example-overview)', 'uri': \n'/tmp/pytest-of-dan/pytest-1922/test_example_snapshot_example_3/example-overview\n/metaxy-system/feature_versions.delta'}}\n✓ Snapshot already recorded (no changes)\n",
         "timestamp": "2026-03-26T15:00:45.411126",
         "scenario_name": "Initial feature graph",
         "step_name": "push_graph"

--- a/examples/example-overview/metaxy.toml
+++ b/examples/example-overview/metaxy.toml
@@ -3,7 +3,7 @@ entrypoints = ["example_overview.__entrypoint__"]
 auto_create_tables = true # Enable for development/examples
 
 [stores.dev]
-type = "metaxy.ext.polars.DeltaMetadataStore"
+type = "metaxy.ext.polars.handlers.delta.DeltaMetadataStore"
 
 [stores.dev.config]
 root_path = "/tmp/example_overview"

--- a/examples/example-quickstart/metaxy.toml
+++ b/examples/example-quickstart/metaxy.toml
@@ -3,7 +3,7 @@ entrypoints = ["example_quickstart.features"]
 auto_create_tables = true # Enable for development/examples
 
 [stores.dev]
-type = "metaxy.ext.polars.DeltaMetadataStore"
+type = "metaxy.ext.polars.handlers.delta.DeltaMetadataStore"
 
 [stores.dev.config]
 root_path = "/tmp/example_quickstart"

--- a/src/metaxy/ext/polars/__init__.py
+++ b/src/metaxy/ext/polars/__init__.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from metaxy._warnings import _warn_deprecated_module
+
 if TYPE_CHECKING:
     from metaxy.ext.polars.handlers.delta import DeltaMetadataStore, DeltaMetadataStoreConfig
     from metaxy.ext.polars.handlers.iceberg import IcebergMetadataStore, IcebergMetadataStoreConfig, TableIdentifier
@@ -26,6 +28,12 @@ def __getattr__(name: str) -> Any:
 
         globals()["DeltaMetadataStore"] = DeltaMetadataStore
         globals()["DeltaMetadataStoreConfig"] = DeltaMetadataStoreConfig
+
+        _warn_deprecated_module(
+            "metaxy.ext.polars.DeltaMetadataStore",
+            "metaxy.ext.polars.handlers.delta.DeltaMetadataStore",
+        )
+
         return globals()[name]
     if name in _ICEBERG_ATTRS:
         from metaxy.ext.polars.handlers.iceberg import (
@@ -37,5 +45,11 @@ def __getattr__(name: str) -> Any:
         globals()["IcebergMetadataStore"] = IcebergMetadataStore
         globals()["IcebergMetadataStoreConfig"] = IcebergMetadataStoreConfig
         globals()["TableIdentifier"] = TableIdentifier
+
+        _warn_deprecated_module(
+            "metaxy.ext.polars.IcebergMetadataStore",
+            "metaxy.ext.polars.handlers.iceberg.IcebergMetadataStore",
+        )
+
         return globals()[name]
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/metaxy/ext/polars/handlers/delta.py
+++ b/src/metaxy/ext/polars/handlers/delta.py
@@ -43,7 +43,7 @@ class DeltaMetadataStoreConfig(MetadataStoreConfig):
     Example:
         ```toml title="metaxy.toml"
         [stores.dev]
-        type = "metaxy.ext.polars.DeltaMetadataStore"
+        type = "metaxy.ext.polars.handlers.delta.DeltaMetadataStore"
 
         [stores.dev.config]
         root_path = "s3://my-bucket/metaxy"

--- a/src/metaxy/ext/polars/handlers/iceberg.py
+++ b/src/metaxy/ext/polars/handlers/iceberg.py
@@ -62,7 +62,7 @@ class IcebergMetadataStoreConfig(MetadataStoreConfig):
     Example:
         ```toml title="metaxy.toml"
         [stores.dev]
-        type = "metaxy.ext.polars.IcebergMetadataStore"
+        type = "metaxy.ext.polars.handlers.iceberg.IcebergMetadataStore"
 
         [stores.dev.config]
         warehouse = "/path/to/warehouse"

--- a/tach.toml
+++ b/tach.toml
@@ -17,20 +17,7 @@ layers = [
 
 [[modules]]
 path = "metaxy"
-depends_on = [
-  "metaxy.metadata_store",
-  "metaxy.entrypoints",
-  "metaxy.models.types",
-  "metaxy.utils",
-  "metaxy._warnings",
-  "metaxy.models",
-  "metaxy.config",
-  "metaxy._version",
-  "metaxy.versioning",
-  "metaxy._decorators",
-  "metaxy._exceptions",
-  "metaxy._hashing",
-]
+depends_on = []
 
 [[modules]]
 path = "metaxy._decorators"
@@ -38,11 +25,11 @@ depends_on = []
 
 [[modules]]
 path = "metaxy._exceptions"
-depends_on = ["metaxy.utils"]
+depends_on = []
 
 [[modules]]
 path = "metaxy._hashing"
-depends_on = ["metaxy._decorators", "metaxy.config"]
+depends_on = []
 
 [[modules]]
 path = "metaxy._packaging"
@@ -61,174 +48,106 @@ depends_on = []
 [[modules]]
 path = "metaxy.cli"
 layer = "cli"
-depends_on = [
-  "metaxy",
-  "metaxy._version",
-]
+depends_on = []
 
 # --- Ext layer ---
 
 [[modules]]
 path = "metaxy.ext.bigquery"
 layer = "ext"
-depends_on = ["metaxy._decorators", "metaxy.ext.ibis"]
+depends_on = []
 
 [[modules]]
 path = "metaxy.ext.clickhouse"
 layer = "ext"
-depends_on = [
-  "metaxy._decorators",
-  "metaxy.ext.ibis",
-]
+depends_on = []
 
 [[modules]]
 path = "metaxy.ext.dagster"
 layer = "ext"
-depends_on = [
-  "metaxy",
-  "metaxy._version",
-  "metaxy._decorators",
-]
+depends_on = []
 
 [[modules]]
 path = "metaxy.ext.duckdb"
 layer = "ext"
-depends_on = [
-  "metaxy._decorators",
-  "metaxy.ext.ibis",
-]
+depends_on = []
 
 [[modules]]
 path = "metaxy.ext.ibis"
 layer = "ext"
-depends_on = [
-  "metaxy._decorators",
-]
+depends_on = []
 
 [[modules]]
 path = "metaxy.ext.lancedb"
 layer = "ext"
-depends_on = [
-  "metaxy._decorators",
-]
+depends_on = []
 
 [[modules]]
 path = "metaxy.ext.metadata_stores"
 layer = "ext"
-depends_on = [
-  "metaxy._warnings",
-  "metaxy.ext.bigquery",
-  "metaxy.ext.clickhouse",
-  "metaxy.ext.duckdb",
-  "metaxy.ext.lancedb",
-  "metaxy.ext.polars",
-  "metaxy.ext.postgresql",
-]
+depends_on = []
 
 [[modules]]
 path = "metaxy.ext.mcp"
 layer = "ext"
-depends_on = ["metaxy"]
+depends_on = []
 
 [[modules]]
 path = "metaxy.ext.polars"
 layer = "ext"
-depends_on = [
-  "metaxy._decorators",
-]
+depends_on = []
 
 [[modules]]
 path = "metaxy.ext.postgresql"
 layer = "ext"
-depends_on = [
-  "metaxy._decorators",
-  "metaxy.ext.ibis",
-]
+depends_on = []
 
 [[modules]]
 path = "metaxy.ext.ray"
 layer = "ext"
-depends_on = ["metaxy"]
+depends_on = []
 
 [[modules]]
 path = "metaxy.ext.sqlalchemy"
 layer = "ext"
-depends_on = [
-  "metaxy._decorators",
-]
+depends_on = []
 
 [[modules]]
 path = "metaxy.ext.sqlmodel"
 layer = "ext"
-depends_on = [
-  "metaxy.ext.sqlalchemy",
-  "metaxy",
-  "metaxy._decorators",
-]
+depends_on = []
 
 # --- Core layer ---
 
 [[modules]]
 path = "metaxy.config"
 layer = "core"
-depends_on = ["metaxy._decorators", "metaxy._hashing", "metaxy.models"]
+depends_on = []
 
 [[modules]]
 path = "metaxy.entrypoints"
 layer = "core"
-depends_on = ["metaxy.models"]
+depends_on = []
 
 [[modules]]
 path = "metaxy.graph"
 layer = "core"
-depends_on = [
-  "metaxy.metadata_store",
-  "metaxy.metadata_store.base",
-  "metaxy.models.types",
-  "metaxy.metadata_store.exceptions",
-  "metaxy.models",
-  "metaxy.utils",
-]
+depends_on = []
 
 [[modules]]
 path = "metaxy.metadata_store"
 layer = "core"
-depends_on = [
-  "metaxy.models",
-  "metaxy.config",
-  "metaxy._version",
-  "metaxy.metadata_store.base",
-  "metaxy.metadata_store.exceptions",
-  "metaxy.metadata_store.types",
-  "metaxy.models.constants",
-  "metaxy._warnings",
-  "metaxy.models.types",
-]
+depends_on = []
 
 [[modules]]
 path = "metaxy.metadata_store.base"
 layer = "core"
-depends_on = [
-  "metaxy.metadata_store",
-  "metaxy._decorators",
-  "metaxy.models.types",
-  "metaxy.metadata_store.types",
-  "metaxy.metadata_store.exceptions",
-  "metaxy.config",
-  "metaxy.metadata_store.warnings",
-  "metaxy.ext.polars.versioning",
-  "metaxy.utils",
-  "metaxy.metadata_store.utils",
-  "metaxy.metadata_store.fallback",
-  "metaxy.models",
-  "metaxy.versioning",
-  "metaxy.models.constants",
-]
+depends_on = []
 
 [[modules]]
 path = "metaxy.metadata_store.exceptions"
 layer = "core"
-depends_on = ["metaxy._decorators"]
+depends_on = []
 
 [[modules]]
 path = "metaxy.metadata_store.fallback"
@@ -243,7 +162,7 @@ depends_on = []
 [[modules]]
 path = "metaxy.metadata_store.utils"
 layer = "core"
-depends_on = ["metaxy.utils"]
+depends_on = []
 
 [[modules]]
 path = "metaxy.metadata_store.warnings"
@@ -253,15 +172,7 @@ depends_on = []
 [[modules]]
 path = "metaxy.models"
 layer = "core"
-depends_on = [
-  "metaxy._hashing",
-  "metaxy._packaging",
-  "metaxy.models.constants",
-  "metaxy._decorators",
-  "metaxy.config",
-  "metaxy.models.types",
-  "metaxy.utils",
-]
+depends_on = []
 
 [[modules]]
 path = "metaxy.models.constants"
@@ -271,37 +182,20 @@ depends_on = []
 [[modules]]
 path = "metaxy.models.types"
 layer = "core"
-depends_on = ["metaxy.models", "metaxy._decorators"]
+depends_on = []
 
 [[modules]]
 path = "metaxy.utils"
 layer = "core"
-depends_on = [
-  "metaxy.metadata_store",
-  "metaxy._exceptions",
-  "metaxy._warnings",
-  "metaxy.metadata_store.exceptions",
-  "metaxy._decorators",
-  "metaxy.models.types",
-  "metaxy.config",
-  "metaxy.models",
-]
+depends_on = []
 
 [[modules]]
 path = "metaxy.versioning"
 layer = "core"
-depends_on = [
-  "metaxy.models",
-  "metaxy.utils",
-  "metaxy.config",
-  "metaxy.models.constants",
-  "metaxy._decorators",
-  "metaxy.models.types",
-  "metaxy._hashing",
-]
+depends_on = []
 
 [[modules]]
 # TODO: get this one of core!
 path = "metaxy.ext.polars.versioning"
 layer = "core"
-depends_on = ["metaxy.config", "metaxy.utils", "metaxy.versioning"]
+depends_on = []


### PR DESCRIPTION
## Summary

This PR deprecates importing DeltaLake and Iceberg stores from `metaxy.ext.polars`. 

Instead, they should be imported from `metaxy.ext.polars.handlers.<store>`. 

<!-- Brief description of the changes -->

## Changelog

- chore(deltalake): the `metaxy.ext.polars.DeltaMetadataStore` import path has been deprecated in favor of `metaxy.ext.polars.handlers.delta.DeltaMetadataStore`
- chore(iceberg): the `metaxy.ext.iceberg.IcebergMetadataStore` import path has been deprecated in favor of `metaxy.ext.polars.handlers.iceberg.IcebergMetadataStore`

<!--
User-facing changelog details, rendered below the commit title in CHANGELOG.md.
Delete this section if there are no user-facing changes.
-->

## Test Plan

<!-- How was this tested? -->