### PR TITLE
feat(core): make lifecycle system columns configurable

### DIFF
--- a/docs/reference/system-columns.md
+++ b/docs/reference/system-columns.md
@@ -25,7 +25,11 @@ the [metadata store][metaxy.MetadataStore]. Learn more about the storage layout 
 | `metaxy_deleted_at`            | Timestamp when the metadata row was soft-deleted (null if active)   | sample  | string |
 | `metaxy_materialization_id`    | External orchestration run ID (e.g., Dagster, Airflow) for tracking | run     | string |
 
-All system column names start with the `metaxy_` prefix.
+The three lifecycle column names can be changed with
+[`created_at_column`](./configuration.md#metaxy.config.MetaxyConfig.created_at_column),
+[`updated_at_column`](./configuration.md#metaxy.config.MetaxyConfig.updated_at_column), and
+[`deleted_at_column`](./configuration.md#metaxy.config.MetaxyConfig.deleted_at_column). This lets Metaxy reuse
+existing timestamp columns. All other system column names start with the `metaxy_` prefix.
 
 ## Example Table
 

--- a/src/metaxy/config/models/metaxy_config.py
+++ b/src/metaxy/config/models/metaxy_config.py
@@ -200,6 +200,44 @@ class MetaxyConfig(BaseSettings):
         description="Auto-create tables when opening stores. It is not advised to enable this setting in production.",
     )
 
+    created_at_column: str = PydanticField(
+        default="metaxy_created_at",
+        min_length=1,
+        description="System column used for metadata row creation timestamps.",
+    )
+
+    updated_at_column: str = PydanticField(
+        default="metaxy_updated_at",
+        min_length=1,
+        description="System column used for metadata row update timestamps.",
+    )
+
+    deleted_at_column: str = PydanticField(
+        default="metaxy_deleted_at",
+        min_length=1,
+        description="System column used for metadata row soft-deletion timestamps.",
+    )
+
+    @model_validator(mode="after")
+    def validate_lifecycle_columns(self) -> Self:
+        columns = {
+            self.created_at_column,
+            self.updated_at_column,
+            self.deleted_at_column,
+        }
+        if len(columns) != 3:
+            raise ValueError("created_at_column, updated_at_column, and deleted_at_column must be distinct")
+
+        conflicts = {
+            column
+            for column in columns
+            if column.startswith("metaxy_")
+            and column not in {"metaxy_created_at", "metaxy_updated_at", "metaxy_deleted_at"}
+        }
+        if conflicts:
+            raise ValueError(f"Lifecycle columns conflict with reserved Metaxy system columns: {sorted(conflicts)}")
+        return self
+
     project: str | None = PydanticField(
         default=None,
         description="[Project](/guide/concepts/projects.md) name. Used to scope operations to enable multiple independent projects in a shared metadata store. Does not modify feature keys or table names. Project names must be valid alphanumeric strings with dashes, underscores, and cannot contain forward slashes (`/`) or double underscores (`__`)",

--- a/src/metaxy/ext/dagster/observable.py
+++ b/src/metaxy/ext/dagster/observable.py
@@ -34,7 +34,7 @@ def observable_metaxy_asset(
     """Decorator to create an observable source asset for a Metaxy feature.
 
     The observation reads the feature's metadata from the store, counts rows,
-    and uses `mean(metaxy_created_at)` as the data version to track changes.
+    and uses the mean configured creation timestamp as the data version.
     Using mean ensures that both additions and deletions are detected.
 
     The decorated function receives `(context, store, lazy_df)` and can return

--- a/src/metaxy/ext/dagster/table_metadata.py
+++ b/src/metaxy/ext/dagster/table_metadata.py
@@ -14,9 +14,12 @@ import polars as pl
 import metaxy as mx
 from metaxy.ext.dagster.utils import get_asset_key_for_metaxy_feature_spec
 from metaxy.models.constants import (
-    ALL_SYSTEM_COLUMNS,
     METAXY_CREATED_AT,
+    METAXY_DELETED_AT,
+    METAXY_UPDATED_AT,
     SYSTEM_COLUMNS_WITH_LINEAGE,
+    get_lifecycle_system_columns,
+    get_reserved_system_columns,
 )
 
 
@@ -45,11 +48,17 @@ def build_column_schema(feature: mx.FeatureDefinition | type[mx.BaseFeature]) ->
     else:
         feature_cls = feature
 
+    created_at_column, updated_at_column, deleted_at_column = get_lifecycle_system_columns()
+    lifecycle_columns = {
+        METAXY_CREATED_AT: created_at_column,
+        METAXY_UPDATED_AT: updated_at_column,
+        METAXY_DELETED_AT: deleted_at_column,
+    }
     columns: list[dg.TableColumn] = []
     for field_name, field_info in feature_cls.model_fields.items():
         columns.append(
             dg.TableColumn(
-                name=field_name,
+                name=lifecycle_columns.get(field_name, field_name),
                 type=_get_type_string(field_info.annotation),
                 description=field_info.description,
             )
@@ -202,7 +211,7 @@ def build_column_lineage(
 
         # Process direct pass-through columns (same name in both, not renamed, ID, or system)
         # System columns are handled separately below since only some have lineage
-        handled_columns = set(id_column_mapping.keys()) | set(reverse_rename.keys()) | ALL_SYSTEM_COLUMNS
+        handled_columns = set(id_column_mapping.keys()) | set(reverse_rename.keys()) | get_reserved_system_columns()
         for col in downstream_columns - handled_columns:
             if col in upstream_columns:
                 if col not in deps_by_column:
@@ -298,8 +307,8 @@ def _collect_tail(lazy_df: nw.LazyFrame[Any], n_rows: int) -> pl.DataFrame:
     - Polars: Uses .tail() directly
     - Ibis: Uses sort + head since tail() is not available
 
-    For backends without tail(), we sort by `metaxy_created_at` (which always
-    exists in Metaxy feature tables) to get the most recent rows.
+    For backends without tail(), we sort by the configured creation timestamp
+    to get the most recent rows.
 
     Args:
         lazy_df: A narwhals LazyFrame to collect from.
@@ -313,10 +322,11 @@ def _collect_tail(lazy_df: nw.LazyFrame[Any], n_rows: int) -> pl.DataFrame:
         return lazy_df.tail(n_rows).collect().to_polars()
     else:
         # For backends without tail() (e.g., Ibis), use sort + head to simulate it
-        # Sort descending by metaxy_created_at (latest first), take head(n_rows),
+        # Sort descending by creation timestamp (latest first), take head(n_rows),
         # then sort ascending to restore chronological order
+        created_at_column, _, _ = get_lifecycle_system_columns()
         return (
-            lazy_df.sort(METAXY_CREATED_AT, descending=True).head(n_rows).sort(METAXY_CREATED_AT).collect().to_polars()
+            lazy_df.sort(created_at_column, descending=True).head(n_rows).sort(created_at_column).collect().to_polars()
         )
 
 

--- a/src/metaxy/ext/dagster/utils.py
+++ b/src/metaxy/ext/dagster/utils.py
@@ -16,7 +16,7 @@ from metaxy.ext.dagster.constants import (
 )
 from metaxy.ext.dagster.resources import MetaxyStoreFromConfigResource
 from metaxy.metadata_store.exceptions import FeatureNotFoundError
-from metaxy.models.constants import METAXY_CREATED_AT, METAXY_MATERIALIZATION_ID
+from metaxy.models.constants import METAXY_MATERIALIZATION_ID, get_lifecycle_system_columns
 
 
 @public
@@ -204,7 +204,7 @@ def compute_stats_from_lazy_frame(lazy_df: nw.LazyFrame) -> FeatureStats:
     """Compute statistics from a narwhals LazyFrame.
 
     Computes row count and data version from the frame.
-    The data version is based on mean(metaxy_created_at) to detect both
+    The data version is based on the mean creation timestamp to detect both
     additions and deletions.
 
     Args:
@@ -213,9 +213,10 @@ def compute_stats_from_lazy_frame(lazy_df: nw.LazyFrame) -> FeatureStats:
     Returns:
         FeatureStats with row_count and data_version.
     """
+    created_at_column, _, _ = get_lifecycle_system_columns()
     stats = lazy_df.select(
         nw.len().alias("__count"),
-        nw.col(METAXY_CREATED_AT).cast(nw.Float64).mean().alias("__mean_ts"),
+        nw.col(created_at_column).cast(nw.Float64).mean().alias("__mean_ts"),
     ).collect()
 
     row_count: int = stats.item(0, "__count")
@@ -233,7 +234,7 @@ def compute_feature_stats(
     """Compute statistics for a feature's metadata.
 
     Reads the feature metadata and computes row count and data version.
-    The data version is based on mean(metaxy_created_at) to detect both
+    The data version is based on the mean creation timestamp to detect both
     additions and deletions.
 
     Args:

--- a/src/metaxy/ext/ray/datasource.py
+++ b/src/metaxy/ext/ray/datasource.py
@@ -93,7 +93,7 @@ class MetaxyDatasource(Datasource):
         allow_fallback: If `True`, check fallback stores on main store miss.
         with_feature_history: If `True`, only return rows with current feature version.
         feature_version: Explicit feature version to filter by (mutually exclusive with `with_feature_history=False`).
-        with_sample_history: Whether to deduplicate samples within `id_columns` groups ordered by `metaxy_created_at`.
+        with_sample_history: Whether to include historical materializations within `id_columns` groups.
         include_soft_deleted: If `True`, include soft-deleted rows in the result.
     """
 

--- a/src/metaxy/ext/sqlalchemy/plugin.py
+++ b/src/metaxy/ext/sqlalchemy/plugin.py
@@ -272,10 +272,11 @@ def _inject_constraints(
     """
     from sqlalchemy import PrimaryKeyConstraint
 
-    from metaxy.models.constants import METAXY_FEATURE_VERSION, METAXY_UPDATED_AT
+    from metaxy.models.constants import METAXY_FEATURE_VERSION, get_lifecycle_system_columns
 
-    # Composite key/index columns: metaxy_feature_version + id_columns + metaxy_updated_at
-    key_columns = [METAXY_FEATURE_VERSION, *spec.id_columns, METAXY_UPDATED_AT]
+    # Composite key/index columns: feature version + IDs + configured update timestamp
+    _, updated_at_column, _ = get_lifecycle_system_columns()
+    key_columns = [METAXY_FEATURE_VERSION, *spec.id_columns, updated_at_column]
 
     if inject_primary_key:
         table.append_constraint(PrimaryKeyConstraint(*key_columns, name="metaxy_pk"))

--- a/src/metaxy/ext/sqlmodel/plugin.py
+++ b/src/metaxy/ext/sqlmodel/plugin.py
@@ -15,7 +15,6 @@ from metaxy import FeatureSpec
 from metaxy._decorators import public
 from metaxy.config import MetaxyConfig
 from metaxy.models.constants import (
-    ALL_SYSTEM_COLUMNS,
     METAXY_CREATED_AT,
     METAXY_DATA_VERSION,
     METAXY_DATA_VERSION_BY_FIELD,
@@ -27,6 +26,8 @@ from metaxy.models.constants import (
     METAXY_PROVENANCE_BY_FIELD,
     METAXY_UPDATED_AT,
     SYSTEM_COLUMN_PREFIX,
+    get_lifecycle_system_columns,
+    get_reserved_system_columns,
 )
 from metaxy.models.feature import BaseFeature, FeatureGraph, MetaxyMeta
 from metaxy.models.feature_spec import FeatureSpecWithIDColumns
@@ -36,11 +37,6 @@ if TYPE_CHECKING:
     from sqlalchemy import MetaData
 
     from metaxy.ext.ibis.metadata_store import IbisMetadataStore
-
-RESERVED_SQLMODEL_FIELD_NAMES = frozenset(
-    set(ALL_SYSTEM_COLUMNS)
-    | {name.removeprefix(SYSTEM_COLUMN_PREFIX) for name in ALL_SYSTEM_COLUMNS if name.startswith(SYSTEM_COLUMN_PREFIX)}
-)
 
 
 class MetaxyTableInfo(BaseModel):
@@ -56,10 +52,10 @@ class SQLModelFeatureConfig(TypedDict, total=False):
     """
 
     inject_primary_key: bool
-    """Whether to automatically create a composite PK for (metaxy_feature_version, *id_columns, metaxy_updated_at)."""
+    """Whether to create a composite PK using the feature version, IDs, and configured update timestamp."""
 
     inject_index: bool
-    """Whether to automatically create a composite index on (metaxy_feature_version, *id_columns, metaxy_updated_at)."""
+    """Whether to create a composite index using the feature version, IDs, and configured update timestamp."""
 
 
 class SQLModelFeatureMeta(MetaxyMeta, SQLModelMetaclass):
@@ -97,6 +93,13 @@ class SQLModelFeatureMeta(MetaxyMeta, SQLModelMetaclass):
 
         # If this is a concrete table (table=True) with a spec
         if kwargs.get("table") and spec is not None:
+            system_columns = get_reserved_system_columns()
+            reserved_field_names = system_columns | {
+                name.removeprefix(SYSTEM_COLUMN_PREFIX)
+                for name in system_columns
+                if name.startswith(SYSTEM_COLUMN_PREFIX)
+            }
+
             # Forbid custom __tablename__ since it won't work with metadata store's get_table_name()
             if "__tablename__" in namespace:
                 raise ValueError(
@@ -106,18 +109,19 @@ class SQLModelFeatureMeta(MetaxyMeta, SQLModelMetaclass):
                 )
 
             # Prevent user-defined fields from shadowing system-managed columns
-            conflicts = {attr_name for attr_name in namespace if attr_name in RESERVED_SQLMODEL_FIELD_NAMES}
+            conflicts = {field_name for field_name in namespace if field_name in reserved_field_names}
+            conflicts.update(namespace.get("__annotations__", {}).keys() & system_columns)
 
             # Also guard against explicit sa_column_kwargs targeting system columns
             for attr_name, attr_value in namespace.items():
                 sa_column_kwargs = getattr(attr_value, "sa_column_kwargs", None)
                 if isinstance(sa_column_kwargs, dict):
                     column_name = sa_column_kwargs.get("name")
-                    if column_name in ALL_SYSTEM_COLUMNS:
+                    if column_name in system_columns:
                         conflicts.add(attr_name)
 
             if conflicts:
-                reserved = ", ".join(sorted(ALL_SYSTEM_COLUMNS))
+                reserved = ", ".join(sorted(system_columns))
                 conflict_list = ", ".join(sorted(conflicts))
                 raise ValueError(
                     "Cannot define SQLModel field(s) "
@@ -127,6 +131,7 @@ class SQLModelFeatureMeta(MetaxyMeta, SQLModelMetaclass):
 
             # Automatically set __tablename__ from the feature key
             namespace["__tablename__"] = spec.key.table_name
+            cls._inject_lifecycle_fields(namespace)
 
             # Inject table args (info metadata + optional constraints)
             cls._inject_table_args(namespace, spec, cls_name, inject_primary_key, inject_index)
@@ -136,6 +141,24 @@ class SQLModelFeatureMeta(MetaxyMeta, SQLModelMetaclass):
         new_class = super().__new__(cls, cls_name, bases, namespace, spec=spec, **kwargs)
 
         return new_class
+
+    @staticmethod
+    def _inject_lifecycle_fields(namespace: dict[str, Any]) -> None:
+        created_at_column, updated_at_column, deleted_at_column = get_lifecycle_system_columns()
+        annotations = namespace.setdefault("__annotations__", {})
+        for field_name, column_name, description, nullable in (
+            ("metaxy_created_at", created_at_column, "Timestamp when the metadata row was created (UTC)", False),
+            ("metaxy_updated_at", updated_at_column, "Timestamp when the metadata row was last updated (UTC)", False),
+            ("metaxy_deleted_at", deleted_at_column, "Soft delete timestamp (UTC); null means active row", True),
+        ):
+            annotations[field_name] = AwareDatetime | None
+            namespace[field_name] = Field(
+                default=None,
+                description=description,
+                sa_type=DateTime(timezone=True),
+                sa_column_kwargs={"name": column_name},
+                nullable=nullable,
+            )
 
     @staticmethod
     def _resolve_sqlmodel_config(
@@ -186,8 +209,9 @@ class SQLModelFeatureMeta(MetaxyMeta, SQLModelMetaclass):
         # Prepare constraints if requested
         constraints = []
         if inject_primary_key or inject_index:
-            # Composite key/index columns: metaxy_feature_version + id_columns + metaxy_updated_at
-            key_columns = [METAXY_FEATURE_VERSION, *spec.id_columns, METAXY_UPDATED_AT]
+            # Composite key/index columns: feature version + IDs + configured update timestamp
+            _, updated_at_column, _ = get_lifecycle_system_columns()
+            key_columns = [METAXY_FEATURE_VERSION, *spec.id_columns, updated_at_column]
 
             if inject_primary_key:
                 constraints.append(PrimaryKeyConstraint(*key_columns, name="metaxy_pk"))

--- a/src/metaxy/metadata_store/base.py
+++ b/src/metaxy/metadata_store/base.py
@@ -33,17 +33,15 @@ from metaxy.metadata_store.warnings import (
     PolarsMaterializationWarning,
 )
 from metaxy.models.constants import (
-    ALL_SYSTEM_COLUMNS,
-    METAXY_CREATED_AT,
     METAXY_DATA_VERSION,
     METAXY_DATA_VERSION_BY_FIELD,
-    METAXY_DELETED_AT,
     METAXY_FEATURE_VERSION,
     METAXY_MATERIALIZATION_ID,
     METAXY_PROJECT_VERSION,
     METAXY_PROVENANCE,
     METAXY_PROVENANCE_BY_FIELD,
-    METAXY_UPDATED_AT,
+    get_lifecycle_system_columns,
+    get_system_columns,
 )
 from metaxy.models.feature import current_graph
 from metaxy.models.plan import FeaturePlan
@@ -119,14 +117,11 @@ VersioningEngineOptions: TypeAlias = Literal["auto", "native", "polars"]
 # Mapping of system columns to their expected Narwhals dtypes
 # Used to cast Null-typed columns to correct types
 # Note: Struct columns (METAXY_PROVENANCE_BY_FIELD, METAXY_DATA_VERSION_BY_FIELD) are not cast
-_SYSTEM_COLUMN_DTYPES = {
+_FIXED_SYSTEM_COLUMN_DTYPES = {
     METAXY_PROVENANCE: nw.String,
     METAXY_FEATURE_VERSION: nw.String,
     METAXY_PROJECT_VERSION: nw.String,
     METAXY_DATA_VERSION: nw.String,
-    METAXY_CREATED_AT: nw.Datetime(time_zone="UTC"),
-    METAXY_UPDATED_AT: nw.Datetime(time_zone="UTC"),
-    METAXY_DELETED_AT: nw.Datetime(time_zone="UTC"),
     METAXY_MATERIALIZATION_ID: nw.String,
 }
 
@@ -149,7 +144,9 @@ def _cast_present_system_columns(
     schema = df.collect_schema()
     columns_to_cast = []
 
-    for col_name, expected_dtype in _SYSTEM_COLUMN_DTYPES.items():
+    timestamp_dtype = nw.Datetime(time_zone="UTC")
+    system_column_dtypes = _FIXED_SYSTEM_COLUMN_DTYPES | dict.fromkeys(get_lifecycle_system_columns(), timestamp_dtype)
+    for col_name, expected_dtype in system_column_dtypes.items():
         if col_name in schema and schema[col_name] == nw.Unknown:
             columns_to_cast.append(nw.col(col_name).cast(expected_dtype))
 
@@ -769,7 +766,7 @@ class MetadataStore(ABC):
         By default, does not include:
            - rows from historical feature versions (configured via `with_feature_history=False`)
            - rows that have been overwritten by subsequent writes with the same feature version (configured via `with_sample_history=False`)
-           - soft-deleted with `metaxy_deleted_at` set to a non-null value (configured via `include_soft_deleted=False`)
+           - soft-deleted with the configured deletion timestamp set to a non-null value
 
         Args:
             feature: Feature to read metadata for
@@ -781,7 +778,7 @@ class MetadataStore(ABC):
             with_feature_history: If True, include rows from all historical feature versions.
                 By default (False), only returns rows with the currently registered feature version.
             with_sample_history: If True, include all historical materializations per sample.
-                By default (False), deduplicates samples within `id_columns` groups ordered by `metaxy_created_at`.
+                By default (False), deduplicates samples within `id_columns` groups using the configured lifecycle timestamps.
             include_soft_deleted: If `True`, include soft-deleted rows in the result. Previous historical materializations of the same feature version will be effectively removed from the output otherwise.
             with_store_info: If `True`, return a tuple of (LazyFrame, MetadataStore) where
                 the MetadataStore is the store that actually contained the feature (which
@@ -796,7 +793,7 @@ class MetadataStore(ABC):
             ValueError: If both feature_version and with_feature_history=False are provided
 
         !!! info
-            When this method is called with default arguments, it will return the latest (by `metaxy_created_at`)
+            When this method is called with default arguments, it will return the latest
             metadata for the current feature version excluding soft-deleted rows. Therefore, it's perfectly suitable
             for most use cases.
 
@@ -808,6 +805,7 @@ class MetadataStore(ABC):
 
         self._check_open()
 
+        _, updated_at_column, deleted_at_column = get_lifecycle_system_columns()
         filters = filters or []
         columns = columns or []
 
@@ -851,7 +849,7 @@ class MetadataStore(ABC):
         elif columns and not is_system_table:
             # Add only system columns that aren't already in the user's columns list
             columns_set = set(columns)
-            missing_system_cols = [c for c in ALL_SYSTEM_COLUMNS if c not in columns_set]
+            missing_system_cols = [c for c in get_system_columns() if c not in columns_set]
             read_columns = [*columns, *missing_system_cols]
         else:
             read_columns = None
@@ -885,11 +883,11 @@ class MetadataStore(ABC):
                 lazy_frame = self.versioning_engine_cls.keep_latest_by_group(
                     df=lazy_frame,
                     group_columns=id_cols,
-                    timestamp_columns=[METAXY_DELETED_AT, METAXY_UPDATED_AT],
+                    timestamp_columns=[deleted_at_column, updated_at_column],
                 )
 
             if filter_deleted:
-                lazy_frame = lazy_frame.filter(nw.col(METAXY_DELETED_AT).is_null())
+                lazy_frame = lazy_frame.filter(nw.col(deleted_at_column).is_null())
 
             # Apply user filters AFTER deduplication so they see the latest version of each row
             for user_filter in user_filters:
@@ -1457,16 +1455,16 @@ class MetadataStore(ABC):
     def _shared_transaction_timestamp(self, *, soft_delete: bool = False) -> Iterator[datetime]:
         """Context manager that establishes a shared timestamp for a write transaction.
 
-        All write operations (write, delete with soft=True) within
-        this context share the same timestamp for metaxy_created_at and metaxy_deleted_at
-        columns. This ensures consistency when a single logical operation affects
-        multiple system columns.
+        All write operations (write, delete with soft=True) within this context
+        share the same timestamp for the configured lifecycle columns. This
+        ensures consistency when a single logical operation affects multiple
+        system columns.
 
         If already within a transaction, returns the existing timestamp without
         creating a new one (reentrant).
 
         Args:
-            soft_delete: If True, preserves metaxy_updated_at during writes within this context.
+            soft_delete: If True, preserves the configured update timestamp during writes.
 
         Yields:
             datetime: The transaction timestamp (UTC)
@@ -1563,13 +1561,6 @@ class MetadataStore(ABC):
             )
 
         # These should normally be added by the provenance engine during resolve_update
-        from metaxy.models.constants import (
-            METAXY_CREATED_AT,
-            METAXY_DATA_VERSION,
-            METAXY_DATA_VERSION_BY_FIELD,
-            METAXY_UPDATED_AT,
-        )
-
         # Re-fetch columns since df may have been modified above
         columns = df.collect_schema().names()
 
@@ -1601,19 +1592,19 @@ class MetadataStore(ABC):
         # Re-fetch columns since df may have been modified
         columns = df.collect_schema().names()
 
-        # Use shared transaction timestamp to ensure consistency across
-        # metaxy_created_at and metaxy_updated_at columns
+        # Use a shared timestamp for the configured creation and update columns.
+        created_at_column, updated_at_column, deleted_at_column = get_lifecycle_system_columns()
         with self._shared_transaction_timestamp() as ts:
-            if METAXY_CREATED_AT not in columns:
-                df = df.with_columns(nw.lit(ts).alias(METAXY_CREATED_AT))
+            if created_at_column not in columns:
+                df = df.with_columns(nw.lit(ts).alias(created_at_column))
 
-            # metaxy_updated_at: set to current transaction time unless soft delete is in progress
+            # Set the update timestamp unless soft delete is in progress.
             # Soft delete preserves the original updated_at to reflect when data was last changed
             if not self._soft_delete_in_progress:
-                df = df.with_columns(nw.lit(ts).alias(METAXY_UPDATED_AT))
+                df = df.with_columns(nw.lit(ts).alias(updated_at_column))
 
-        if METAXY_DELETED_AT not in columns:
-            df = df.with_columns(nw.lit(None, dtype=nw.Datetime(time_zone="UTC")).alias(METAXY_DELETED_AT))
+        if deleted_at_column not in columns:
+            df = df.with_columns(nw.lit(None, dtype=nw.Datetime(time_zone="UTC")).alias(deleted_at_column))
 
         # Add materialization_id if not already present
         from metaxy.models.constants import METAXY_MATERIALIZATION_ID
@@ -1770,8 +1761,9 @@ class MetadataStore(ABC):
     ) -> None:
         """Delete records matching provided filters.
 
-        Performs a soft delete by default. This is achieved by setting metaxy_deleted_at to the current timestamp.
-        Subsequent [[MetadataStore.read]] calls would ignore these records by default.
+        Performs a soft delete by default by setting the configured deletion
+        timestamp. Subsequent [[MetadataStore.read]] calls ignore these records
+        by default.
 
         Args:
             feature: Feature to delete from.
@@ -1782,9 +1774,8 @@ class MetadataStore(ABC):
             with_sample_history: If True, include all historical materializations. If False (default), deduplicate to latest rows.
 
         !!! critical
-            By default, deletions target historical records. Even when `with_feature_history` is `False`,
-            records with the same feature version but an older `metaxy_created_at` would be targeted as
-            well. Consider adding additional conditions to `filters` if you want to avoid that.
+            With `with_sample_history=True`, matching historical materializations
+            are deleted as well. Add conditions to `filters` to narrow the target.
         """
         self._check_write_mode()
         feature_key = self._resolve_feature_key(feature)
@@ -1808,8 +1799,9 @@ class MetadataStore(ABC):
                 allow_fallback=True,
             )
             with self._shared_transaction_timestamp(soft_delete=True) as ts:
+                _, _, deleted_at_column = get_lifecycle_system_columns()
                 soft_deletion_marked = lazy.with_columns(
-                    nw.lit(ts).alias(METAXY_DELETED_AT),
+                    nw.lit(ts).alias(deleted_at_column),
                 )
                 self.write(feature_key, soft_deletion_marked.to_native())
         else:

--- a/src/metaxy/models/constants.py
+++ b/src/metaxy/models/constants.py
@@ -1,7 +1,4 @@
-"""Shared constants for system-managed column names.
-
-All system columns use the metaxy_ prefix to avoid conflicts with user columns.
-"""
+"""Shared constants for system-managed column names."""
 
 from __future__ import annotations
 
@@ -64,7 +61,16 @@ _STALE_BY_PREDICATE = "__stale_by_predicate"
 
 # --- System Column Sets ------------------------------------------------------------
 
-ALL_SYSTEM_COLUMNS = frozenset(
+LIFECYCLE_SYSTEM_COLUMNS = frozenset(
+    {
+        METAXY_CREATED_AT,
+        METAXY_UPDATED_AT,
+        METAXY_DELETED_AT,
+    }
+)
+"""Default names for configurable lifecycle columns."""
+
+FIXED_SYSTEM_COLUMNS = frozenset(
     {
         METAXY_PROVENANCE_BY_FIELD,
         METAXY_PROVENANCE,
@@ -72,22 +78,19 @@ ALL_SYSTEM_COLUMNS = frozenset(
         METAXY_PROJECT_VERSION,
         METAXY_DATA_VERSION_BY_FIELD,
         METAXY_DATA_VERSION,
-        METAXY_CREATED_AT,
-        METAXY_UPDATED_AT,
-        METAXY_DELETED_AT,
         METAXY_MATERIALIZATION_ID,
     }
 )
-"""All Metaxy-managed column names that are injected into feature tables."""
+"""Metaxy-managed columns whose names are not configurable."""
+
+ALL_SYSTEM_COLUMNS = FIXED_SYSTEM_COLUMNS | LIFECYCLE_SYSTEM_COLUMNS
+"""Default names for all Metaxy-managed columns injected into feature tables."""
 
 # Columns that should be dropped when joining upstream features (will be recalculated)
-_DROPPABLE_COLUMNS = frozenset(
+_FIXED_DROPPABLE_COLUMNS = frozenset(
     {
         METAXY_FEATURE_VERSION,
         METAXY_PROJECT_VERSION,
-        METAXY_CREATED_AT,
-        METAXY_UPDATED_AT,
-        METAXY_DELETED_AT,
         METAXY_DATA_VERSION_BY_FIELD,
         METAXY_DATA_VERSION,
         METAXY_MATERIALIZATION_ID,
@@ -97,12 +100,10 @@ _DROPPABLE_COLUMNS = frozenset(
 # Columns that should be dropped before joining upstream features in FeatureDepTransformer
 # These are NOT needed for provenance calculation and would cause column name conflicts
 # when joining 3+ upstream features (e.g., metaxy_created_at_right already exists error)
-_COLUMNS_TO_DROP_BEFORE_JOIN = frozenset(
+_FIXED_COLUMNS_TO_DROP_BEFORE_JOIN = frozenset(
     {
         METAXY_FEATURE_VERSION,
         METAXY_PROJECT_VERSION,
-        METAXY_CREATED_AT,
-        METAXY_UPDATED_AT,
         METAXY_MATERIALIZATION_ID,
     }
 )
@@ -126,7 +127,7 @@ def is_system_column(name: str) -> bool:
         >>> is_system_column("my_column")
         False
     """
-    return name in ALL_SYSTEM_COLUMNS
+    return name in get_system_columns()
 
 
 def is_droppable_system_column(name: str) -> bool:
@@ -147,7 +148,31 @@ def is_droppable_system_column(name: str) -> bool:
         >>> is_droppable_system_column("metaxy_provenance_by_field")
         False
     """
-    return name in _DROPPABLE_COLUMNS
+    return name in _FIXED_DROPPABLE_COLUMNS or name in get_lifecycle_system_columns()
+
+
+def get_lifecycle_system_columns() -> tuple[str, str, str]:
+    """Return configured created, updated, and deleted column names."""
+    from metaxy.config import MetaxyConfig
+
+    config = MetaxyConfig.get(_allow_default_config=True)
+    return config.created_at_column, config.updated_at_column, config.deleted_at_column
+
+
+def get_system_columns() -> frozenset[str]:
+    """Return all system column names for the active configuration."""
+    return FIXED_SYSTEM_COLUMNS | frozenset(get_lifecycle_system_columns())
+
+
+def get_reserved_system_columns() -> frozenset[str]:
+    """Return default and configured system column names."""
+    return ALL_SYSTEM_COLUMNS | get_system_columns()
+
+
+def get_columns_to_drop_before_join() -> frozenset[str]:
+    """Return system columns removed before upstream joins."""
+    created_at, updated_at, _ = get_lifecycle_system_columns()
+    return _FIXED_COLUMNS_TO_DROP_BEFORE_JOIN | {created_at, updated_at}
 
 
 # System columns that have lineage from upstream features

--- a/src/metaxy/versioning/feature_dep_transformer.py
+++ b/src/metaxy/versioning/feature_dep_transformer.py
@@ -6,11 +6,11 @@ import narwhals as nw
 from narwhals.typing import FrameT
 
 from metaxy.models.constants import (
-    _COLUMNS_TO_DROP_BEFORE_JOIN,
     METAXY_DATA_VERSION,
     METAXY_DATA_VERSION_BY_FIELD,
     METAXY_PROVENANCE,
     METAXY_PROVENANCE_BY_FIELD,
+    get_columns_to_drop_before_join,
 )
 from metaxy.models.feature_spec import FeatureDep, FeatureSpec
 from metaxy.models.plan import FeaturePlan
@@ -126,11 +126,11 @@ class FeatureDepTransformer:
             combined_filters.extend(filters)
 
         # Drop columns that should not be carried through joins
-        # (e.g., metaxy_created_at, metaxy_materialization_id, metaxy_feature_version)
+        # (e.g., the configured creation timestamp and fixed system columns)
         # These are recalculated for the downstream feature and would cause column name
         # conflicts when joining 3+ upstream features
         existing_columns = set(df.collect_schema().names())  # ty: ignore[invalid-argument-type]
-        columns_to_drop = [col for col in _COLUMNS_TO_DROP_BEFORE_JOIN if col in existing_columns]
+        columns_to_drop = [col for col in get_columns_to_drop_before_join() if col in existing_columns]
         if columns_to_drop:
             df = df.drop(*columns_to_drop)  # ty: ignore[invalid-argument-type]
 

--- a/src/metaxy/versioning/upstream_preparer.py
+++ b/src/metaxy/versioning/upstream_preparer.py
@@ -9,15 +9,14 @@ import narwhals as nw
 from narwhals.typing import FrameT
 
 from metaxy.models.constants import (
-    METAXY_CREATED_AT,
     METAXY_DATA_VERSION,
     METAXY_DATA_VERSION_BY_FIELD,
-    METAXY_DELETED_AT,
     METAXY_FEATURE_VERSION,
     METAXY_MATERIALIZATION_ID,
     METAXY_PROJECT_VERSION,
     METAXY_PROVENANCE,
     METAXY_PROVENANCE_BY_FIELD,
+    get_lifecycle_system_columns,
 )
 from metaxy.models.types import FeatureKey
 from metaxy.versioning.renamed_df import RenamedDataFrame
@@ -158,13 +157,14 @@ class UpstreamPreparer(Generic[FrameT]):
                 all_columns[col].append(feature_key)
 
         # System columns that are allowed to collide (needed for provenance calculation)
+        created_at_column, _, deleted_at_column = get_lifecycle_system_columns()
         allowed_system_columns = {
             METAXY_PROVENANCE,
             METAXY_PROVENANCE_BY_FIELD,
             METAXY_DATA_VERSION,
             METAXY_DATA_VERSION_BY_FIELD,
-            METAXY_CREATED_AT,
-            METAXY_DELETED_AT,
+            created_at_column,
+            deleted_at_column,
             METAXY_MATERIALIZATION_ID,
         }
         id_cols = set(self.engine.shared_id_columns)

--- a/src/metaxy/versioning/validation.py
+++ b/src/metaxy/versioning/validation.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from collections import Counter
 from typing import TYPE_CHECKING
 
-from metaxy.models.constants import ALL_SYSTEM_COLUMNS
+from metaxy.models.constants import get_reserved_system_columns
 from metaxy.models.feature_spec import FeatureDep
 from metaxy.versioning.feature_dep_transformer import FeatureDepTransformer
 
@@ -43,6 +43,7 @@ def validate_column_configuration(plan: FeaturePlan) -> None:
 
 def _validate_individual_dep_renames(plan: FeaturePlan) -> None:
     """Validate rename mappings for each dependency individually."""
+    system_columns = get_reserved_system_columns()
     for dep in plan.feature_deps or []:
         if not isinstance(dep, FeatureDep):
             continue
@@ -55,11 +56,11 @@ def _validate_individual_dep_renames(plan: FeaturePlan) -> None:
 
         for old_name, new_name in dep.rename.items():
             # Check for renaming to system columns
-            if new_name in ALL_SYSTEM_COLUMNS:
+            if new_name in system_columns:
                 raise ValueError(
                     f"Cannot rename column '{old_name}' to system column name '{new_name}' "
                     f"in dependency '{dep.feature.to_string()}'. "
-                    f"System columns: {sorted(ALL_SYSTEM_COLUMNS)}"
+                    f"System columns: {sorted(system_columns)}"
                 )
 
             # Check against upstream feature's ID columns

--- a/tach.toml
+++ b/tach.toml
@@ -238,7 +238,7 @@ depends_on = [
 [[modules]]
 path = "metaxy.models.constants"
 layer = "core"
-depends_on = []
+depends_on = ["metaxy.config"]
 
 [[modules]]
 path = "metaxy.models.types"

--- a/tests/ext/dagster/test_dagster_type.py
+++ b/tests/ext/dagster/test_dagster_type.py
@@ -246,6 +246,13 @@ class TestBuildColumnSchema:
         assert "metaxy_created_at" in column_names
         assert "metaxy_data_version" in column_names
 
+    def test_uses_configured_lifecycle_column(self, simple_feature: type[mx.BaseFeature]):
+        with mx.MetaxyConfig(created_at_column="created_at").use():
+            column_names = {column.name for column in build_column_schema(simple_feature).columns}
+
+        assert "created_at" in column_names
+        assert "metaxy_created_at" not in column_names
+
     def test_columns_sorted_alphabetically(self, simple_feature: type[mx.BaseFeature]):
         """Test that columns are sorted alphabetically."""
         schema = build_column_schema(simple_feature)

--- a/tests/ext/sqlmodel/test_native.py
+++ b/tests/ext/sqlmodel/test_native.py
@@ -1807,3 +1807,36 @@ def test_sqlmodel_has_materialization_id_field() -> None:
     if hasattr(TestFeature, "__table__"):
         table_columns = {col.name for col in TestFeature.__table__.columns}
         assert METAXY_MATERIALIZATION_ID in table_columns
+
+
+def test_sqlmodel_uses_configured_lifecycle_columns() -> None:
+    from metaxy.config import MetaxyConfig
+
+    with MetaxyConfig(
+        project="test",
+        created_at_column="created_at",
+        updated_at_column="updated_at",
+        deleted_at_column="deleted_at",
+    ).use():
+
+        class CustomLifecycleFeature(
+            BaseSQLModelFeature,
+            table=True,
+            spec=SampleFeatureSpec(key=FeatureKey(["custom", "lifecycle"])),
+        ):
+            uid: str = Field(primary_key=True)
+
+        with pytest.raises(ValueError, match="reserved Metaxy system columns"):
+
+            class ConflictingLifecycleFeature(
+                BaseSQLModelFeature,
+                table=True,
+                spec=SampleFeatureSpec(key=FeatureKey(["conflicting", "lifecycle"])),
+            ):
+                uid: str = Field(primary_key=True)
+                metaxy_created_at: int
+
+    table = CustomLifecycleFeature.__table__  # ty: ignore[unresolved-attribute]
+    table_columns = {column.name for column in table.columns}
+    assert {"created_at", "updated_at", "deleted_at"} <= table_columns
+    assert not {"metaxy_created_at", "metaxy_updated_at", "metaxy_deleted_at"} & table_columns

--- a/tests/metadata_stores/core/test_metadata_store.py
+++ b/tests/metadata_stores/core/test_metadata_store.py
@@ -16,6 +16,7 @@ from metaxy import (
     FieldKey,
     FieldSpec,
 )
+from metaxy.config import MetaxyConfig
 from metaxy.ext.polars.handlers.delta import DeltaMetadataStore
 from metaxy.metadata_store import (
     FeatureNotFoundError,
@@ -177,6 +178,36 @@ def test_write_and_read(
         assert len(result) == 3
         assert "sample_uid" in result.columns
         assert "metaxy_provenance_by_field" in result.columns
+
+
+def test_configurable_lifecycle_columns(
+    store: DeltaMetadataStore,
+    UpstreamFeatureA: type[BaseFeature],
+    make_upstream_a_data: Callable[..., pl.DataFrame],
+) -> None:
+    config = MetaxyConfig(
+        project="test",
+        created_at_column="created_at",
+        updated_at_column="updated_at",
+        deleted_at_column="deleted_at",
+    )
+    with config.use(), store.open("w"):
+        created_at = pl.datetime(2024, 1, 1, time_zone="UTC")
+        store.write(
+            UpstreamFeatureA,
+            make_upstream_a_data(sample_uids=[1], prefix="hash", include_path=False).with_columns(
+                created_at.alias("created_at")
+            ),
+        )
+
+        active = collect_to_polars(store.read(UpstreamFeatureA))
+        assert {"created_at", "updated_at", "deleted_at"} <= set(active.columns)
+        assert not {"metaxy_created_at", "metaxy_updated_at", "metaxy_deleted_at"} & set(active.columns)
+        assert active["created_at"].item() == active.select(created_at).item()
+
+        store.delete(UpstreamFeatureA, filters=None)
+        deleted = collect_to_polars(store.read(UpstreamFeatureA, include_soft_deleted=True))
+        assert deleted["deleted_at"].is_not_null().all()
 
 
 def test_write_invalid_schema(store: DeltaMetadataStore, UpstreamFeatureA: type[BaseFeature]) -> None:

--- a/tests/metaxy_testing/src/metaxy_testing/parametric/metadata.py
+++ b/tests/metaxy_testing/src/metaxy_testing/parametric/metadata.py
@@ -18,16 +18,14 @@ from hypothesis import strategies as st
 from hypothesis.strategies import composite
 from metaxy.config import MetaxyConfig
 from metaxy.models.constants import (
-    METAXY_CREATED_AT,
     METAXY_DATA_VERSION,
     METAXY_DATA_VERSION_BY_FIELD,
-    METAXY_DELETED_AT,
     METAXY_FEATURE_VERSION,
     METAXY_MATERIALIZATION_ID,
     METAXY_PROJECT_VERSION,
     METAXY_PROVENANCE,
     METAXY_PROVENANCE_BY_FIELD,
-    METAXY_UPDATED_AT,
+    get_lifecycle_system_columns,
 )
 from metaxy.models.types import FeatureKey
 from metaxy.versioning.types import HashAlgorithm
@@ -317,10 +315,11 @@ def feature_metadata_strategy(
     from datetime import datetime, timezone
 
     ts = datetime.now(timezone.utc)
+    created_at_column, updated_at_column, deleted_at_column = get_lifecycle_system_columns()
     df = df.with_columns(
-        pl.lit(ts).alias(METAXY_CREATED_AT),
-        pl.lit(ts).alias(METAXY_UPDATED_AT),
-        pl.lit(None, dtype=pl.Datetime(time_zone="UTC")).alias(METAXY_DELETED_AT),
+        pl.lit(ts).alias(created_at_column),
+        pl.lit(ts).alias(updated_at_column),
+        pl.lit(None, dtype=pl.Datetime(time_zone="UTC")).alias(deleted_at_column),
     )
 
     # If id_columns_df was provided, replace the generated ID columns with provided ones
@@ -744,6 +743,7 @@ def downstream_metadata_strategy(
     from datetime import datetime, timezone
 
     ts = datetime.now(timezone.utc)
+    created_at_column, updated_at_column, deleted_at_column = get_lifecycle_system_columns()
     downstream_df = downstream_df.with_columns(
         nw.lit(feature_versions[downstream_feature_key]).alias(METAXY_FEATURE_VERSION),
         nw.lit(project_version).alias(METAXY_PROJECT_VERSION),
@@ -751,10 +751,10 @@ def downstream_metadata_strategy(
         nw.col(METAXY_PROVENANCE).alias(METAXY_DATA_VERSION),
         nw.col(METAXY_PROVENANCE_BY_FIELD).alias(METAXY_DATA_VERSION_BY_FIELD),
         # Add timestamp columns
-        nw.lit(ts).alias(METAXY_CREATED_AT),
-        nw.lit(ts).alias(METAXY_UPDATED_AT),
+        nw.lit(ts).alias(created_at_column),
+        nw.lit(ts).alias(updated_at_column),
         # Soft delete column defaults to NULL
-        nw.lit(None, dtype=nw.Datetime(time_zone="UTC")).alias(METAXY_DELETED_AT),
+        nw.lit(None, dtype=nw.Datetime(time_zone="UTC")).alias(deleted_at_column),
         # Add materialization_id (nullable)
         nw.lit(None, dtype=nw.String).alias(METAXY_MATERIALIZATION_ID),
     )

--- a/tests/models/test_system_columns.py
+++ b/tests/models/test_system_columns.py
@@ -1,8 +1,9 @@
+from metaxy.config import MetaxyConfig
 from metaxy.models import constants as sys_cols
 
 
-def test_is_system_column_recognises_canonical_names_only() -> None:
-    """Test that is_system_column recognizes canonical system column names."""
+def test_is_system_column_recognises_default_names() -> None:
+    """Test that is_system_column recognizes default system column names."""
     # Should recognize actual system columns
     assert sys_cols.is_system_column(sys_cols.METAXY_PROJECT_VERSION)
     assert sys_cols.is_system_column(sys_cols.METAXY_FEATURE_VERSION)
@@ -34,3 +35,15 @@ def test_materialization_id_is_system_column() -> None:
 def test_materialization_id_is_droppable() -> None:
     """Test that metaxy_materialization_id is droppable during joins."""
     assert sys_cols.is_droppable_system_column(sys_cols.METAXY_MATERIALIZATION_ID)
+
+
+def test_configured_lifecycle_columns_replace_canonical_names() -> None:
+    with MetaxyConfig(
+        created_at_column="created_at",
+        updated_at_column="updated_at",
+        deleted_at_column="deleted_at",
+    ).use():
+        assert sys_cols.is_system_column("created_at")
+        assert sys_cols.is_droppable_system_column("updated_at")
+        assert not sys_cols.is_system_column(sys_cols.METAXY_CREATED_AT)
+        assert sys_cols.METAXY_CREATED_AT in sys_cols.get_reserved_system_columns()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -93,6 +93,19 @@ def test_metaxy_config_default() -> None:
 
     assert config.store == "dev"
     assert config.stores == {}
+    assert (
+        config.created_at_column,
+        config.updated_at_column,
+        config.deleted_at_column,
+    ) == ("metaxy_created_at", "metaxy_updated_at", "metaxy_deleted_at")
+
+
+def test_lifecycle_columns_must_be_distinct_and_not_fixed_system_columns() -> None:
+    with pytest.raises(ValueError, match="must be distinct"):
+        MetaxyConfig(created_at_column="timestamp", updated_at_column="timestamp")
+
+    with pytest.raises(ValueError, match="conflict with reserved"):
+        MetaxyConfig(created_at_column="metaxy_feature_version")
 
 
 def test_bare_construction_does_not_auto_discover_toml(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

- Add configurable creation, update, and soft-deletion system column names while preserving current defaults.
- Thread configured names through storage, versioning, Dagster, SQLAlchemy/SQLModel, and testing helpers.
- Keep default lifecycle names reserved where model fields could otherwise be overwritten.

Closes #866

## Changelog

Metaxy lifecycle timestamp columns can now be renamed with `created_at_column`, `updated_at_column`, and `deleted_at_column`.

## Test Plan

- `uv run pytest -q tests/test_config.py tests/models/test_system_columns.py tests/versioning/test_validation.py tests/metadata_stores/core/test_metadata_store.py tests/ext/sqlmodel/test_native.py tests/ext/dagster/test_dagster_type.py tests/metaxy_testing/tests`
- `uv run ruff format --check`
- `uv run ruff check`
- `uv run ty check`
- `uv run --group docs mkdocs build --clean --strict`
