### PR TITLE
docs(duckdb): show preinstalled extensions

### DIFF
--- a/docs/integrations/metadata-stores/databases/duckdb.md
+++ b/docs/integrations/metadata-stores/databases/duckdb.md
@@ -21,6 +21,26 @@ description: "Learn how to use DuckDB as a Metaxy metadata store."
 pip install 'metaxy[duckdb]'
 ```
 
+## Pre-installing DuckDB Extensions
+
+Pre-install extensions during the image build for faster startup and air-gapped deployments.
+
+!!! example
+
+    List the extensions explicitly in a text file:
+
+    ```sql title="duckdb-extensions.sql"
+    --8<-- "example-ducklake/duckdb-extensions.sql"
+    ```
+
+    Install them before copying the application code to keep the extension layer cacheable:
+
+    ```dockerfile title="Dockerfile"
+    --8<-- "example-ducklake/Dockerfile"
+    ```
+
+    Keep the DuckDB CLI and Python package versions equal. Update the text file when the application's required extensions change.
+
 ## API Reference
 
 <!-- dprint-ignore-start -->

--- a/docs/integrations/metadata-stores/storage/ducklake.md
+++ b/docs/integrations/metadata-stores/storage/ducklake.md
@@ -13,6 +13,8 @@ description: "Learn how to store Metaxy metadata in DuckLake."
 
 Currently, there is only one production-ready implementation of DuckLake - via DuckDB, and the built-in [`DuckDBMetadataStore`][metaxy.ext.duckdb.DuckDBMetadataStore] can be configured to use DuckLake as its storage backend. Learn more about the DuckDB integration [here](/integrations/metadata-stores/databases/duckdb.md).
 
+For air-gapped deployments, [pre-install the required DuckDB extensions](/integrations/metadata-stores/databases/duckdb.md#pre-installing-duckdb-extensions).
+
 ## Configuration
 
 There are two main parts that configure DuckLake: a **catalog** (where the transaction log and other metadata is stored) and a **storage** (where the data files (1) live).

--- a/examples/example-ducklake/Dockerfile
+++ b/examples/example-ducklake/Dockerfile
@@ -1,0 +1,12 @@
+ARG DUCKDB_VERSION=1.4.3
+
+FROM duckdb/duckdb:${DUCKDB_VERSION} AS duckdb-extensions
+COPY duckdb-extensions.sql /duckdb-extensions.sql
+RUN ["/duckdb", "-init", "/duckdb-extensions.sql", "-c", "SELECT 1"]
+
+FROM python:3.12-slim
+ARG DUCKDB_VERSION
+COPY --from=duckdb-extensions /root/.duckdb /root/.duckdb
+RUN pip install --no-cache-dir "duckdb==${DUCKDB_VERSION}" "metaxy[duckdb]"
+WORKDIR /app
+COPY . /app

--- a/examples/example-ducklake/duckdb-extensions.sql
+++ b/examples/example-ducklake/duckdb-extensions.sql
@@ -1,0 +1,3 @@
+INSTALL ducklake;
+INSTALL httpfs;
+INSTALL hashfuncs FROM community;


### PR DESCRIPTION
## Summary

Resolves #1027.

Documents how to bake DuckDB extensions into a Docker image without changing Metaxy:

- explicitly list extensions in `duckdb-extensions.sql`
- install them in a version-aligned DuckDB builder stage
- copy the baked extension directory into the application image

## Test Plan

- `uv run --group docs mkdocs build --clean --strict`
- `uv run --group docs pytest ./docs -q`
- verified `ducklake`, `httpfs`, and `hashfuncs` install from the manifest