### PR TITLE
fix(dagster): table preview for `Map` columns with non-primitive value types

### DIFF
--- a/src/metaxy/ext/dagster/table_metadata.py
+++ b/src/metaxy/ext/dagster/table_metadata.py
@@ -411,6 +411,18 @@ def _prepare_dataframe_for_table_record(df: pl.DataFrame) -> pl.DataFrame:
     return df.select(exprs)
 
 
+def _json_encode_expr(expr: pl.Expr) -> pl.Expr:
+    """Return a Polars Expr that JSON-encodes the value of `expr` to a String.
+
+    Polars exposes `.struct.json_encode()` only on Struct dtype, so to encode
+    a value of arbitrary dtype we wrap it in a 1-field struct, encode that,
+    then strip the wrapper via regex. Output is a JSON literal: strings are
+    quoted, numbers/bools/null are bare, lists/structs/arrays/maps are
+    recursively encoded.
+    """
+    return pl.struct(expr.alias("_")).struct.json_encode().str.extract(r'\{"_":(.*)\}', 1)
+
+
 def _truncate_list_expr(list_expr: pl.Expr, alias: str, max_items: int = 2) -> pl.Expr:
     """Truncate a list expression and convert to string.
 
@@ -434,18 +446,14 @@ def _truncate_list_expr(list_expr: pl.Expr, alias: str, max_items: int = 2) -> p
         list_expr.list.tail(half),
     )
 
-    # Convert to JSON string via struct wrapper
-    def to_json(expr: pl.Expr) -> pl.Expr:
-        return pl.struct(expr.alias("_")).struct.json_encode().str.extract(r'\{"_":(.*)\}', 1)
-
-    short_result = to_json(list_expr)
+    short_result = _json_encode_expr(list_expr)
     # For truncated: insert ".." after the first half elements
     # e.g., [1,10] -> [1,..,10]
     # Match: opening bracket, then `half` comma-separated values
     # The pattern matches values that may contain nested brackets
     value_pattern = r"[^\[\],]+(?:\[[^\]]*\])?"  # matches value or value[...]
     first_n_values = ",".join([value_pattern] * half)
-    long_result = to_json(truncated).str.replace(
+    long_result = _json_encode_expr(truncated).str.replace(
         r"^(\[" + first_n_values + r"),",
         "$1,..,",
     )
@@ -456,17 +464,18 @@ def _truncate_list_expr(list_expr: pl.Expr, alias: str, max_items: int = 2) -> p
 def _map_to_json_expr(list_expr: pl.Expr, alias: str) -> pl.Expr:
     """Convert a Map's physical List(Struct({key, value})) expression to a JSON object string.
 
