### PR TITLE
feat(core): add metadata query format parser

### DIFF
--- a/docs/guide/concepts/metadata-queries.md
+++ b/docs/guide/concepts/metadata-queries.md
@@ -1,0 +1,44 @@
+---
+title: "Metadata Queries"
+description: "Metadata query syntax."
+---
+
+# Metadata Queries
+
+A metadata query selects a feature by key and can specify a version and filters.
+
+```text
+<key>[:<version>][?<filter>[&<filter>...]]
+```
+
+??? info "Formal Grammar (EBNF)"
+
+    ```text
+    query        = key, [":", version], ["?", filters];
+    key          = first-part, {"/", part};
+    first-part   = (lowercase-letter | "_"), {lowercase-letter | digit | "_" | "-"};
+    part         = (lowercase-letter | digit | "_"), {lowercase-letter | digit | "_" | "-"};
+    version      = "current" | "latest" | version-hash;
+    version-hash = alphanumeric, {alphanumeric};
+    filters      = filter, {"&", filter};
+    ```
+
+Feature keys follow [`FeatureKey`][metaxy.FeatureKey] rules. Key parts cannot contain double underscores (`__`).
+
+- `current` selects the version defined by the running code. This is the default.
+
+- `latest` selects the latest version recorded in the metadata store.
+
+- An alphanumeric version hash selects that exact version.
+
+Filters use Metaxy's [SQL-like filter syntax](filters.md). Separate multiple filters with `&`; they are combined with `AND`.
+
+## Example
+
+```py
+import metaxy as mx
+
+query = mx.MetadataQuery.from_uri("group/my_feature:latest?age>25&status='active'")
+```
+
+`:` separates the key from its version, `?` starts the filters, and `&` separates filters. Inside filters, encode literal `?` as `%3F`, `&` as `%26`, and `%` as `%25`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,6 +66,7 @@ plugins:
   - exclude:
       glob:
         - snippets/*
+        - guide/concepts/metadata-queries.md
   - metaxy-examples:
       examples_dir: "../examples"
   - cyclopts

--- a/src/metaxy/__init__.py
+++ b/src/metaxy/__init__.py
@@ -43,6 +43,11 @@ from metaxy.models.fields_mapping import (
     FieldsMappingType,
 )
 from metaxy.models.lineage import LineageRelationship
+from metaxy.models.metadata_query import (
+    MetadataQuery,
+    MetadataQueryParseError,
+    parse_metadata_uri,
+)
 from metaxy.models.types import (
     CoercibleToFeatureKey,
     CoercibleToFieldKey,
@@ -190,6 +195,9 @@ __all__ = [
     "IDColumns",
     "HashAlgorithm",
     "LineageRelationship",
+    "MetadataQuery",
+    "MetadataQueryParseError",
+    "parse_metadata_uri",
     "AccessMode",
     "current_graph",
     "MetaxyMissingFeatureDependency",

--- a/src/metaxy/models/metadata_query.py
+++ b/src/metaxy/models/metadata_query.py
@@ -1,0 +1,85 @@
+"""Parsing for metadata query strings."""
+
+from __future__ import annotations
+
+import re
+from urllib.parse import unquote
+
+import narwhals as nw
+from pydantic import field_validator
+from typing_extensions import Self
+
+from metaxy._decorators import public
+from metaxy.models.bases import FrozenBaseModel
+from metaxy.models.filter_expression import NarwhalsFilter
+from metaxy.models.types import FeatureKey
+
+_METADATA_URI_PATTERN = re.compile(
+    r"(?P<key>[^:?\s]+)(?::(?P<version>[A-Za-z0-9]+))?"
+    r"(?:\?(?P<filters>[^\s?\r\n](?:[^?\r\n]*[^\s?\r\n])?))?"
+)
+
+
+@public
+class MetadataQueryParseError(ValueError):
+    """Raised when a metadata query string is invalid."""
+
+
+@public
+class MetadataQuery(FrozenBaseModel):
+    """A parsed ``<key>:<version>?<filters>`` metadata query."""
+
+    key: FeatureKey
+    version: str = "current"
+    filters: tuple[NarwhalsFilter, ...] = ()
+
+    @field_validator("version")
+    @classmethod
+    def _validate_version(cls, version: str) -> str:
+        if version not in {"current", "latest"} and re.fullmatch(r"[A-Za-z0-9]+", version) is None:
+            raise ValueError("Version must be 'current', 'latest', or an alphanumeric version hash.")
+        return version
+
+    @classmethod
+    def from_uri(cls, uri: str) -> Self:
+        """Parse ``<key>[:<version>][?<filter>[&<filter>...]]``."""
+        match = _METADATA_URI_PATTERN.fullmatch(uri)
+        if match is None:
+            raise MetadataQueryParseError(f"Invalid metadata URI: {uri!r}")
+
+        try:
+            filter_string = match["filters"]
+            if filter_string and re.search(r"%(?![0-9A-Fa-f]{2})", filter_string):
+                raise ValueError("Invalid percent escape.")
+            filters = (
+                tuple(
+                    NarwhalsFilter.model_validate(unquote(item, errors="strict")) for item in filter_string.split("&")
+                )
+                if filter_string
+                else ()
+            )
+            return cls(
+                key=FeatureKey(match["key"]),
+                version=match["version"] or "current",
+                filters=filters,
+            )
+        except ValueError as exc:
+            raise MetadataQueryParseError(f"Invalid metadata URI {uri!r}: {exc}") from exc
+
+    @property
+    def filter_expressions(self) -> tuple[nw.Expr, ...]:
+        """Return filters as Narwhals expressions."""
+        return tuple(filter_.to_expr() for filter_ in self.filters)
+
+
+@public
+def parse_metadata_uri(uri: str) -> MetadataQuery:
+    """Parse a metadata URI."""
+    return MetadataQuery.from_uri(uri)
+
+
+__all__ = [
+    "MetadataQuery",
+    "MetadataQueryParseError",
+    "parse_metadata_uri",
+]

--- a/tests/models/test_metadata_query.py
+++ b/tests/models/test_metadata_query.py
@@ -1,0 +1,76 @@
+import narwhals as nw
+import polars as pl
+import pytest
+from metaxy import FeatureKey, MetadataQuery, parse_metadata_uri
+from metaxy.models.metadata_query import MetadataQueryParseError
+
+
+@pytest.mark.parametrize(
+    ("query_string", "key", "version", "filter_count"),
+    [
+        ("my_feature", "my_feature", "current", 0),
+        ("group/subgroup/feature:current", "group/subgroup/feature", "current", 0),
+        ("my_feature:latest", "my_feature", "latest", 0),
+        ("my_feature:local", "my_feature", "local", 0),
+        ("my_feature:abc123def", "my_feature", "abc123def", 0),
+        ("my_feature:latest?age>25&status='active'", "my_feature", "latest", 2),
+    ],
+)
+def test_parse_metadata_uri(
+    query_string: str,
+    key: str,
+    version: str,
+    filter_count: int,
+) -> None:
+    query = parse_metadata_uri(query_string)
+
+    assert query.key == FeatureKey(key)
+    assert query.version == version
+    assert len(query.filters) == filter_count
+
+
+def test_metadata_query_filters_are_executable() -> None:
+    query = MetadataQuery.from_uri("my_feature?age>25&status='active'")
+    frame = nw.from_native(pl.DataFrame({"age": [20, 30, 40], "status": ["active", "active", "deleted"]}))
+
+    result = frame.filter(*query.filter_expressions).to_native()
+
+    assert result["age"].to_list() == [30]
+
+
+def test_metadata_query_percent_encoded_delimiters_are_literals() -> None:
+    query = MetadataQuery.from_uri("my_feature?label='a%26b%25'&note='x%3Fy'")
+    frame = nw.from_native(pl.DataFrame({"label": ["a&b%", "a&b%"], "note": ["x?y", "z"]}))
+
+    result = frame.filter(*query.filter_expressions).to_native()
+
+    assert len(query.filters) == 2
+    assert result["note"].to_list() == ["x?y"]
+
+
+def test_metadata_query_model_is_immutable() -> None:
+    query = MetadataQuery(key=FeatureKey("my_feature"))
+
+    with pytest.raises(ValueError):
+        query.version = "latest"
+
+
+@pytest.mark.parametrize(
+    "query_string",
+    [
+        "",
+        " my_feature",
+        "MyFeature",
+        "my_feature:",
+        "my_feature:abc-123",
+        "my_feature?",
+        "my_feature?age>25&",
+        "my_feature:latest:extra",
+        "my_feature?age>25?status='active'",
+        "my_feature?label='%GG'",
+        "my_feature?label='%FF'",
+    ],
+)
+def test_invalid_metadata_query_raises(query_string: str) -> None:
+    with pytest.raises(MetadataQueryParseError):
+        parse_metadata_uri(query_string)


### PR DESCRIPTION
## Summary

- add a public `MetadataQuery` model and `parse_metadata_query()` for `<key>[:<version>][?<filters>]`
- use `current` as the canonical code version, with `latest` and explicit version hashes supported
- reuse the existing SQL-like Narwhals filter parser and document the formal grammar

## Changelog

Added a metadata query format combining feature keys, versions, and filters.

## Test Plan

standard CI pipeline

Resolves #59