### PR TITLE
feat: add metaxy-rivers integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,9 @@ map = [
   "polars-map>=0.2.1",
   "narwhals-map>=0.1.1",
 ]
+rivers = [
+  "rivers>=0.4.0",
+]
 ibis = [
   "pyarrow>=18.0.0",
   "ibis-framework>=11.0.0",

--- a/src/metaxy/ext/rivers/__init__.py
+++ b/src/metaxy/ext/rivers/__init__.py
@@ -1,0 +1,12 @@
+from metaxy.ext.rivers.io_handler import MetaxyIOHandler, MetaxyOutput
+from metaxy.ext.rivers.metaxify import metaxify
+from metaxy.ext.rivers.resources import MetaxyResource
+from metaxy.ext.rivers.utils import build_feature_info_metadata
+
+__all__ = [
+    "metaxify",
+    "MetaxyResource",
+    "MetaxyIOHandler",
+    "MetaxyOutput",
+    "build_feature_info_metadata",
+]

--- a/src/metaxy/ext/rivers/constants.py
+++ b/src/metaxy/ext/rivers/constants.py
@@ -1,0 +1,10 @@
+"""
+Ported 1:1 from metaxy/ext/dagster/constants.py where the concept applies
+to Rivers. Dagster-only keys (column schema/lineage) are dropped.
+"""
+
+RIVERS_METAXY_FEATURE_METADATA_KEY = "metaxy/feature"
+RIVERS_METAXY_PARTITION_KEY = "partition_by"
+RIVERS_METAXY_PARTITION_METADATA_KEY = "metaxy/partition"
+RIVERS_METAXY_PROJECT_TAG_KEY = "metaxy/project"
+RIVERS_METAXY_INFO_METADATA_KEY = "metaxy/info"

--- a/src/metaxy/ext/rivers/io_handler.py
+++ b/src/metaxy/ext/rivers/io_handler.py
@@ -1,0 +1,204 @@
+﻿"""
+Ported from metaxy/ext/dagster/io_manager.py (MetaxyIOManager).
+
+CONFIRMED against python\rivers\io_handlers\base.py and
+python\rivers\_core\__init__.pyi:
+
+    class BaseIOHandler(BaseSettings, ABC):
+        def handle_output(self, context: OutputContext, obj: Any) -> None: ...
+        def load_input(self, context: InputContext) -> Any: ...
+    # attached as an INSTANCE: @Asset(io_handler=MetaxyIOHandler(name=...))
+    # (not a class, unlike our first draft)
+
+    class OutputContext:
+        asset_name: str
+        asset_metadata: dict[str, str] | None
+        partition: PartitionContext | None
+        add_output_metadata(dict[str, str|int|float|bool|None|MetadataValue])
+        register_data_version(str)
+
+    class InputContext:
+        asset_name: str            # the UPSTREAM asset (this context describes it)
+        downstream_asset: str
+        asset_metadata: dict[str, str] | None   # the upstream asset's metadata
+        partition: PartitionContext | None
+
+    class PartitionContext:
+        keys: list[PartitionKey]
+        key: PartitionKey          # keys[0]
+
+Because BaseIOHandler is itself pydantic BaseSettings with NO setup()/
+teardown() hooks (unlike Resource), this handler resolves its own store
+directly rather than depending on a separately-injected MetaxyResource --
+there's no confirmed mechanism for Rivers to inject a Resource into an
+IOHandler instance.
+
+CONFIRMED (partitions/__init__.pyi):
+    class PartitionKey.Single(PartitionKey):
+        key: list[str]   # NOTE: a list, even for the "Single" variant --
+                          # presumably supports multiple keys per step
+                          # (e.g. a backfill range materialized in one run).
+    class PartitionKey.Multi(PartitionKey):
+        keys: dict[str, list[str]]
+
+REMAINING TODO (documented, not silently guessed):
+    - Since `Single.key` is a list, `_build_filters()` below filters with
+      `.is_in(...)` when there are multiple keys and `==` for exactly one,
+      mirroring Dagster's build_partition_filter_from_input_context
+      single-vs-multiple-partition-keys branch. `Multi` (dict of dimension
+      -> list[str]) is NOT handled yet -- multi-dimensional partitions
+      will raise NotImplementedError rather than silently filtering wrong.
+    - `metaxy/partition` (the static multi-asset-to-one-feature dict) has
+      to be JSON-encoded since Rivers metadata is dict[str, str] only
+      (Dagster's metadata dict allowed arbitrary values). Both the
+      writer (metaxify / user code setting this metadata) and this reader
+      must agree on that encoding -- documented in metaxify.py too.
+    - Unlike Dagster's MetaxyIOManager, this handler does not log the
+      "metaxy/materialized_in_run" count or any resolved-store/table_name
+      input metadata -- Rivers' OutputContext/InputContext do not expose a
+      run id or resolved-store info the way Dagster's contexts do (see
+      resources.py's KNOWN LIMITATION note re: no run id at setup time).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import narwhals as nw
+
+import metaxy as mx
+from metaxy.metadata_store.exceptions import FeatureNotFoundError
+from rivers import BaseIOHandler
+from rivers._core import InputContext, OutputContext
+
+from .constants import (
+    RIVERS_METAXY_FEATURE_METADATA_KEY,
+    RIVERS_METAXY_INFO_METADATA_KEY,
+    RIVERS_METAXY_PARTITION_KEY,
+    RIVERS_METAXY_PARTITION_METADATA_KEY,
+)
+from .utils import build_feature_info_metadata
+
+MetaxyOutput = Any
+
+
+def _partition_key_values(context: InputContext | OutputContext) -> list[str] | None:
+    """Return the list of partition key string(s) for this context, or None.
+
+    Only handles PartitionKey.Single (a plain list[str]). Raises for
+    PartitionKey.Multi since there's no confirmed mapping yet from a
+    {dimension: [values]} dict onto a single filter column.
+    """
+    partition = context.partition
+    if partition is None:
+        return None
+    key = partition.key
+    if hasattr(key, "keys") and not hasattr(key, "key"):
+        # PartitionKey.Multi
+        raise NotImplementedError(
+            "Multi-dimensional Rivers partitions are not yet supported by "
+            "MetaxyIOHandler -- only PartitionKey.Single is handled."
+        )
+    return list(getattr(key, "key", []))
+
+
+class MetaxyIOHandler(BaseIOHandler):
+    """IO handler that reads/writes data to a Metaxy MetadataStore,
+    mirroring metaxy.ext.dagster.MetaxyIOManager.
+
+    Configured directly (it's pydantic BaseSettings, like MetaxyResource):
+
+        @Asset(io_handler=MetaxyIOHandler(name="dev"), ...)
+
+    Expects `"metaxy/feature"` to be set in the asset's metadata, mapping
+    the Rivers asset to a Metaxy feature key.
+    """
+
+    name: str | None = None
+
+    def _get_store(self) -> mx.MetadataStore:
+        return mx.MetaxyConfig.get().get_store(self.name)
+
+    def _feature_key_from_metadata(self, metadata: dict[str, str] | None) -> mx.FeatureKey:
+        metadata = metadata or {}
+        raw_key = metadata.get(RIVERS_METAXY_FEATURE_METADATA_KEY)
+        if raw_key is None:
+            raise ValueError(
+                f'Missing `"{RIVERS_METAXY_FEATURE_METADATA_KEY}"` key in asset metadata'
+            )
+        return mx.ValidatedFeatureKeyAdapter.validate_python(raw_key)
+
+    def _build_filters(
+        self, metadata: dict[str, str] | None, context: InputContext | OutputContext
+    ) -> list[nw.Expr]:
+        metadata = metadata or {}
+        filters: list[nw.Expr] = []
+
+        partition_col = metadata.get(RIVERS_METAXY_PARTITION_KEY)
+        partition_keys = _partition_key_values(context)
+        if partition_col and partition_keys:
+            if len(partition_keys) == 1:
+                filters.append(nw.col(partition_col) == partition_keys[0])
+            else:
+                filters.append(nw.col(partition_col).is_in(partition_keys))
+
+        # metaxy/partition: JSON-encoded {col: value} dict (see module docstring)
+        raw_metaxy_partition = metadata.get(RIVERS_METAXY_PARTITION_METADATA_KEY)
+        if raw_metaxy_partition:
+            metaxy_partition = json.loads(raw_metaxy_partition)
+            for col, value in metaxy_partition.items():
+                if isinstance(value, list):
+                    filters.append(nw.col(col).is_in(value))
+                else:
+                    filters.append(nw.col(col) == value)
+
+        return filters
+
+    # -- IO handler interface --------------------------------------------
+
+    def load_input(self, context: InputContext) -> nw.LazyFrame[Any]:
+        store = self._get_store()
+        with store:
+            # InputContext describes the UPSTREAM asset directly -- no
+            # separate "upstream_output" indirection needed, unlike Dagster.
+            feature_key = self._feature_key_from_metadata(context.asset_metadata)
+            filters = self._build_filters(context.asset_metadata, context)
+
+            lazy_frame, _resolved_store = store.read(
+                feature=feature_key,
+                filters=filters,
+                with_store_info=True,
+            )
+            return lazy_frame
+
+    def handle_output(self, context: OutputContext, obj: MetaxyOutput) -> None:
+        store = self._get_store()
+        feature_key = self._feature_key_from_metadata(context.asset_metadata)
+        feature = mx.get_feature_by_key(feature_key)
+
+        if obj is not None:
+            with store.open("w"):
+                store.write(feature=feature, df=obj)
+
+        self._log_output_metadata(context, store, feature_key)
+
+    def _log_output_metadata(
+        self, context: OutputContext, store: mx.MetadataStore, feature_key: mx.FeatureKey
+    ) -> None:
+        with store:
+            try:
+                mx.get_feature_by_key(feature_key)  # raises FeatureNotFoundError if missing
+                context.add_output_metadata(
+                    {
+                        "metaxy/feature": feature_key.to_string(),
+                        # NOTE: metadata values here must be JSON-serializable to
+                        # a str|int|float|bool|None|MetadataValue -- build_feature_info_metadata
+                        # returns a nested dict, so it's JSON-encoded to a string.
+                        RIVERS_METAXY_INFO_METADATA_KEY: json.dumps(
+                            build_feature_info_metadata(feature_key)
+                        ),
+                    }
+                )
+            except FeatureNotFoundError:
+                pass

--- a/src/metaxy/ext/rivers/metaxify.py
+++ b/src/metaxy/ext/rivers/metaxify.py
@@ -1,0 +1,117 @@
+"""
+Adapted from metaxy/ext/dagster/metaxify.py.
+
+NOW FULLY CONFIRMED against python\\rivers\\_core\\assets\\__init__.pyi's
+`Asset.__new__` overload for the `@Asset(...)` (parenthesized) form:
+
+    def __new__(cls, *, name: str | None = ..., tags: ..., kinds: ...,
+                 group: ..., code_version: str | None = ...,
+                 io_handler: IOHandler | str | None = ...,
+                 metadata: dict[str, str] | None = ...,
+                 partitions_def: ..., deps: list["DepDef"] | None = ...,
+                 hooks: ..., automation_condition: ...,
+                 backfill_strategy: ..., pool: ..., pool_slots: ...,
+                 retry: ..., compute: ...) -> Callable[[Callable], "SingleAsset"]
+
+Two things this resolves vs. the earlier draft:
+
+  1. `name=` IS a real kwarg. This means we can pin the registered asset
+     name directly to the Metaxy feature's table_name -- no more in-memory
+     feature->asset-name registry, no more import-order dependency for
+     deps resolution. `AssetDef.input(upstream_key.table_name)` now works
+     deterministically as long as every metaxify-decorated asset for that
+     feature also sets `name=` to the same table_name (which it does,
+     always, below).
+
+  2. `description=` is CONFIRMED ABSENT from the overload -- removed
+     entirely rather than guessed at.
+
+STILL NOT PORTED (no confirmed Rivers equivalent -- Dagster-only concepts,
+same as before): column schema injection, column lineage injection,
+"kinds"/"tags" auto-injection from the feature graph, key_prefix-style
+remapping.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Callable, TypeVar
+
+import metaxy as mx
+from rivers import Asset, AssetDef
+
+from .constants import RIVERS_METAXY_FEATURE_METADATA_KEY, RIVERS_METAXY_INFO_METADATA_KEY
+from .io_handler import MetaxyIOHandler
+from .utils import build_feature_info_metadata
+
+_F = TypeVar("_F", bound=Callable[..., Any])
+
+
+def metaxify(
+    feature: mx.CoercibleToFeatureKey,
+    *,
+    inject_code_version: bool = True,
+    io_handler_name: str | None = None,
+    **asset_kwargs: Any,
+) -> Callable[[_F], Any]:
+    """Decorator that wires Metaxy feature info into a Rivers `@Asset`.
+
+    Unlike Dagster's `@metaxify` (which reads the feature key from
+    `metadata={"metaxy/feature": ...}` on an already-decorated asset),
+    this takes the feature explicitly, since wiring happens at decoration
+    time here:
+
+        @metaxify("my/feature")
+        def my_asset(context):
+            ...
+
+    The asset is always registered under `name=<feature's table_name>`
+    (overriding any `name=` you pass in `asset_kwargs`), so that
+    dependency resolution between metaxify-decorated assets is
+    deterministic. Any other `asset_kwargs` (e.g. `partitions_def=`,
+    `retry=`, `pool=`, `tags=`) are passed straight through to `Asset(...)`.
+    """
+
+    def decorator(fn: _F) -> Any:
+        feature_key = mx.coerce_to_feature_key(feature)
+        feature_def = mx.get_feature_by_key(feature_key)
+        feature_spec = feature_def.spec
+
+        # --- deps: resolve upstream Metaxy features directly by table_name.
+        # Deterministic now that every metaxify-decorated asset is
+        # registered under name=<table_name> (see docstring).
+        deps: list[Any] = [
+            AssetDef.input(mx.coerce_to_feature_key(dep.feature).table_name)
+            for dep in feature_spec.deps
+        ]
+        deps.extend(asset_kwargs.pop("deps", []))
+
+        # --- code_version: append metaxy version, same format as Dagster.
+        code_version = asset_kwargs.pop("code_version", None)
+        if inject_code_version:
+            metaxy_code_version = f"metaxy:{feature_spec.code_version}"
+            code_version = (
+                f"{code_version},{metaxy_code_version}" if code_version else metaxy_code_version
+            )
+
+        # --- metadata: dict[str, str] ONLY (confirmed) -- nested info is
+        # JSON-encoded, unlike Dagster's dict[str, Any] metadata.
+        metadata: dict[str, str] = {
+            **{k: str(v) for k, v in asset_kwargs.pop("metadata", {}).items()},
+            RIVERS_METAXY_FEATURE_METADATA_KEY: feature_key.to_string(),
+            RIVERS_METAXY_INFO_METADATA_KEY: json.dumps(build_feature_info_metadata(feature_key)),
+            "metaxy/feature_code_version": feature_spec.code_version,
+        }
+
+        asset_kwargs.pop("name", None)  # always overridden, see docstring
+
+        return Asset(
+            name=feature_key.table_name,
+            io_handler=MetaxyIOHandler(name=io_handler_name),
+            deps=deps,
+            code_version=code_version,
+            metadata=metadata,
+            **asset_kwargs,
+        )(fn)
+
+    return decorator

--- a/src/metaxy/ext/rivers/resources.py
+++ b/src/metaxy/ext/rivers/resources.py
@@ -1,0 +1,63 @@
+"""
+Ported from metaxy/ext/dagster/resources.py (MetaxyStoreFromConfigResource).
+
+CONFIRMED against python\\rivers\\resource.py:
+    class Resource(BaseSettings):
+        def setup(self) -> None: ...
+        def teardown(self) -> None: ...
+    Resources are injected into asset functions via type-hinted parameters
+    (see _worker_call_with_resources: resources are deserialized via
+    model_validate_json, setup() is called, then injected as an arg).
+
+KNOWN LIMITATION vs. the Dagster version (confirmed, not a guess):
+    Dagster's create_resource(context) receives an InitResourceContext and
+    passes `materialization_id=context.run.run_id` so every write from a
+    run is tagged with that run's id. Rivers' `setup(self) -> None` takes
+    NO context/run-id argument at all -- there is currently no way to get
+    a run id at resource-setup time. This means per-run materialization
+    tracking (the `metaxy/materialized_in_run` metadata Dagster's
+    MetaxyIOManager reports) cannot be reproduced the same way here.
+    Left out rather than faked with a wrong value.
+"""
+
+from __future__ import annotations
+
+import metaxy as mx
+from rivers import Resource
+
+
+class MetaxyResource(Resource):
+    """Resource for asset functions that want direct `MetadataStore` access
+    (e.g. to call `store.resolve_update(...)`), mirroring
+    `metaxy.ext.dagster.MetaxyStoreFromConfigResource`.
+
+    Usage (resources are injected via type-hinted parameters in Rivers):
+
+        @Asset(...)
+        def my_asset(context, metaxy: MetaxyResource):
+            with metaxy.store:
+                increment = metaxy.store.resolve_update("my/feature")
+            ...
+
+    If `name` is not provided, the default store will be used (set via
+    `store = "my_name"` in `metaxy.toml` or the `$METAXY_STORE` env var).
+    """
+
+    name: str | None = None
+
+    _store: mx.MetadataStore | None = None
+
+    def setup(self) -> None:
+        self._store = mx.MetaxyConfig.get().get_store(self.name)
+
+    def teardown(self) -> None:
+        self._store = None
+
+    @property
+    def store(self) -> mx.MetadataStore:
+        if self._store is None:
+            raise RuntimeError(
+                "MetaxyResource.store accessed before setup() was called "
+                "by the Rivers runtime."
+            )
+        return self._store

--- a/src/metaxy/ext/rivers/utils.py
+++ b/src/metaxy/ext/rivers/utils.py
@@ -1,0 +1,37 @@
+"""
+Ported 1:1 from metaxy/ext/dagster/utils.py::build_feature_info_metadata.
+
+Touches only metaxy-core APIs -- nothing orchestrator-specific -- so it
+needs no adaptation for Rivers.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import metaxy as mx
+
+
+def build_feature_info_metadata(feature: mx.CoercibleToFeatureKey) -> dict[str, Any]:
+    """Build feature info metadata dict.
+
+    NOTE: unlike Dagster (dict[str, Any] metadata), Rivers asset metadata
+    is dict[str, str] only. Callers (io_handler.py, metaxify.py) JSON-encode
+    this return value before attaching it as asset/output metadata.
+    """
+    feature_key = mx.coerce_to_feature_key(feature)
+    feature_def = mx.get_feature_by_key(feature_key)
+    feature_version = mx.current_graph().get_feature_version(feature_key)
+
+    return {
+        "feature": {
+            "project": feature_def.project,
+            "spec": feature_def.spec.model_dump(mode="json"),
+            "version": feature_version,
+            "type": feature_def.feature_class_path,
+        },
+        "metaxy": {
+            "version": mx.__version__,
+            "plugins": mx.MetaxyConfig.get().plugins,
+        },
+    }

--- a/tests/ext/rivers/conftest.py
+++ b/tests/ext/rivers/conftest.py
@@ -1,0 +1,17 @@
+﻿"""Common fixtures for Rivers integration tests."""
+
+from collections.abc import Iterator
+
+import metaxy as mx
+import pytest
+
+
+@pytest.fixture
+def metaxy_config() -> Iterator[mx.MetaxyConfig]:
+    """In-memory DuckDB-backed Metaxy config, scoped to a single test."""
+    store_config = mx.StoreConfig(
+        type="metaxy.ext.duckdb.DuckDBMetadataStore",
+        config={"database": ":memory:"},
+    )
+    with mx.MetaxyConfig(project="test", stores={"dev": store_config}).use() as config:
+        yield config

--- a/tests/ext/rivers/test_metaxify.py
+++ b/tests/ext/rivers/test_metaxify.py
@@ -1,0 +1,133 @@
+﻿"""Tests for metaxy.ext.rivers.metaxify."""
+
+import metaxy as mx
+from metaxy.ext.rivers.constants import (
+    RIVERS_METAXY_FEATURE_METADATA_KEY,
+    RIVERS_METAXY_INFO_METADATA_KEY,
+)
+from metaxy.ext.rivers.metaxify import metaxify
+
+
+def test_metaxify_sets_asset_name_to_table_name(metaxy_config: mx.MetaxyConfig):
+    """The asset name should always be the feature's table_name, regardless of the function name."""
+    spec = mx.FeatureSpec(
+        key=["test", "name_from_table"],
+        id_columns=["id"],
+        fields=["value"],
+    )
+
+    class NameFromTableFeature(mx.BaseFeature, spec=spec):
+        id: str
+        value: int
+
+    @metaxify("test/name_from_table")
+    def some_other_function_name():
+        pass
+
+    feature_key = mx.coerce_to_feature_key("test/name_from_table")
+    expected_table_name = feature_key.table_name
+
+    assert some_other_function_name.name == expected_table_name
+
+
+def test_metaxify_injects_metadata(metaxy_config: mx.MetaxyConfig):
+    """metaxify should inject the feature key and feature info into asset metadata."""
+    spec = mx.FeatureSpec(
+        key=["test", "metadata_injection"],
+        id_columns=["id"],
+        fields=["value"],
+    )
+
+    class MetadataInjectionFeature(mx.BaseFeature, spec=spec):
+        id: str
+        value: int
+
+    @metaxify("test/metadata_injection")
+    def my_asset():
+        pass
+
+    metadata = my_asset.metadata
+    assert metadata is not None
+    assert metadata[RIVERS_METAXY_FEATURE_METADATA_KEY] == "test/metadata_injection"
+    assert RIVERS_METAXY_INFO_METADATA_KEY in metadata
+    assert "metaxy/feature_code_version" in metadata
+
+
+def test_metaxify_preserves_user_metadata(metaxy_config: mx.MetaxyConfig):
+    """User-supplied metadata should be preserved alongside injected metaxy metadata."""
+    spec = mx.FeatureSpec(
+        key=["test", "user_metadata"],
+        id_columns=["id"],
+        fields=["value"],
+    )
+
+    class UserMetadataFeature(mx.BaseFeature, spec=spec):
+        id: str
+        value: int
+
+    @metaxify("test/user_metadata", metadata={"custom_key": "custom_value"})
+    def my_asset():
+        pass
+
+    metadata = my_asset.metadata
+    assert metadata["custom_key"] == "custom_value"
+    assert metadata[RIVERS_METAXY_FEATURE_METADATA_KEY] == "test/user_metadata"
+
+
+def test_metaxify_injects_code_version(metaxy_config: mx.MetaxyConfig):
+    """metaxify should inject a metaxy:<code_version> string into code_version."""
+    spec = mx.FeatureSpec(
+        key=["test", "code_version_injection"],
+        id_columns=["id"],
+        fields=["value"],
+    )
+
+    class CodeVersionFeature(mx.BaseFeature, spec=spec):
+        id: str
+        value: int
+
+    @metaxify("test/code_version_injection")
+    def my_asset():
+        pass
+
+    assert my_asset.code_version is not None
+    assert my_asset.code_version.startswith("metaxy:")
+
+
+def test_metaxify_disable_code_version_injection(metaxy_config: mx.MetaxyConfig):
+    """When inject_code_version=False and no code_version is passed, code_version should be None."""
+    spec = mx.FeatureSpec(
+        key=["test", "no_code_version"],
+        id_columns=["id"],
+        fields=["value"],
+    )
+
+    class NoCodeVersionFeature(mx.BaseFeature, spec=spec):
+        id: str
+        value: int
+
+    @metaxify("test/no_code_version", inject_code_version=False)
+    def my_asset():
+        pass
+
+    assert my_asset.code_version is None
+
+
+def test_metaxify_passes_through_asset_kwargs(metaxy_config: mx.MetaxyConfig):
+    """Unrecognized asset_kwargs (e.g. tags, group) should be passed straight through to Asset(...)."""
+    spec = mx.FeatureSpec(
+        key=["test", "kwargs_passthrough"],
+        id_columns=["id"],
+        fields=["value"],
+    )
+
+    class KwargsPassthroughFeature(mx.BaseFeature, spec=spec):
+        id: str
+        value: int
+
+    @metaxify("test/kwargs_passthrough", tags=["custom_tag"], group="custom_group")
+    def my_asset():
+        pass
+
+    assert my_asset.tags == ["custom_tag"]
+    assert my_asset.group == "custom_group"

--- a/tests/ext/rivers/test_resources.py
+++ b/tests/ext/rivers/test_resources.py
@@ -1,0 +1,36 @@
+﻿"""Tests for metaxy.ext.rivers.resources."""
+
+import pytest
+
+import metaxy as mx
+from metaxy.ext.rivers.resources import MetaxyResource
+
+
+def test_metaxy_resource_store_before_setup_raises(metaxy_config: mx.MetaxyConfig):
+    """Accessing .store before setup() is called should raise RuntimeError."""
+    resource = MetaxyResource()
+
+    with pytest.raises(RuntimeError, match="setup"):
+        _ = resource.store
+
+
+def test_metaxy_resource_setup_and_teardown(metaxy_config: mx.MetaxyConfig):
+    """setup() should make .store available; teardown() should clear it."""
+    resource = MetaxyResource()
+
+    resource.setup()
+    assert resource.store is not None
+    assert isinstance(resource.store, mx.MetadataStore)
+
+    resource.teardown()
+    with pytest.raises(RuntimeError, match="setup"):
+        _ = resource.store
+
+
+def test_metaxy_resource_uses_named_store(metaxy_config: mx.MetaxyConfig):
+    """A MetaxyResource with name=None should resolve to the default ("dev") store."""
+    resource = MetaxyResource(name="dev")
+
+    resource.setup()
+    assert resource.store is not None
+    resource.teardown()

--- a/tests/ext/rivers/test_utils.py
+++ b/tests/ext/rivers/test_utils.py
@@ -1,0 +1,27 @@
+﻿"""Tests for metaxy.ext.rivers.utils."""
+
+import metaxy as mx
+from metaxy.ext.rivers.utils import build_feature_info_metadata
+
+
+def test_build_feature_info_metadata(metaxy_config: mx.MetaxyConfig):
+    """Test that build_feature_info_metadata returns the expected structure."""
+    spec = mx.FeatureSpec(
+        key=["test", "info_metadata"],
+        id_columns=["id"],
+        fields=["value"],
+    )
+
+    class InfoMetadataFeature(mx.BaseFeature, spec=spec):
+        id: str
+        value: int
+
+    info = build_feature_info_metadata("test/info_metadata")
+
+    assert "feature" in info
+    assert info["feature"]["project"] == "test"
+    assert info["feature"]["spec"]["id_columns"] == ["id"]
+    assert "version" in info["feature"]
+
+    assert "metaxy" in info
+    assert info["metaxy"]["version"] == mx.__version__

--- a/uv.lock
+++ b/uv.lock
@@ -32,7 +32,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "caio" },
+    { name = "caio", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/67/e2/d7cb819de8df6b5c1968a2756c3cb4122d4fa2b8fc768b53b7c9e5edb646/aiofile-3.9.0.tar.gz", hash = "sha256:e5ad718bb148b265b6df1b3752c4d1d83024b93da9bd599df74b9d9ffcf7919b", size = 17943, upload-time = "2024-10-08T10:39:35.846Z" }
 wheels = [
@@ -50,7 +50,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "caio" },
+    { name = "caio", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/48/41/2fea7e193e061ce54eacc3b7bc0e6a99e4fcff43c78cf0a76dd781ed8334/aiofile-3.11.1.tar.gz", hash = "sha256:1f91912c6643d2a4e49ca4ae3514f0bf3867ce948a36d99a6411b8f4755f4cf9", size = 19342, upload-time = "2026-05-16T08:18:33.538Z" }
 wheels = [
@@ -70,6 +70,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/02/a6/74c8cadc2882977d80ad756a13857857dbcf9bd405bc80b662eb10651282/alembic-1.17.2.tar.gz", hash = "sha256:bbe9751705c5e0f14877f02d46c53d10885e377e3d90eda810a016f9baa19e8e", size = 1988064, upload-time = "2025-11-14T20:35:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/88/6237e97e3385b57b5f1528647addea5cc03d4d65d5979ab24327d41fb00d/alembic-1.17.2-py3-none-any.whl", hash = "sha256:f483dd1fe93f6c5d49217055e4d15b905b425b6af906746abb35b69c1996c4e6", size = 248554, upload-time = "2025-11-14T20:35:05.699Z" },
+]
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/8e/38aa427ed5402449e226975b649c5dc73ccadfefeb95e6aecb8f8ea4b6b6/annotated_doc-0.0.5.tar.gz", hash = "sha256:c7e58ce09192557605d8bbd92836d7e1d520ac9580096042c0bfd197efacf1bb", size = 10758, upload-time = "2026-07-28T13:50:58.129Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/30/e900b21425a860e195f32e37657aa1f7c7f2b1bfb26f03ca209b90933c06/annotated_doc-0.0.5-py3-none-any.whl", hash = "sha256:117bac03a25ede5df5440e855b32d556049ca169ead221505badf432fed4b101", size = 5302, upload-time = "2026-07-28T13:50:57.239Z" },
 ]
 
 [[package]]
@@ -701,6 +710,15 @@ pandas = [
 ]
 
 [[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -741,7 +759,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -814,7 +832,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -2534,17 +2552,17 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "decorator" },
-    { name = "exceptiongroup" },
-    { name = "jedi" },
-    { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit" },
-    { name = "pygments" },
-    { name = "stack-data" },
-    { name = "traitlets" },
-    { name = "typing-extensions" },
+    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version < '3.11'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "jedi", marker = "python_full_version < '3.11'" },
+    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
+    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
+    { name = "pygments", marker = "python_full_version < '3.11'" },
+    { name = "stack-data", marker = "python_full_version < '3.11'" },
+    { name = "traitlets", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/85/31/10ac88f3357fc276dc8a64e8880c82e80e7459326ae1d0a211b40abf6665/ipython-8.37.0.tar.gz", hash = "sha256:ca815841e1a41a1e6b73a0b08f3038af9b2252564d01fc405356d34033012216", size = 5606088, upload-time = "2025-05-31T16:39:09.613Z" }
 wheels = [
@@ -2562,17 +2580,17 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "decorator" },
-    { name = "ipython-pygments-lexers" },
-    { name = "jedi" },
-    { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit" },
-    { name = "pygments" },
-    { name = "stack-data" },
-    { name = "traitlets" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version >= '3.11'" },
+    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
+    { name = "jedi", marker = "python_full_version >= '3.11'" },
+    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
+    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "stack-data", marker = "python_full_version >= '3.11'" },
+    { name = "traitlets", marker = "python_full_version >= '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/12/51/a703c030f4928646d390b4971af4938a1b10c9dfce694f0d99a0bb073cb2/ipython-9.8.0.tar.gz", hash = "sha256:8e4ce129a627eb9dd221c41b1d2cdaed4ef7c9da8c17c63f6f578fe231141f83", size = 4424940, upload-time = "2025-12-03T10:18:24.353Z" }
 wheels = [
@@ -2584,7 +2602,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -3014,6 +3032,18 @@ wheels = [
 ]
 
 [[package]]
+name = "loky"
+version = "3.5.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpickle" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/61/690a4503ede61d36cc7fa2d5fa11fe02d94f030bd82155cd8935b2694580/loky-3.5.6.tar.gz", hash = "sha256:d96935ed689aa53eeb7b329769544950fa10a52706968f5d0af3d9c33a761e77", size = 102275, upload-time = "2025-08-27T09:53:52.4Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/80/7f1f1bf8c2d5dfd8e9c0e1191aa355ff8b80b5619f84d6dcc2703fa7fd5a/loky-3.5.6-py3-none-any.whl", hash = "sha256:6d5300ac68cbd5084e89a6a0a187785d6a79950d461c80223d2c9a41d672b3d4", size = 56515, upload-time = "2025-08-27T09:53:51.145Z" },
+]
+
+[[package]]
 name = "lz4"
 version = "4.4.5"
 source = { registry = "https://pypi.org/simple" }
@@ -3413,6 +3443,9 @@ postgres = [
 ray = [
     { name = "ray", marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.13' and sys_platform == 'win32')" },
 ]
+rivers = [
+    { name = "rivers" },
+]
 sqlalchemy = [
     { name = "sqlalchemy" },
 ]
@@ -3525,6 +3558,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0.0" },
     { name = "ray", marker = "(python_full_version < '3.14' and sys_platform != 'win32' and extra == 'ray') or (python_full_version < '3.13' and sys_platform == 'win32' and extra == 'ray')", specifier = ">2.36.0" },
     { name = "rich", specifier = ">=13.0.0" },
+    { name = "rivers", marker = "extra == 'rivers'", specifier = ">=0.4.0" },
     { name = "sqlalchemy", marker = "extra == 'clickhouse'", specifier = ">=2.0" },
     { name = "sqlalchemy", marker = "extra == 'sqlalchemy'", specifier = ">=2.0" },
     { name = "sqlalchemy", marker = "extra == 'sqlmodel'", specifier = ">=2.0" },
@@ -3535,7 +3569,7 @@ requires-dist = [
     { name = "tomlkit", specifier = ">=0.13.2" },
     { name = "typing-extensions", specifier = ">=4.0.0" },
 ]
-provides-extras = ["map", "ibis", "mermaid", "sqlalchemy", "sqlmodel", "bigquery", "clickhouse", "duckdb", "delta", "dagster", "iceberg", "lancedb", "postgres", "mcp", "ray"]
+provides-extras = ["map", "rivers", "ibis", "mermaid", "sqlalchemy", "sqlmodel", "bigquery", "clickhouse", "duckdb", "delta", "dagster", "iceberg", "lancedb", "postgres", "mcp", "ray"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -4518,6 +4552,68 @@ wheels = [
 ]
 
 [[package]]
+name = "obstore"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/2f/f83afaab7945509d72245b2b00af0b4834ce78fdd2d9ae9f0ad1a3036a91/obstore-0.11.0.tar.gz", hash = "sha256:a2f55163bcd348b4a60d12e6893eac50eddc742bad8032a1705d49140b992204", size = 130565, upload-time = "2026-06-25T18:29:49.405Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/ea/3792fd91107068987d96e65b616ce2e7b461b3a04665d69ef91babd3094f/obstore-0.11.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:fc61226fecb74125f4bfdb5f8c29e440538814968e304a6df5a41e8becc21f6d", size = 5491962, upload-time = "2026-06-25T18:28:07.095Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/a5/60f84c4fdbe8c6f769820544b7dbc7c0595e47bb610fdb32acb87b0240e3/obstore-0.11.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2427bf1c18d49c04c5f08763e921ba382b615655dd0ec6544a6f696462c9ecc6", size = 4675452, upload-time = "2026-06-25T18:28:09.5Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/d1/558a2500ca0a7808691b13d39c39752b48987105c0f73d1c36b343ab61fb/obstore-0.11.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:931f58915ee9b71d82951e8c4e438a6823ba7d362f6edde394089bec07c9dd65", size = 5069608, upload-time = "2026-06-25T18:28:11.203Z" },
+    { url = "https://files.pythonhosted.org/packages/76/85/1211b6b132a216381c1af7368be6ef7df52294209046de5ec41007c33c8e/obstore-0.11.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:86055c89ebae043dedbbe7b02b07f68f3af7e9d70eedadc5d79805572ffc2543", size = 5298950, upload-time = "2026-06-25T18:28:13.22Z" },
+    { url = "https://files.pythonhosted.org/packages/01/f1/78c069aa1372b2d274895cb5b3dec097135a9a981d7ca6335bd7500ae0d5/obstore-0.11.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:51c5e265910bb6502b6246bef9f9f1f9151b8889d8bac549f94ab30eccae67d5", size = 5492459, upload-time = "2026-06-25T18:28:15.222Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/f7/103df5872a229fa7619a88c4ee5f181bc02a64dba7424098fece44be9058/obstore-0.11.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:82e59348de18fa332306dd4aceee14af69d64d6626cd3244de3869041dfed461", size = 5361500, upload-time = "2026-06-25T18:28:16.837Z" },
+    { url = "https://files.pythonhosted.org/packages/55/40/7b03d2a2ae89b6703e70dafb1b8498b8a615601c9ebe01fbb125f635392d/obstore-0.11.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d9d7411de9eef9007c971059ca714e50ef1bff24ba95c4ca762c9155b569af4b", size = 5635311, upload-time = "2026-06-25T18:28:18.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/a9/552ca7e52813dfe26cbddff964d7807c8ac720c6d915066adbc61d8d2638/obstore-0.11.0-cp310-cp310-manylinux_2_24_aarch64.whl", hash = "sha256:9be99562b09b32e7b1e51305f9871fa6d96ecf26fa05b7df8f6064be7036e77f", size = 5415966, upload-time = "2026-06-25T18:28:20.641Z" },
+    { url = "https://files.pythonhosted.org/packages/21/93/35f974522a5d325e56b2fe5d9d306231f73384216a26d5595382141b8b0e/obstore-0.11.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d40161c924435ae45c89b3b32f6329ad247b76feec17f3123f92621defa533ed", size = 5622823, upload-time = "2026-06-25T18:28:22.587Z" },
+    { url = "https://files.pythonhosted.org/packages/66/b6/99580e8b8a3d26130a299b9f7f5b15ed9fcfaf57a6b69becf59d6e169842/obstore-0.11.0-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:b69b9e6d5fd5f36063fb17eada334fc6e52e3309daed20b04986945dbc0915a2", size = 5297560, upload-time = "2026-06-25T18:28:24.558Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e6/e3b70c0472c7848d57c273e172853c0d20ab97ec6491abc034da2ea8c327/obstore-0.11.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:2b1d9568db8af6341c7ca9ecf15bc444c1ac748933b0e0e93fb9f2797a16ea37", size = 5427004, upload-time = "2026-06-25T18:28:26.366Z" },
+    { url = "https://files.pythonhosted.org/packages/de/4d/1fa2abe05f9ba3fa010aadb3695ce02e97ab3da6b8e12e46b309ca71f249/obstore-0.11.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:2a569f81c835c28b247a531849b357249d96753a30b45b4f4c3b442f24d988fc", size = 5865056, upload-time = "2026-06-25T18:28:28.231Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ba/ddc091b18baa49afdfc8b270ac8c16bdd69b05bf3e75acd2e20bd5970d9d/obstore-0.11.0-cp310-cp310-win_amd64.whl", hash = "sha256:545b23c2d13f2a5911a3b1a2c0b9dbf307b430684d171c5a7905c3e514a80662", size = 5323295, upload-time = "2026-06-25T18:28:30.107Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b2/00c213e7e5ca8065f97e37e55294adab836e3f6a88b23e4029069aaecf95/obstore-0.11.0-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:42f36546c7ac44dbab1173d2330a8a1b1a3f0e37950e553b8c904e3dd0744b25", size = 5491935, upload-time = "2026-06-25T18:28:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/37/6a6b9a5e15a8a37c24d14317a87648097c4888593b588510c03c030d2e90/obstore-0.11.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:687bb9d3962d568b7c439c5d0c6fea19b2749862a8e5c8eebd0c058c4eccde9e", size = 4672619, upload-time = "2026-06-25T18:28:33.852Z" },
+    { url = "https://files.pythonhosted.org/packages/28/f9/6745ce8c4f7bfac19dc14a4438b48a2e93a689b92b0cecfc695e41a4e8b1/obstore-0.11.0-cp311-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:010b51578c7514a41719d795cdb7a1e6529be509dac3772e477187a59422bb97", size = 5072806, upload-time = "2026-06-25T18:28:36.127Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/18/991d3b3cdd851c0225e55f3dc45b47fd9e249827d188995011469f805132/obstore-0.11.0-cp311-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cfaa8129a3f5d8518a3a75184d4b02348db0f6263177cd1f0951f6568243cc9e", size = 5303777, upload-time = "2026-06-25T18:28:37.89Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/e9/90e56015a45b5e56a84fc3188c4e5fb088b288d41992c73a629e10df6760/obstore-0.11.0-cp311-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c790a5cb9ff2970d1f464a6a708d734dce9939e9f668cb6708c5dba5d61589b2", size = 5493871, upload-time = "2026-06-25T18:28:39.981Z" },
+    { url = "https://files.pythonhosted.org/packages/66/02/f1744091d59ce71c5523174eb860fbb298275c901e89b9ea6fbf3e654a33/obstore-0.11.0-cp311-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:827113e12fe8088e0281a9d57b90b2b8dbc8a6ffe3b15dadb9baa5feb3d266c1", size = 5361913, upload-time = "2026-06-25T18:28:42.089Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/59/3f47822683ee2b6db8685faa25829946d6343a561251ec2704548455d946/obstore-0.11.0-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a2ff6d3ed553298828fb760b4aef6347fbcc7b5c5e3ce3f8381ce805c370021a", size = 5638724, upload-time = "2026-06-25T18:28:43.897Z" },
+    { url = "https://files.pythonhosted.org/packages/23/50/1df335fdf9b527b3933f1e94ab6fc720ad314260fab8591cb0b6668ff192/obstore-0.11.0-cp311-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:39d04b324fcf984e7050734ebda77b81764025b0c011750201a0d8954087f7aa", size = 5413508, upload-time = "2026-06-25T18:28:45.624Z" },
+    { url = "https://files.pythonhosted.org/packages/de/dc/a259aba149b841ca7c91fea177df9972a60a636b54077beed1a35b254994/obstore-0.11.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:37c0d15d775b1370ef5204ee3919a5ddf7e2592d11815213105f8db031f2ab8d", size = 5619995, upload-time = "2026-06-25T18:28:47.599Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/b4/ec25fdb4d6b060bc6eea647fc0e88f75fcc20fe8d16d67fb0dbe999d323b/obstore-0.11.0-cp311-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:7f468caf9b6e0f12ff151e5fe618de5fc9192befa9bd02734b06de4efd2e49f6", size = 5299512, upload-time = "2026-06-25T18:28:49.629Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/e5/29be060d06ec13e2af3d1b6cfb77b7c37f8be6c56b77295c945fefad73e4/obstore-0.11.0-cp311-abi3-musllinux_1_2_i686.whl", hash = "sha256:42d8e8fad85be8ee488c1a9a9b7c6a42128abb84e67175da40d3d1165c1846df", size = 5427026, upload-time = "2026-06-25T18:28:51.317Z" },
+    { url = "https://files.pythonhosted.org/packages/57/b7/577a965f440e9ea64243518663f9d16be7df8eafc7123818e8e841fa21ce/obstore-0.11.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9c8fd2a544e2e0b926669c47fcfb8d2314e234abc240ea165dae04ee42e1d7ac", size = 5869187, upload-time = "2026-06-25T18:28:53.166Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/18/8fdbaee22bfd5b9c44e1fdff8ca0508e2fe60c42bf9fc85f0c9c27b4ecf2/obstore-0.11.0-cp311-abi3-win_amd64.whl", hash = "sha256:6fb3d4678c0f4242d3109362e9b1df5d7b27765f43d5aacb2e81af53a75cb9ef", size = 5329384, upload-time = "2026-06-25T18:28:55.305Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/8b/7555e48ec768728fcfc71a051c6b28d6ddaf1bececf492ce5ef995aab5f0/obstore-0.11.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:f3132393eff9f3f2b543ecbb3bcc12319a7c433fef06493b4350d6854d505a14", size = 5515763, upload-time = "2026-06-25T18:28:57.527Z" },
+    { url = "https://files.pythonhosted.org/packages/23/8f/94d83f3336421cbb5e436ab0ae5695eae72f7c82990d6b1ac090712c8052/obstore-0.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a3a8da19b47af4c14ecc694209b3c18ac6d89f96be5656ee3a19b77947c14155", size = 4649491, upload-time = "2026-06-25T18:28:59.386Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/86/11f4e1f51a8c6cf21a5915c018d2357201ad3c5799d418f0c6529fafaab2/obstore-0.11.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e91298b9b6c3a0408c28eece62bca6c5b6cda2f6350351d84e07b4dc8fb2631f", size = 5060659, upload-time = "2026-06-25T18:29:01.139Z" },
+    { url = "https://files.pythonhosted.org/packages/49/e7/fd3036b0923d10e878e2073020f1ef692a618ed1cc3980d3e4a468c93713/obstore-0.11.0-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3422c532486671dfb5e3e739bf15ec9ca2a8da544a3c23b74ae3857dcab1c6a8", size = 5277058, upload-time = "2026-06-25T18:29:02.96Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/a7/b016c3ac6857ac856326dc0a292e3871b8500d03f25f3b90e168b05de357/obstore-0.11.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3de027ce46cf0592c2b41654e2c27dbc52a4a726f6fbc511380acc0da3a9f658", size = 5475852, upload-time = "2026-06-25T18:29:05.032Z" },
+    { url = "https://files.pythonhosted.org/packages/85/9e/644ffe8db7757de7f71f94a036ab24222bccb4de290d3ca69f76547e812d/obstore-0.11.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1a80a95548678210bc336b866e37139c293565c3b163eb3fef2433d5d6640a33", size = 5363082, upload-time = "2026-06-25T18:29:06.878Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/0b/26af6b5fa6ba96af84086f44f78b4e5b0af1729c31402d7b28c68989d174/obstore-0.11.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:acaa261dc15efb95bbeca06f8fe9b47ee23d7302a6aa1fa3a9654baab8b23d7c", size = 5629116, upload-time = "2026-06-25T18:29:08.771Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ce/f30d502991c6719b2fbd7b8385ef3e39da07bfca099108bcc5eeed8b9c20/obstore-0.11.0-cp314-cp314t-manylinux_2_24_aarch64.whl", hash = "sha256:a3300cabbc3129670987b3723629c791d83c117ef1b6a0c670c2043648e000a1", size = 5404534, upload-time = "2026-06-25T18:29:11.294Z" },
+    { url = "https://files.pythonhosted.org/packages/52/20/d5bf5f816e868717ba647ed9a2109e800deb402d0265d410456b3fcb4376/obstore-0.11.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f4e6a9480843645cd4ee122c41d5c5a46a56f1e9cdda85638826f2e0e439fe5c", size = 5613159, upload-time = "2026-06-25T18:29:13.414Z" },
+    { url = "https://files.pythonhosted.org/packages/db/b4/6d4c1c211e3b06cc8554189e0d4406e8fa1f98ed55f9213b8e398a11599f/obstore-0.11.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:9fb2b1814c4314b8903f4e2ebbe8c3365fea6543669615ee9a0288b0d3a2edeb", size = 5286279, upload-time = "2026-06-25T18:29:15.424Z" },
+    { url = "https://files.pythonhosted.org/packages/02/5e/d7b5589424a56171b16ab94cf92eb493490c300aaa044913bbdd94cace68/obstore-0.11.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:63fb9b072815eafe4705f617f567d896b1c858adcb390795fa1e269367791031", size = 5401780, upload-time = "2026-06-25T18:29:17.514Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/18/841baea8936e51a18b0e5d4c51f09c0a7798cb73b027e9794be2362a0f0b/obstore-0.11.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:086fafba314ff98cfab1c4bf7814699e862513e8889720cf6f7462296cb32787", size = 5853618, upload-time = "2026-06-25T18:29:19.354Z" },
+    { url = "https://files.pythonhosted.org/packages/83/9a/d6127f5422b78e0222b0a9eadcfd7a5aa8d873a9498da7d4a77d4ac8ce2e/obstore-0.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:676d1154f6f08721110f9b7d14ee3a3c0293abaf9da135bb90f54e276dca1cac", size = 5314113, upload-time = "2026-06-25T18:29:21.209Z" },
+    { url = "https://files.pythonhosted.org/packages/61/17/6ddc3e035a0adc3397bc2b9ea4ebe52db6711ad87ddf0180b7675fa25d6a/obstore-0.11.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c30aec09acff505e27b7392eb5e4b7bb7073d3f21e44ea43a64913369d83cba0", size = 5500652, upload-time = "2026-06-25T18:29:23.423Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/66/0e8ebfebf7151b401dee19373b3a699b179c3687bea5d684adbef2c7c67d/obstore-0.11.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:32ec11db91b85e4482baf2c8c0f43b469e8788765cd844839c84468516446181", size = 4681675, upload-time = "2026-06-25T18:29:25.766Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/84/717505cdf8e453ef16be74e6ca4204629722227c1cbecf3719a17513dd9a/obstore-0.11.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0a7f574cf222156f95846fda755365085e8c825be48359f32fa57935fa79f172", size = 5078712, upload-time = "2026-06-25T18:29:27.502Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/e4/a3a87a9ef6973cc59f8cd3543b74cde3bac81ff18bfdab80a460c95d5df0/obstore-0.11.0-pp311-pypy311_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:193d8af924c24ab60c342d64c55896f8cae026851182ade6f1b650789d17b84a", size = 5309116, upload-time = "2026-06-25T18:29:29.912Z" },
+    { url = "https://files.pythonhosted.org/packages/98/40/af6699c140cd4f5fb638ccad2053b096ebaa8b5fcd2a2c5176113c1bc847/obstore-0.11.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ed68e3653f12a995bca4372cdccf8663bd3df2ce9750132d11c4c04489e2dc61", size = 5503037, upload-time = "2026-06-25T18:29:32.396Z" },
+    { url = "https://files.pythonhosted.org/packages/22/0c/e83123e8e2d2075dd686ed1c13e462c19b9c57ec0a67c316bdde862c6def/obstore-0.11.0-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ee8d5aa13158e39d20e76730fdc81a50fd80f6d415a1dc327cf317e5c4e2e878", size = 5368241, upload-time = "2026-06-25T18:29:34.366Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/94/d1cba6347ed6e540765e6db2c2a262f8aba50ae40a0d47749465c42e94a0/obstore-0.11.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca0a6bef07fc26990828528090c6b41860ca949d3cf1b81b24854674173b47ba", size = 5644399, upload-time = "2026-06-25T18:29:36.482Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/24/a9033feffb423d5f6a7bdc85041e9b9e1f67b2835fd484427d005ed17187/obstore-0.11.0-pp311-pypy311_pp73-manylinux_2_24_aarch64.whl", hash = "sha256:c9c6ccc06801afb0fc0e8f0e8c957f643c2c4f7e349eb36a736167e280709c6c", size = 5423124, upload-time = "2026-06-25T18:29:38.513Z" },
+    { url = "https://files.pythonhosted.org/packages/69/e8/2ee75c66bc703670bbf1aa51c320a4d282efa85adf8e9fa3f7467c02513e/obstore-0.11.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:9555f36a0724d34d747b38cda0cb55b3f650a22e8671614037c52190bf4da6cc", size = 5630049, upload-time = "2026-06-25T18:29:40.647Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/72/76b3099664d997747e5e7b11b322926d486d1471266941fc0103d912b666/obstore-0.11.0-pp311-pypy311_pp73-musllinux_1_2_armv7l.whl", hash = "sha256:f0c1527daf1c75d3f70ee3f6bef2767d8b07005cd7a5b43dc8c96a1323f3ac54", size = 5308482, upload-time = "2026-06-25T18:29:42.643Z" },
+    { url = "https://files.pythonhosted.org/packages/34/96/03594ac63d7b1a0e773b0c604c38003ee828e6d5348488eaeb2c57bdc29e/obstore-0.11.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:ed5910bde525d7d936d36dc78c7d4c07b57b6c9b55e402357b107103595d56ff", size = 5433377, upload-time = "2026-06-25T18:29:45.323Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/53/07226c948760264fb7ba253825ecbe5941abfac9875e6d1b2679cc82e3ef/obstore-0.11.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:65c0208ead516c1a79afced16f2cda9b5542886123e53ea0a8a7d5d56b86fba5", size = 5868708, upload-time = "2026-06-25T18:29:47.668Z" },
+]
+
+[[package]]
 name = "openapi-pydantic"
 version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -5452,16 +5548,16 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.12.0"
+version = "2.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/43/4b/ac7e0aae12027748076d72a8764ff1c9d82ca75a7a52622e67ed3f765c54/pydantic_settings-2.12.0.tar.gz", hash = "sha256:005538ef951e3c2a68e1c08b292b5f2e71490def8589d4221b95dab00dafcfd0", size = 194184, upload-time = "2025-11-10T14:25:47.013Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/ca/31c57507b13119d7d3cfa1576dad2911a4861e3be07b579395f4e9d393f9/pydantic_settings-2.15.0.tar.gz", hash = "sha256:694b793e84f766ba76a90ebdefc01d0a9a045dab0382bee70393da93712ad117", size = 261253, upload-time = "2026-08-07T09:24:57.419Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/60/5d4751ba3f4a40a6891f24eec885f51afd78d208498268c734e256fb13c4/pydantic_settings-2.12.0-py3-none-any.whl", hash = "sha256:fddb9fd99a5b18da837b29710391e945b1e30c135477f484084ee513adb93809", size = 51880, upload-time = "2025-11-10T14:25:45.546Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a4/2bffa9f8e804325a09867f0e9d30795c80ea9f8d62560bd1b6ad6220eb2f/pydantic_settings-2.15.0-py3-none-any.whl", hash = "sha256:0ba092c291c94baceb5eff768aa0d56400a457585bc0175925a5a5510303da42", size = 69413, upload-time = "2026-08-07T09:24:55.839Z" },
 ]
 
 [[package]]
@@ -5954,14 +6050,14 @@ name = "ray"
 version = "2.55.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "filelock" },
-    { name = "jsonschema" },
-    { name = "msgpack" },
-    { name = "packaging" },
-    { name = "protobuf" },
-    { name = "pyyaml" },
-    { name = "requests" },
+    { name = "click", marker = "python_full_version < '3.14'" },
+    { name = "filelock", marker = "python_full_version < '3.14'" },
+    { name = "jsonschema", marker = "python_full_version < '3.14'" },
+    { name = "msgpack", marker = "python_full_version < '3.14'" },
+    { name = "packaging", marker = "python_full_version < '3.14'" },
+    { name = "protobuf", marker = "python_full_version < '3.14'" },
+    { name = "pyyaml", marker = "python_full_version < '3.14'" },
+    { name = "requests", marker = "python_full_version < '3.14'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/d0/a85097dd53aaca1a44acc4dd0b3d2c0e9233179433e2ee326e4018ab3cf7/ray-2.55.1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:2d5786661e192148719accc959def6cdcabd7a24cd9008005bf3d0e3c8cfd529", size = 65829601, upload-time = "2026-04-22T20:09:10.013Z" },
@@ -6207,6 +6303,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/bc/6d/a506aaa4a9eaa945ed8ab2b7347859f53593864289853c5d6d62b77246e0/rich_rst-1.3.2.tar.gz", hash = "sha256:a1196fdddf1e364b02ec68a05e8ff8f6914fee10fbca2e6b6735f166bb0da8d4", size = 14936, upload-time = "2025-10-14T16:49:45.332Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/13/2f/b4530fbf948867702d0a3f27de4a6aab1d156f406d72852ab902c4d04de9/rich_rst-1.3.2-py3-none-any.whl", hash = "sha256:a99b4907cbe118cf9d18b0b44de272efa61f15117c61e39ebdc431baf5df722a", size = 12567, upload-time = "2025-10-14T16:49:42.953Z" },
+]
+
+[[package]]
+name = "rivers"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "loky" },
+    { name = "obstore" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "typer" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/ec/3746496943d83988e49a32fd89b0c312b8c99f0a3e118a7238c794a61bf5/rivers-0.4.0-cp310-abi3-macosx_10_13_x86_64.whl", hash = "sha256:de7d74e5f7588faae81f8fd4914963ae120b6e1aaa87b7a701de6879f1ac96a0", size = 30824138, upload-time = "2026-07-24T11:52:17.421Z" },
+    { url = "https://files.pythonhosted.org/packages/be/cc/ec73277f2ead4d33d83bd4864f19397048a3b34a4f60d4dbcc39b1c59481/rivers-0.4.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:8e816d40c46d626265cae9a0349220e29270ce9746ae740ef606c2731ef1c2f2", size = 29781394, upload-time = "2026-07-24T11:52:20.725Z" },
+    { url = "https://files.pythonhosted.org/packages/88/77/e3e65a37c01752b2653977ce80bcc8bdce09ee6bc6ad41200eaf0953b820/rivers-0.4.0-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:acec93de3beded3862de9bdc3aed4daf4504cd2b9ff326b5ea7048d4b74f848b", size = 29476619, upload-time = "2026-07-24T11:52:24.054Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/43/1d03bcc7909972213c6d11607374c02b4cb31c8001b2eb3258dcb0279e65/rivers-0.4.0-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0063d105a0722b8f41d22801d0399054056f148c8ce94e341612cc3a85186e34", size = 30499612, upload-time = "2026-07-24T11:52:27.338Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/e6/ef2bf522c191335995a6ef8e58d78191b10b6c053c6f160cddc6c2be88ba/rivers-0.4.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:928657a15e8dfe89e163a593a5eeea712e4a04480e820266ef4d02b5c66138a7", size = 35739382, upload-time = "2026-07-24T11:52:31.369Z" },
+    { url = "https://files.pythonhosted.org/packages/89/5e/47fe073b953dcc2087bd59710d16a2439e3db09a624fd6ff0fb30445118e/rivers-0.4.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9ba62fd80dbfda6a602c20218112ef38957542049f432da374b23d3a5401fead", size = 37114228, upload-time = "2026-07-24T11:52:35.838Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/15/2e73f8725f0691ff2287c0b8dd8546e2c41520c43291f53d1af406b9b0e0/rivers-0.4.0-cp310-abi3-win_amd64.whl", hash = "sha256:8c82cb7fcf71a23f9677ddda1b56d2b1b7be45920c7deff33ee42d5768ee3cb8", size = 32796796, upload-time = "2026-07-24T11:52:39.843Z" },
 ]
 
 [[package]]
@@ -6827,17 +6944,17 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.16.1"
+version = "0.27.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
+    { name = "annotated-doc" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "rich" },
     { name = "shellingham" },
-    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/43/78/d90f616bf5f88f8710ad067c1f8705bf7618059836ca084e5bb2a0855d75/typer-0.16.1.tar.gz", hash = "sha256:d358c65a464a7a90f338e3bb7ff0c74ac081449e53884b12ba658cbd72990614", size = 102836, upload-time = "2025-08-18T19:18:22.898Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/40/4a3db7990d1f62a53182aa96eaef57aeb2886a27f90a195bc66713565d31/typer-0.27.1.tar.gz", hash = "sha256:a79bef8469a79c45498e7b814ecf8d603cc7644e9acbd9e19cac0334240b18df", size = 203994, upload-time = "2026-08-03T14:41:03.438Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2d/76/06dbe78f39b2203d2a47d5facc5df5102d0561e2807396471b5f7c5a30a1/typer-0.16.1-py3-none-any.whl", hash = "sha256:90ee01cb02d9b8395ae21ee3368421faf21fa138cb2a541ed369c08cec5237c9", size = 46397, upload-time = "2025-08-18T19:18:21.663Z" },
+    { url = "https://files.pythonhosted.org/packages/43/89/9518bc0c3929bee36b3a4a8e3daddd6e03f92f9961c66d4983b837160543/typer-0.27.1-py3-none-any.whl", hash = "sha256:53150287edd11baeb4e4722c8e394fcdf8181c0ae89485cba8d25c778d5edd56", size = 122874, upload-time = "2026-08-03T14:41:04.391Z" },
 ]
 
 [[package]]


### PR DESCRIPTION

Closes #1237

## Summary

Adds a Metaxy integration for [Rivers](https://github.com/ion-elgreco/rivers), mirroring the
existing `metaxy.ext.dagster` integration's design where a confirmed equivalent exists in
Rivers' API. New module: `src/metaxy/ext/rivers/`.

- **`metaxify()`** — decorator that wires a Metaxy feature into a Rivers `@Asset`: sets the
  asset name to the feature's `table_name`, appends `metaxy:<code_version>` to `code_version`,
  resolves upstream deps via `AssetDef.input(...)`, and injects feature/version info into
  asset metadata.
- **`MetaxyIOHandler`** — Rivers `BaseIOHandler` that reads from and writes to a Metaxy
  `MetadataStore`, handling partition filtering (`partition_by` and JSON-encoded
  `metaxy/partition` metadata) on both `load_input` and `handle_output`.
- **`MetaxyResource`** — Rivers `Resource` giving asset functions direct `MetadataStore`
  access via `setup()`/`teardown()`, for cases that need e.g. `store.resolve_update(...)`.
- `rivers>=0.4.0` added as a new `rivers` optional extra in `pyproject.toml`.

## Scope: what's intentionally not included

Rivers' Python API surface (`.pyi` stubs) was checked directly rather than guessed at. Where
no confirmed Rivers equivalent exists for a Dagster concept, it was left out and documented
in the source rather than approximated:

- **Column schema / column lineage injection** — Dagster-only concept, no Rivers equivalent.
- **`key_prefix`-style key remapping** — same reason.
- **Per-run materialization tracking** (Dagster's `metaxy/materialized_in_run`) — Rivers'
  `Resource.setup()` receives no run-id/context argument, so there's no confirmed way to tag
  writes with the current run.
- **Multi-dimensional partitions** (`PartitionKey.Multi`) — `MetaxyIOHandler` raises
  `NotImplementedError` for these rather than silently filtering incorrectly. Only
  `PartitionKey.Single` is handled.
- **Tests for `load_input` / `handle_output`** — exercising these requires driving Rivers'
  actual executor (constructing real `InputContext`/`OutputContext` instances), which needs
  further investigation into the Rivers test harness. Left for a follow-up PR rather than
  shipping untested or guessed-at test code.

## Bug found & fixed along the way

While wiring this up, found that `MetaxyIOHandler.handle_output` was missing entirely — the
code after `load_input`'s `return` was dead/unreachable and referenced an undefined `obj`
variable (would have raised `NameError` if ever reached). Rewrote as a proper `handle_output`
method matching `BaseIOHandler`'s interface, following the same read/write structure as
`metaxy.ext.dagster.io_manager.MetaxyIOManager`.

## Testing
10 passed — covers `metaxify()` (asset name, metadata injection, user-metadata preservation,
code_version injection/opt-out, kwarg passthrough) and `MetaxyResource` (setup/teardown
lifecycle, store access before/after setup).

`-p no:postgresql` works around an unrelated, pre-existing Windows issue in this repo's
`pytest-postgresql` plugin (`libpq` not found) — not something this PR introduces or touches.

Also manually verified end-to-end:
# Follow-ups (tracked separately, not blocking this PR)

- Tests for `MetaxyIOHandler.load_input` / `handle_output` against a real Rivers executor run.
- An `examples/example-rivers/` project, mirroring `examples/example-dagster/`.
- Docs page under `docs/integrations/orchestration/rivers/`, mirroring the Dagster docs.
- Multi-dimensional partition support in `MetaxyIOHandler`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/anam-org/metaxy/pull/1238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