-    Produces `{"key1": "value1", "key2": "value2"}` format.
+    Produces `{"key1": "value1", "key2": [1, 2, 3]}` format. Both keys and
+    values are JSON-encoded so any value dtype works: strings are quoted,
+    numbers/bools/null are rendered as JSON literals, and complex types
+    (List/Struct/Array/Map) are recursively encoded by Polars.
     """
     return (
         pl.lit("{")
         .add(
             list_expr.list.eval(
-                pl.lit('"')
-                .add(pl.element().struct.field("key"))
-                .add(pl.lit('": "'))
-                .add(pl.element().struct.field("value").cast(pl.String))
-                .add(pl.lit('"'))
+                _json_encode_expr(pl.element().struct.field("key"))
+                .add(pl.lit(": "))
+                .add(_json_encode_expr(pl.element().struct.field("value")))
             ).list.join(", ")
         )
         .add(pl.lit("}"))

--- a/tests/ext/dagster/test_table_metadata.py
+++ b/tests/ext/dagster/test_table_metadata.py
@@ -428,3 +428,31 @@ def test_build_table_preview_map_columns() -> None:
 
     result = build_table_preview_metadata(nw.from_native(df.lazy()), schema, n_rows=5)
     assert result.records[0].data["mapping"] == '{"a": "1", "b": "2"}'
+
+
+def test_build_table_preview_map_with_list_values() -> None:
+    """Map columns whose value type is a non-primitive (e.g. List[Int64]) must
+    still render — the formatter cannot assume the value is castable to String.
+
+    Regression test: an `encoding_shape: dict[str, list[int]]` field on a feature
+    is stored as ``Map[str, List[Int64]]``. The previous implementation called
+    ``cast(pl.String)`` on the value, which raised
+    ``InvalidOperationError: cannot cast List type (inner: 'Int64', to: 'String')``
+    and broke the Dagster table preview metadata build.
+    """
+    from metaxy.utils._arrow_map import convert_structs_to_maps
+
+    df = convert_structs_to_maps(
+        pl.DataFrame({"id": [1], "shape": [{"motion": [12, 750, 256], "audio": [12, 1500]}]}),
+        columns=["shape"],
+    )
+
+    schema = dg.TableSchema(
+        columns=[
+            dg.TableColumn(name="id", type="int"),
+            dg.TableColumn(name="shape", type="Map"),
+        ]
+    )
+
+    result = build_table_preview_metadata(nw.from_native(df.lazy()), schema, n_rows=5)
+    assert result.records[0].data["shape"] == '{"motion": [12,750,256], "audio": [12,1500]}'


### PR DESCRIPTION
## Fix Dagster table preview crash for Map columns with non-primitive value types

### Problem

#### Observations

A Dagster asset materialization in a downstream project produced this error twice (once for the main asset, once for the `__errors` companion) while the materialization itself succeeded:

```
metaxy/ext/dagster/utils.py:578 build_runtime_feature_metadata
  -> metaxy/ext/dagster/table_metadata.py:411 _prepare_dataframe_for_table_record
  -> df.select(exprs)

polars.exceptions.InvalidOperationError: cannot cast List type (inner: 'Int64', to: 'String')

Failing expr: element().struct.field_by_name(value)().strict_cast(String)
Outer expr:   col("encoding_shape").to_physical().list.eval(...)
```

The triggering column was a feature field typed `dict[str, list[int]]`, which metaxy stores as `Map[str, List[Int64]]` (a `polars_map.Map` extension whose physical layout is `List(Struct({key, value}))`).

#### Inferences

- `_map_to_json_expr` was the only path that handled Map columns in the table-preview formatter. It assumed `Map.value` was always castable to `String` (correct for `Map[str, str]`, the only Map columns metaxy emitted before).
- A Map whose value is itself a List/Struct/Array/Map would break the same way; `List[Int64]` was simply the first such type to ship.

### Solution

Encode both the key and the value via Polars' native `json_encode`, which handles every dtype recursively. Polars only exposes `json_encode` on `Struct`, so the value is wrapped in a 1-field struct, encoded, and the wrapper is stripped via regex.

The same trick was already duplicated as a nested `to_json` helper inside `_truncate_list_expr`. Both copies are now replaced by a single module-level `_json_encode_expr`.

Output format:

- `Map[str, str]` → `'{"a": "1", "b": "2"}'` (unchanged — existing snapshot still passes)
- `Map[str, List[Int64]]` → `'{"motion": [12,750,256], "audio": [12,1500]}'`
- Any nested complex value (Struct, Array, Map) is JSON-encoded recursively.

### Changes

- `src/metaxy/ext/dagster/table_metadata.py`
    - New module-level `_json_encode_expr(expr)`: wrap in a 1-field struct, `struct.json_encode()`, strip wrapper via regex.
    - `_map_to_json_expr`: route both key and value through `_json_encode_expr` (replaces the broken `cast(pl.String)` on the value).
    - `_truncate_list_expr`: drop the local `to_json` and call `_json_encode_expr` instead.
- `tests/ext/dagster/test_table_metadata.py`
    - Add `test_build_table_preview_map_with_list_values` — regression test that builds a `Map[str, List[Int64]]` column and asserts the rendered preview. Pre-fix it raised the exact `cannot cast List type` error from the production log.

### Verification

- `ruff check`, `ruff format --check`, `ty check` on touched files: clean.
- `pytest tests/ext/dagster/test_table_metadata.py`: 14 passed, 9 snapshots passed.
- `pytest tests/ext/dagster/`: 215 passed, 72 skipped (clickhouse-marker), 0 failed.
- All three modified helpers are `_`\-prefixed and have no callers outside `table_metadata.py` (verified by grep).