### PR TITLE
feat!: enable `Map` datatype by default

### DIFF
--- a/.claude-plugin/skills/metaxy/SKILL.md
+++ b/.claude-plugin/skills/metaxy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: metaxy
-description: This skill should be used when the user asks to "define a feature", "create a BaseFeature class", "track feature versions", "set up metadata store", "field-level lineage", "FieldSpec", "FeatureDep", "run metaxy CLI", "metaxy migrations", "metaxy lock", "lock features", "external features", "multi-environment", "monorepo features", "enable Map datatype", "enable_map_datatype", or needs guidance on metaxy feature definitions, versioning, metadata stores, CLI commands, testing patterns, feature locking, Map datatype configuration, or multi-environment configuration.
+description: This skill should be used when the user asks to "define a feature", "create a BaseFeature class", "track feature versions", "set up metadata store", "field-level lineage", "FieldSpec", "FeatureDep", "run metaxy CLI", "metaxy migrations", "metaxy lock", "lock features", "external features", "multi-environment", "monorepo features", "Map datatype", or needs guidance on metaxy feature definitions, versioning, metadata stores, CLI commands, testing patterns, feature locking, the Map datatype, or multi-environment configuration.
 ---
 
 # Metaxy
@@ -111,9 +111,9 @@ def metaxy_env(tmp_path):
             yield config
 ```
 
-#### Map Datatype (Experimental)
+#### Map Datatype
 
-To enable native Arrow Map column support (recommended for stores that support it), set `enable_map_datatype = true` in `metaxy.toml`. Requires the `polars-map` package. See https://docs.metaxy.io/stable/guide/concepts/metadata-stores/#map-datatype
+Metaxy represents its field-versioning columns with the native Arrow `Map` type (backed by the `polars-map` and `narwhals-map` core dependencies). Stores without native `Map` support (LanceDB) transparently store the columns as `Struct` and reconstruct `Map` on read. See https://docs.metaxy.io/stable/guide/concepts/metadata-stores/#map-datatype
 
 When working with Map columns, use `metaxy.utils.collect_to_polars`, `metaxy.utils.collect_to_arrow`, or `metaxy.utils.switch_implementation_to_polars` to materialize or convert frames. These utilities preserve Map column types that would otherwise be lost with standard Narwhals backend conversions. See https://docs.metaxy.io/stable/guide/concepts/metadata-stores/#map-datatype
 

--- a/.claude-plugin/skills/metaxy/examples/configuration.md
+++ b/.claude-plugin/skills/metaxy/examples/configuration.md
@@ -16,9 +16,6 @@ entrypoints = ["src/my_project/features"]
 # Auto-create tables (global setting, not recommended for production)
 # auto_create_tables = true
 
-# Enable native Arrow Map columns (experimental, requires polars-map)
-# enable_map_datatype = true
-
 # Development store
 [stores.dev]
 type = "metaxy.ext.polars.handlers.delta.DeltaMetadataStore"

--- a/docs/examples/ducklake.md
+++ b/docs/examples/ducklake.md
@@ -29,10 +29,6 @@ Available backend combinations:
 
     MotherDuck supports a "Bring Your Own Bucket" (BYOB) mode where MotherDuck manages the DuckLake catalog while you provide your own S3-compatible storage. Storage secrets are created `IN MOTHERDUCK` so that MotherDuck compute can access your bucket.
 
-!!! tip "Recommended: enable [`Map` datatype](../guide/concepts/metadata-stores.md#map-datatype)"
-
-    DuckLake has native `Map` type support. Enabling [`enable_map_datatype`](../reference/configuration.md#metaxy.config.MetaxyConfig.enable_map_datatype) preserves `Map` columns across read and write operations.
-
 ## Getting Started
 
 Install the example's dependencies:

--- a/docs/guide/concepts/metadata-stores.md
+++ b/docs/guide/concepts/metadata-stores.md
@@ -294,40 +294,17 @@ Fallback stores can be chained at arbitrary depth.
 
 ## `Map` Datatype
 
-Metaxy uses dictionary-like columns internally for Metaxy's field-level versioning columns. Most storage systems and Apache Arrow represent have native support for the [`Map`](https://arrow.apache.org/docs/python/generated/pyarrow.map_.html) type, but [Polars doesn't](https://github.com/pola-rs/polars/issues/8385). Polars converts `Map` columns to `List(Struct(key, value))` (physically equivalent to `Map`). This means that:
+Metaxy uses dictionary-like columns internally for its field-level versioning columns. Most storage systems and Apache Arrow have native support for the [`Map`](https://arrow.apache.org/docs/python/generated/pyarrow.map_.html) datatype that expresses exactly that. Currently, Metaxy uses [`narwhals-map`](https://pypi.org/project/narwhals-map/) plugin which adds `Map` support to Narwhals.
 
-1. user-defined `Map` columns lose their type when round-tripped through Polars
-
-2. Metaxy has to represent field-versioning columns as `Struct` instead, which is very much not ideal as the fields **will** change over time, causing problems with some storage systems.
-
-!!! note
-
-    This is also known as "The `Map` Hell" problem (the term invented by me).
-
-### Experimental `Map` Datatype Support
-
-These problems can be solved with the [`enable_map_datatype`](../../reference/configuration.md#metaxy.config.MetaxyConfig.enable_map_datatype) configuration option:
-
-```toml title="metaxy.toml"
-enable_map_datatype = true
-```
-
-!!! warning "Experimental"
-
-    `Map` datatype support is experimental and requires the [`narwhals-map`](https://pypi.org/project/narwhals-map/) and [`polars-map`](https://pypi.org/project/polars-map/) packages to be installed. They are shipped with `metaxy[map]` extra.
-
-When enabled, Metaxy uses [`narwhals-map`](https://pypi.org/project/narwhals-map/) to represent `Map` columns as `narwhals_map.Map` across all dataframe backends. Metadata stores consume and return Narwhals frames with `narwhals_map.Map` and `polars_map.Map` columns, keeping `Map` columns intact across operations and preserving user-defined `Map` columns.
-
-The following metadata stores support `Map` columns when `enable_map_datatype` is enabled:
-
-- [DuckDB](../../integrations/metadata-stores/databases/duckdb.md)
-- [ClickHouse](../../integrations/metadata-stores/databases/clickhouse.md)
-- [Delta Lake](../../integrations/metadata-stores/storage/delta.md)
-- [Apache Iceberg](../../integrations/metadata-stores/storage/iceberg.md)
+Stores whose storage engine has no native `Map` type still present `Map` columns to Metaxy: they convert the versioning columns to a storable representation on write and reconstruct `Map` on read. [LanceDB](../../integrations/metadata-stores/databases/lancedb.md) stores them as named `Struct` columns; [PostgreSQL](../../integrations/metadata-stores/databases/postgresql.md) stores them as JSON.
 
 !!! info "`Map` support in Narwhals"
 
-    Narwhals does not have native `Map` support yet (see the [tracking issue](https://github.com/narwhals-dev/narwhals/issues/3525)). Metaxy uses [`narwhals-map`](https://pypi.org/project/narwhals-map/) to bridge this gap, providing a `narwhals_map.Map` datatype and the `nw.Expr.map` namespace for working with `Map` columns across backends.
+    Narwhals does not have native `Map` support yet (see the [tracking issue](https://github.com/narwhals-dev/narwhals/issues/3525)). Metaxy uses [`narwhals-map`](https://pypi.org/project/narwhals-map/) to bridge this gap.
+
+!!! info "`Map` support in Polars"
+
+    Polars does not have native `Map` support yet (see the [tracking issue](https://github.com/pola-rs/polars/issues/8385)). Metaxy uses [`polars-map`](https://pypi.org/project/polars-map/) to bridge this gap.
 
 !!! tip "Collecting results with `Map` columns"
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,11 +23,6 @@ description: "A high level introduction to Metaxy."
 
 ---
 
-!!! success "Published in JOSS"
-
-    Metaxy is published in the [Journal of Open Source Software](https://joss.theoj.org/papers/10.21105/joss.10449).
-    Read the [docs copy of the paper](./publications/2026-introducing-metaxy/paper.md).
-
 ## Metaxy
 
 Metaxy is a pluggable metadata layer for building multimodal Data and ML pipelines. Metaxy manages and tracks **metadata** across complex computational graphs and provides sample and sub-sample versioning, allowing the codebase to evolve over time without friction.

--- a/docs/integrations/metadata-stores/databases/clickhouse.md
+++ b/docs/integrations/metadata-stores/databases/clickhouse.md
@@ -10,10 +10,6 @@ description: "Learn how to use ClickHouse as a Metaxy metadata store."
 
 1. extremely fast
 
-!!! tip "Recommended: enable [`Map` datatype](../../../guide/concepts/metadata-stores.md#map-datatype)"
-
-    ClickHouse natively supports the `Map` type. Enabling [`enable_map_datatype`](../../../reference/configuration.md#metaxy.config.MetaxyConfig.enable_map_datatype) preserves `Map` columns across read and write operations.
-
 ## Installation
 
 ```shell
@@ -41,16 +37,6 @@ ClickHouse offers multiple approaches to represent Metaxy's structured versionin
     - **No migrations required** when feature fields change
 
     - **Good performance** for key-value lookups
-
-??? info "Legacy: Struct-to-Map conversion without `enable_map_datatype`"
-
-    When [`enable_map_datatype`](../../../reference/configuration.md#metaxy.config.MetaxyConfig.enable_map_datatype) is **not** enabled, Metaxy transforms its system columns (`metaxy_provenance_by_field`, `metaxy_data_version_by_field`):
-
-    - **Reading**: System Map columns are converted into [Ibis Structs](https://ibis-project.org/reference/datatypes#ibis.expr.datatypes.core.Struct) (e.g., `Struct[{"field_a": str, "field_b": str}]`)
-
-    - **Writing**: If the input comes from Polars, then [Polars Structs][polars.datatypes.Struct] are converted into expected ClickHouse Map format
-
-    User-defined Map columns are **not transformed**. They remain as `List[Struct[{"key": str, "value": str}]]` (Arrow's Map representation). Make sure to use the right format when providing a Polars DataFrame for writing.
 
 ### SQLAlchemy and Alembic Migrations
 

--- a/docs/integrations/metadata-stores/databases/duckdb.md
+++ b/docs/integrations/metadata-stores/databases/duckdb.md
@@ -11,10 +11,6 @@ description: "Learn how to use DuckDB as a Metaxy metadata store."
 
     File-based DuckDB does not (currently) support concurrent writes. If multiple writers are a requirement (e.g. with distributed data processing), consider using [Motherduck](https://motherduck.com/), [DuckLake](../storage/ducklake.md) with a `PostgreSQL` catalog, or refer to [DuckDB's documentation](https://duckdb.org/docs/stable/connect/concurrency#writing-to-duckdb-from-multiple-processes) to learn about implementing application-side work-arounds.
 
-!!! tip "Recommended: enable [`Map` datatype](../../../guide/concepts/metadata-stores.md#map-datatype)"
-
-    DuckDB natively supports the `Map` type. Enabling [`enable_map_datatype`](../../../reference/configuration.md#metaxy.config.MetaxyConfig.enable_map_datatype) preserves `Map` columns across read and write operations.
-
 ## Installation
 
 ```shell

--- a/docs/integrations/metadata-stores/databases/lancedb.md
+++ b/docs/integrations/metadata-stores/databases/lancedb.md
@@ -13,6 +13,10 @@ description: "Learn how to use LanceDB as a Metaxy metadata store."
 
 It runs embedded (local directory) or against external storage (object stores, HTTP endpoints, LanceDB Cloud), so you can use the same store type for local development and cloud workloads.
 
+!!! info "[`Map` datatype](../../../guide/concepts/metadata-stores.md#map-datatype)"
+
+    LanceDB has no native `Map` type yet ([lance#2341](https://github.com/lance-format/lance/issues/2341)). Metaxy transparently stores the field-versioning columns as named `Struct` and reconstructs them as `Map` on read, so downstream code always sees `Map` columns.
+
 ## Installation
 
 The backend relies on [`lancedb`](https://lancedb.com/), which is shipped with Metaxy's `lancedb` extras.

--- a/docs/integrations/metadata-stores/databases/postgresql.md
+++ b/docs/integrations/metadata-stores/databases/postgresql.md
@@ -17,11 +17,12 @@ This results in the following limitations for [`MetadataStore.resolve_update`][m
 - **Increased I/O**: entire upstream metadata has to be fetched to memory
 - **Increased Memory footprint**: expect high memory usage, especially when having many upstream features
 
-## Metaxy's Versioning Struct Columns
+## Metaxy's Versioning Columns
 
-PostgreSQL doesn't have native map-like or struct types, so it's recommended to store Metaxy's versioning columns as `JSONB`.
-As a convenience feature, `PostgreSQLMetadataStore` will automatically json-encodes `pl.Struct` columns when writing metadata and parse them to `pl.Struct` when reading.
-This behavior can be disabled with [`auto_cast_struct_for_jsonb`](#metaxy.ext.postgresql.PostgreSQLMetadataStoreConfig.auto_cast_struct_for_jsonb) configuration parameter. This setting only affects user-defined columns, while Metaxy's versioning columns are always encoded/parsed.
+PostgreSQL doesn't have native map-like or struct types, so Metaxy's versioning columns are stored as `JSONB`.
+Metaxy's [`Map`](../../../guide/concepts/metadata-stores.md#map-datatype) versioning columns are decomposed into named `Struct` columns, JSON-encoded for storage, and reconstructed as `Map` on read, so callers always see `Map` columns.
+As a convenience feature, `PostgreSQLMetadataStore` also automatically json-encodes user-defined `pl.Struct` columns when writing metadata and parses them back to `pl.Struct` when reading.
+This convenience for user columns can be disabled with the [`auto_cast_struct_for_jsonb`](#metaxy.ext.postgresql.PostgreSQLMetadataStoreConfig.auto_cast_struct_for_jsonb) configuration parameter; Metaxy's versioning columns are always converted regardless.
 
 ## API Reference
 

--- a/docs/integrations/metadata-stores/storage/delta.md
+++ b/docs/integrations/metadata-stores/storage/delta.md
@@ -9,15 +9,6 @@ description: "Learn how to use Delta Lake to store Metaxy metadata."
 
 It supports the local filesystem and remote object stores.
 
-!!! tip
-
-    If Polars 1.37 or greater is installed, lazy Polars frames are sinked via
-    `LazyFrame.sink_delta`, avoiding unnecessary materialization.
-
-!!! tip "Recommended: enable [`Map` datatype](../../../guide/concepts/metadata-stores.md#map-datatype)"
-
-    Delta Lake supports the `Map` natively. Enabling [`enable_map_datatype`](../../../reference/configuration.md#metaxy.config.MetaxyConfig.enable_map_datatype) preserves `Map` columns across read and write operations.
-
 ## Installation
 
 ```shell

--- a/docs/integrations/metadata-stores/storage/iceberg.md
+++ b/docs/integrations/metadata-stores/storage/iceberg.md
@@ -10,10 +10,6 @@ description: "Learn how to use Apache Iceberg to store Metaxy metadata."
 !!! note
     By default, it uses a SQLite-backed SQL catalog for local development. You can configure any PyIceberg-supported catalog (REST, Glue, Hive) via [`catalog_properties`](#metaxy.ext.polars.handlers.iceberg.IcebergMetadataStoreConfig.catalog_properties).
 
-!!! tip "Recommended: enable [`Map` datatype](../../../guide/concepts/metadata-stores.md#map-datatype)"
-
-    Apache Iceberg supports the `Map` type natively. Enabling [`enable_map_datatype`](../../../reference/configuration.md#metaxy.config.MetaxyConfig.enable_map_datatype) preserves `Map` columns across read and write operations.
-
 ## Installation
 
 ```shell

--- a/docs/reference/api/config.md
+++ b/docs/reference/api/config.md
@@ -8,6 +8,10 @@ description: "API reference for configuration classes."
 This is the Python SDK for Metaxy's configuration. See [config file reference](../configuration.md) to learn how to configure Metaxy via `TOML` files.
 
 ::: metaxy.MetaxyConfig
+    options:
+      filters:
+        - "!^_[^_]"
+        - "!^enable_map_datatype$"
 
 ::: metaxy.StoreConfig
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -14,3 +14,8 @@ Technical documentation for Metaxy.
 - **[Configuration](./configuration.md)** - Configuration options
 
 - **[Storage Layout](./system-columns.md)** - Feature table schema documentation
+
+!!! success "Published in JOSS"
+
+    Metaxy is published in the [Journal of Open Source Software](https://joss.theoj.org/papers/10.21105/joss.10449).
+    Read the [docs copy of the paper](../publications/2026-introducing-metaxy/paper.md).

--- a/publications/2026-introducing-metaxy/paper.md
+++ b/publications/2026-introducing-metaxy/paper.md
@@ -28,9 +28,7 @@ date: 2026-02-16
 bibliography: paper.bib
 ---
 
-!!! "Published in JOSS"
-
-    This paper is published in the [Journal of Open Source Software](https://joss.theoj.org/papers/10.21105/joss.10449).
+This paper is published in the [Journal of Open Source Software](https://joss.theoj.org/papers/10.21105/joss.10449).
 
 # Summary
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,13 +43,11 @@ dependencies = [
   "packaging>=25.0",
   "tomli-w>=1.2.0",
   "tomlkit>=0.13.2",
-]
-
-[project.optional-dependencies]
-map = [
   "polars-map>=0.2.1",
   "narwhals-map>=0.1.1",
 ]
+
+[project.optional-dependencies]
 ibis = [
   "pyarrow>=18.0.0",
   "ibis-framework>=11.0.0",
@@ -158,8 +156,6 @@ dev = [
   "mkdocs-metaxy",
   "pytest-postgresql>=8.0.0",
   "tach>=0.34.0",
-  "polars-map>=0.2.1",
-  "narwhals-map>=0.1.1",
 ]
 
 examples = [

--- a/src/metaxy/config/models/metaxy_config.py
+++ b/src/metaxy/config/models/metaxy_config.py
@@ -15,7 +15,7 @@ from pydantic_settings import (
     PydanticBaseSettingsSource,
     SettingsConfigDict,
 )
-from typing_extensions import Self
+from typing_extensions import Self, deprecated
 
 from metaxy._decorators import public
 from metaxy.config.metaxy_source import MetaxyTomlSource, discover_config_with_parents
@@ -190,11 +190,6 @@ class MetaxyConfig(BaseSettings):
 
     hash_truncation_length: int = PydanticField(default=8, description="Truncate hash values to this length.", ge=8)
 
-    enable_map_datatype: bool = PydanticField(
-        default=False,
-        description="Preserve [`Map` datatype](/guide/concepts/metadata-stores.md/#map-datatype) across Metaxy operations. Requires `polars-map` to be installed. Experimental.",
-    )
-
     auto_create_tables: bool = PydanticField(
         default=False,
         description="Auto-create tables when opening stores. It is not advised to enable this setting in production.",
@@ -227,6 +222,35 @@ class MetaxyConfig(BaseSettings):
 
     # Private attribute to track which config file was used (set by load())
     _config_file: Path | None = PrivateAttr(default=None)
+
+    @property
+    @deprecated(
+        "`enable_map_datatype` is deprecated and will be removed in Metaxy 0.3.0; the Map datatype is always enabled."
+    )
+    def enable_map_datatype(self) -> bool:
+        """Whether the native `Map` datatype is preserved across Metaxy operations.
+
+        Always `True`.
+        """
+        return True
+
+    @model_validator(mode="before")
+    @classmethod
+    def _reject_disabled_map_datatype(cls, data: Any) -> Any:
+        """Reject attempts to disable the always-on `Map` datatype."""
+        if not isinstance(data, dict) or "enable_map_datatype" not in data:
+            return data
+
+        if not data.pop("enable_map_datatype"):
+            raise ValueError("enable_map_datatype cannot be disabled; the Map datatype is always enabled")
+
+        warnings.warn(
+            "`enable_map_datatype` is deprecated and will be removed in Metaxy 0.3.0; "
+            "it has no effect because the Map datatype is always enabled.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return data
 
     @property
     def config_file(self) -> Path | None:
@@ -398,9 +422,8 @@ class MetaxyConfig(BaseSettings):
         _global_config = None
 
     def _apply_extensions(self) -> None:
-        """Register optional narwhals extensions based on config."""
-        if self.enable_map_datatype:
-            import narwhals_map  # noqa: F401  # registers Map dtype and .map namespace on narwhals
+        """Register the narwhals Map extension."""
+        import narwhals_map  # noqa: F401  # registers Map dtype and .map namespace on narwhals
 
     @contextmanager
     def use(self) -> Iterator[Self]:

--- a/src/metaxy/ext/clickhouse/metadata_store.py
+++ b/src/metaxy/ext/clickhouse/metadata_store.py
@@ -1,23 +1,19 @@
 """This module implements [`IbisMetadataStore`][metaxy.ext.ibis.metadata_store.IbisMetadataStore] for ClickHouse.
 
-It takes care of some ClickHouse-specific logic such as `nw.Struct` type conversion against ClickHouse types such as `Map(K,V)`."""
+It takes care of some ClickHouse-specific logic such as native hash functions and `Map(K, V)` type handling."""
 
 from typing import TYPE_CHECKING, Any, cast
 
 import narwhals as nw
 from narwhals.typing import FrameT
-from pydantic import Field
 
 if TYPE_CHECKING:
     import ibis
-    import pyarrow as pa
-    from ibis.expr.schema import Schema as IbisSchema
 
     from metaxy.metadata_store.base import MetadataStore
 
 from metaxy._decorators import public
 from metaxy.ext.ibis.metadata_store import (
-    Frame,
     IbisMetadataStore,
     IbisMetadataStoreConfig,
 )
@@ -88,11 +84,6 @@ class ClickHouseMetadataStoreConfig(IbisMetadataStoreConfig):
         ```
     """
 
-    auto_cast_struct_for_map: bool = Field(
-        default=True,
-        description="Auto-convert DataFrame Struct columns to Map format on write when the ClickHouse column is Map type. Metaxy system columns are always converted. Ignored when enable_map_datatype is set.",
-    )
-
 
 @public
 class ClickHouseMetadataStore(IbisMetadataStore):
@@ -124,7 +115,6 @@ class ClickHouseMetadataStore(IbisMetadataStore):
         *,
         connection_params: dict[str, Any] | None = None,
         fallback_stores: list["MetadataStore"] | None = None,
-        auto_cast_struct_for_map: bool = True,
         **kwargs: Any,
     ):
         """
@@ -156,8 +146,6 @@ class ClickHouseMetadataStore(IbisMetadataStore):
 
             fallback_stores: Ordered list of read-only fallback stores.
 
-            auto_cast_struct_for_map: whether to auto-convert DataFrame user-defined Struct columns to Map format on write when the ClickHouse column is Map type. Metaxy system columns are always converted.
-
             **kwargs: Passed to [`IbisMetadataStore`][metaxy.ext.ibis.metadata_store.IbisMetadataStore]`
 
         Raises:
@@ -169,12 +157,6 @@ class ClickHouseMetadataStore(IbisMetadataStore):
                 "Must provide either connection_string or connection_params. "
                 "Example: connection_string='clickhouse://localhost:8443/default'"
             )
-
-        # Cache for ClickHouse table schemas (cleared on close)
-        self._ch_schema_cache: dict[str, IbisSchema] = {}
-
-        # Store auto_cast_struct_for_map setting
-        self.auto_cast_struct_for_map = auto_cast_struct_for_map
 
         # Initialize Ibis store with ClickHouse backend
         super().__init__(
@@ -266,103 +248,23 @@ class ClickHouseMetadataStore(IbisMetadataStore):
 
         return hash_functions
 
-    def _get_cached_schema(self, table_name: str) -> "IbisSchema":
-        """Get cached ClickHouse table schema, fetching if not cached.
-
-        Args:
-            table_name: Name of the table
-
-        Returns:
-            Ibis schema for the table
-        """
-        if table_name not in self._ch_schema_cache:
-            self._ch_schema_cache[table_name] = self.conn.table(table_name).schema()
-        return self._ch_schema_cache[table_name]
-
     def transform_after_read(self, table: "ibis.Table", feature_key: "FeatureKey") -> "ibis.Table":
-        """Transform ClickHouse-specific column types for PyArrow compatibility.
+        """Cast ClickHouse `JSON` columns to String for PyArrow compatibility.
 
-        Handles:
-
-        - `JSON` columns: Cast to String (ClickHouse driver returns dict, PyArrow expects bytes)
-
-        - `Map(String, String)` metaxy columns: When `enable_map_datatype` is off, convert to
-          named Struct by extracting keys. When on, leave as Map (collected to `polars_map.Map`
-          by `collect_to_polars`).
-
-        User-defined Map columns are always left as-is.
+        The ClickHouse driver returns `JSON` columns as dicts while PyArrow expects bytes.
+        `Map` columns are left as-is and collected to `polars_map.Map` by `collect_to_polars`.
         """
         import ibis.expr.datatypes as dt
 
-        from metaxy.config import MetaxyConfig
-
         schema = table.schema()
-        mutations: dict[str, Any] = {}
-
-        for col_name, dtype in schema.items():
-            if isinstance(dtype, dt.JSON):
-                mutations[col_name] = table[col_name].cast("string")
-
-            elif isinstance(dtype, dt.Map) and not MetaxyConfig.get().enable_map_datatype:
-                from metaxy.models.constants import (
-                    METAXY_DATA_VERSION_BY_FIELD,
-                    METAXY_PROVENANCE_BY_FIELD,
-                )
-
-                if col_name in {METAXY_PROVENANCE_BY_FIELD, METAXY_DATA_VERSION_BY_FIELD}:
-                    mutations[col_name] = self._map_to_struct_expr(table, col_name, dtype, feature_key)
+        mutations = {
+            col_name: table[col_name].cast("string") for col_name, dtype in schema.items() if isinstance(dtype, dt.JSON)
+        }
 
         if not mutations:
             return table
 
         return table.mutate(**mutations)
-
-    def _map_to_struct_expr(
-        self,
-        table: "ibis.Table",
-        col_name: str,
-        map_dtype: Any,  # dt.Map - avoid generic type param issues
-        feature_key: "FeatureKey",
-    ) -> Any:
-        """Convert a Map column to Struct expression.
-
-        ClickHouse `Map(String, String)` can be converted to a Struct by
-        extracting specific keys using `ibis.struct()`.
-
-        Args:
-            table: Ibis table
-            col_name: Map column name
-            map_dtype: Map data type (has key_type, value_type)
-            feature_key: Feature key to get field names from
-
-        Returns:
-            Ibis expression that produces a Struct
-        """
-        import ibis
-
-        from metaxy.models.feature import FeatureGraph
-
-        # Get field names from the feature spec
-        graph = FeatureGraph.get_active()
-        definition = graph.feature_definitions_by_key.get(feature_key)
-        if definition is None:
-            # Feature not in graph - fall back to String cast
-            return table[col_name].cast("string")
-
-        # Use to_struct_key() for struct field names (uses "_" separator, not "/")
-        # This matches how provenance/data_version fields are accessed elsewhere
-        field_names = [f.key.to_struct_key() for f in definition.spec.fields]
-
-        if not field_names:
-            return table[col_name].cast("string")
-
-        # Build Struct from map key access using safe access via .get()
-        # This returns empty string for missing keys instead of throwing KeyError
-        # This is essential for empty tables/maps where keys don't exist yet
-        map_col = table[col_name]
-        struct_dict = {name: map_col.get(name, "") for name in field_names}
-
-        return ibis.struct(struct_dict)
 
     @staticmethod
     def _is_table_not_found_error(e: Exception) -> bool:
@@ -375,244 +277,6 @@ class ClickHouseMetadataStore(IbisMetadataStore):
         except ImportError:
             return False
         return isinstance(e, DatabaseError) and "UNKNOWN_TABLE" in str(e)
-
-    def transform_before_write(self, df: Frame, feature_key: "FeatureKey", table_name: str) -> Frame:
-        """Transform Polars Struct columns to Map format for ClickHouse.
-
-        When `enable_map_datatype` is set, the base `IbisMetadataStore._write_feature`
-        handles Struct→Map conversion via Arrow. Otherwise, falls back to the legacy
-        ClickHouse-specific conversion.
-        """
-        from metaxy.config import MetaxyConfig
-
-        if MetaxyConfig.get().enable_map_datatype:
-            return df
-
-        if table_name not in self.conn.list_tables():
-            return df
-
-        ch_schema = self._get_cached_schema(table_name)
-        return self._transform_struct_to_map(df, ch_schema)
-
-    def _transform_struct_to_map(self, df: Frame, ch_schema: "IbisSchema") -> Frame:
-        """Transform Struct columns to Map-compatible format for ClickHouse.
-
-        When `auto_cast_struct_for_map=True` (default), transforms ALL DataFrame Struct
-        columns to Map format when the corresponding ClickHouse column is Map type.
-
-        When `auto_cast_struct_for_map=False`, only transforms metaxy system columns
-        (metaxy_provenance_by_field, metaxy_data_version_by_field).
-
-        For Polars: Converts Struct to List[Struct{key, value}] which Ibis/ClickHouse
-        recognizes as array<struct<key, value>> and can insert into Map(K,V) columns.
-
-        For Ibis: Converts Struct to Map using ibis.map() function.
-
-        Args:
-            df: Input DataFrame (may be Narwhals wrapping Polars or Ibis)
-            ch_schema: ClickHouse table schema
-
-        Returns:
-            DataFrame with Struct columns converted to Map-compatible format
-        """
-        import ibis.expr.datatypes as dt
-
-        from metaxy.models.constants import (
-            METAXY_DATA_VERSION_BY_FIELD,
-            METAXY_PROVENANCE_BY_FIELD,
-        )
-
-        # Known metaxy struct columns (always transformed when auto_cast is False)
-        metaxy_struct_columns = {
-            METAXY_PROVENANCE_BY_FIELD,
-            METAXY_DATA_VERSION_BY_FIELD,
-        }
-
-        # Find Map columns in ClickHouse schema
-        if self.auto_cast_struct_for_map:
-            # Transform ALL Struct columns that have corresponding Map columns in CH
-            map_columns = {name for name, dtype in ch_schema.items() if isinstance(dtype, dt.Map)}
-        else:
-            # Only transform metaxy system columns
-            map_columns = {
-                name for name, dtype in ch_schema.items() if isinstance(dtype, dt.Map) and name in metaxy_struct_columns
-            }
-
-        if not map_columns:
-            return df
-
-        # Handle Ibis-backed DataFrames (keep lazy)
-        if df.implementation == nw.Implementation.IBIS:
-            return self._transform_ibis_struct_to_map(df, map_columns, ch_schema)
-
-        # All other backends: collect to Polars and transform
-        return self._transform_polars_struct_to_map(df, map_columns, ch_schema)
-
-    def _transform_ibis_struct_to_map(self, df: Frame, map_columns: set[str], ch_schema: "IbisSchema") -> Frame:
-        """Transform Ibis Struct columns to Map format for ClickHouse.
-
-        Args:
-            df: Narwhals DataFrame backed by Ibis
-            map_columns: Set of column names that need to be converted to Map
-            ch_schema: ClickHouse table schema (to get Map value types)
-
-        Returns:
-            DataFrame with Struct columns converted to Map
-        """
-        from typing import cast as typing_cast
-
-        import ibis
-        import ibis.expr.datatypes as dt
-
-        ibis_table = typing_cast("ibis.Table", df.to_native())
-        schema = ibis_table.schema()
-
-        mutations: dict[str, ibis.Expr] = {}
-        for col_name in map_columns:
-            if col_name not in schema:
-                continue
-
-            col_dtype = schema[col_name]
-            if not isinstance(col_dtype, dt.Struct):
-                continue
-
-            assert isinstance(col_dtype, dt.Struct)
-
-            # Get field names from the struct type
-            field_names = list(col_dtype.names)  # ty: ignore[invalid-argument-type]
-
-            # Get target Map value type from ClickHouse schema
-            # We already verified this is a Map type in the caller
-            ch_map_dtype = ch_schema[col_name]
-            target_value_type = ch_map_dtype.value_type  # ty: ignore[unresolved-attribute]
-
-            # Handle empty structs (no fields) - convert to empty Map
-            if not field_names:
-                # Create empty map literal with correct types
-                mutations[col_name] = ibis.literal(
-                    {},
-                    type=dt.Map(dt.String(), target_value_type),  # ty: ignore[invalid-argument-type, missing-argument]
-                )
-                continue
-
-            # Build map from struct fields: Map(field_name -> field_value)
-            # ibis.map() takes two arrays: keys and values
-            # Cast values to match ClickHouse Map value type
-            keys = ibis.array([ibis.literal(name) for name in field_names])
-            values = ibis.array([ibis_table[col_name][name].cast(target_value_type) for name in field_names])
-            mutations[col_name] = ibis.map(keys, values)
-
-        if not mutations:
-            return df
-
-        result_table = ibis_table.mutate(**mutations)  # ty: ignore[invalid-argument-type]
-        return nw.from_native(result_table, eager_only=False)
-
-    def _transform_polars_struct_to_map(self, df: Frame, map_columns: set[str], ch_schema: "IbisSchema") -> Frame:
-        """Transform Polars Struct columns to Map-compatible format for ClickHouse.
-
-        Args:
-            df: Narwhals DataFrame backed by Polars
-            map_columns: Set of column names that need to be converted to Map
-            ch_schema: ClickHouse table schema (to get Map value types)
-
-        Returns:
-            DataFrame with Struct columns converted to List[Struct{key, value}]
-        """
-        import polars as pl
-
-        from metaxy.utils import collect_to_polars
-
-        # Get native Polars DataFrame
-        pl_df = collect_to_polars(df)
-
-        # Check which columns need transformation (are Struct in Polars)
-        # Tuple: (col_name, field_names, target_polars_type)
-        # field_names may be empty for empty structs
-        cols_to_transform: list[tuple[str, list[str], pl.DataType]] = []
-        for col_name in map_columns:
-            if col_name in pl_df.columns:
-                col_dtype = pl_df.schema[col_name]
-                if isinstance(col_dtype, pl.Struct):
-                    field_names = [f.name for f in col_dtype.fields]
-                    # Get target value type from ClickHouse schema
-                    # We already verified this is a Map type in the caller
-                    ch_map_dtype = ch_schema[col_name]
-                    target_pl_type = self.ibis_type_to_polars(
-                        ch_map_dtype.value_type  # ty: ignore[unresolved-attribute]
-                    )
-                    cols_to_transform.append((col_name, field_names, target_pl_type))
-
-        if not cols_to_transform:
-            return df
-
-        # Transform Struct columns to List[Struct{key, value}] format
-        # This is what Ibis/ClickHouse expects for Map(K,V) columns
-        transformations = []
-        for col_name, field_names, target_type in cols_to_transform:
-            # Handle empty structs (no fields) - convert to empty List
-            if not field_names:
-                # Create empty list with correct Map-compatible struct type
-                empty_list_type = pl.List(pl.Struct({"key": pl.Utf8, "value": target_type}))
-                transformations.append(pl.lit([], dtype=empty_list_type).alias(col_name))
-                continue
-
-            # Build list of {key: field_name, value: field_value} structs
-            # Cast values to match ClickHouse Map value type
-            # Filter out NULL values since ClickHouse Maps don't support NULL
-            key_value_structs = [
-                pl.when(pl.col(col_name).struct.field(field_name).is_not_null())
-                .then(
-                    pl.struct(
-                        [
-                            pl.lit(field_name).alias("key"),
-                            pl.col(col_name).struct.field(field_name).cast(target_type).alias("value"),
-                        ]
-                    )
-                )
-                .otherwise(None)
-                for field_name in field_names
-            ]
-            # Concat and drop nulls to exclude entries with NULL values
-            transformations.append(pl.concat_list(key_value_structs).list.drop_nulls().alias(col_name))
-
-        pl_df = pl_df.with_columns(transformations)
-
-        # The insert ships this column as Arrow (`FORMAT Arrow`); ClickHouse reads the Arrow schema
-        # server-side, then casts the resulting array into the target `Map(K, V)` column. PyArrow
-        # marks a list's element field as nullable. Since ClickHouse 26.4 ("Nullable(Tuple) reading
-        # for Arrow") the reader honors that flag and materializes the element struct as
-        # `Array(Nullable(Tuple(...)))`; earlier versions dropped the element nullability and read a
-        # plain `Array(Tuple(...))`. The array-to-Map cast only accepts the non-nullable form, so the
-        # inner struct is forced non-nullable here. This is also the accurate representation: `Map`
-        # keys and values are non-nullable and null entries are already dropped above.
-        arrow_table = pl_df.to_arrow()
-        for col_name, _, _ in cols_to_transform:
-            arrow_table = self._make_map_list_non_nullable(arrow_table, col_name)
-
-        return nw.from_native(arrow_table)
-
-    @staticmethod
-    def _make_map_list_non_nullable(arrow_table: "pa.Table", col_name: str) -> "pa.Table":
-        """Rewrite a `List[Struct{key, value}]` column so its inner struct and fields are non-nullable.
-
-        ClickHouse's Arrow reader maps a nullable list element to `Nullable(Tuple(...))`, and its
-        array-to-`Map` cast rejects `Array(Nullable(Tuple(...)))`, requiring `Array(Tuple(...))`.
-        """
-        import pyarrow as pa
-
-        field = arrow_table.schema.field(col_name)
-        list_type = field.type
-        struct_type = list_type.value_type
-        non_nullable_struct = pa.struct([pa.field(f.name, f.type, nullable=False) for f in struct_type])
-        item_field = pa.field(list_type.value_field.name, non_nullable_struct, nullable=False)
-        new_list_type = pa.large_list(item_field) if pa.types.is_large_list(list_type) else pa.list_(item_field)
-
-        return arrow_table.set_column(
-            arrow_table.schema.get_field_index(col_name),
-            pa.field(col_name, new_list_type),
-            arrow_table.column(col_name).cast(new_list_type),
-        )
 
     def ibis_type_to_polars(self, ibis_type: Any) -> Any:
         """Convert Ibis data type to Polars data type, with ClickHouse Map support.

--- a/src/metaxy/ext/ibis/metadata_store.py
+++ b/src/metaxy/ext/ibis/metadata_store.py
@@ -350,10 +350,7 @@ class IbisMetadataStore(MetadataStore, ABC):
         # Apply backend-specific transformations before writing
         df = self.transform_before_write(df, feature_key, table_name)
 
-        from metaxy.config import MetaxyConfig
-
-        if MetaxyConfig.get().enable_map_datatype:
-            df = self._handle_map_columns(df, table_name)
+        df = self._handle_map_columns(df, table_name)
 
         if df.implementation == nw.Implementation.IBIS:
             df_to_insert = df.to_native()  # Ibis expression

--- a/src/metaxy/ext/lancedb/metadata_store.py
+++ b/src/metaxy/ext/lancedb/metadata_store.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 import narwhals as nw
+import polars as pl
 from narwhals.typing import Frame
 from pydantic import Field
 
@@ -238,6 +239,40 @@ class LanceDBMetadataStore(MetadataStore):
         """Use XXHASH32 by default."""
         return HashAlgorithm.XXHASH32
 
+    # Map compatibility --------------------------------------------------------
+    # LanceDB has no native Map type (https://github.com/lance-format/lance/issues/2341),
+    # so metaxy `Map` columns are stored as named Structs and reconstructed on read.
+
+    def _maps_to_structs(self, df: pl.DataFrame, feature_key: FeatureKey) -> pl.DataFrame:
+        """Decompose `Map` columns into named `Struct` columns Lance can store."""
+        from metaxy.utils._arrow_map import convert_maps_to_structs
+        from metaxy.utils.dataframes import find_map_columns
+
+        map_columns = find_map_columns(nw.from_native(df))
+        # Empty frames carry no keys, so fall back to the feature's field names to keep the schema stable.
+        fallback = {col: self._map_field_names(feature_key, col) for col in map_columns}
+        return convert_maps_to_structs(df, map_columns, fallback_field_names=fallback)
+
+    @staticmethod
+    def _structs_to_maps(lf: pl.LazyFrame) -> pl.LazyFrame:
+        """Reconstruct metaxy system `Map` columns from the named `Struct` columns stored in Lance."""
+        from metaxy.models.constants import METAXY_DATA_VERSION_BY_FIELD, METAXY_PROVENANCE_BY_FIELD
+        from metaxy.utils._arrow_map import convert_structs_to_maps
+
+        return convert_structs_to_maps(lf, columns=[METAXY_PROVENANCE_BY_FIELD, METAXY_DATA_VERSION_BY_FIELD])
+
+    def _map_field_names(self, feature_key: FeatureKey, column: str) -> list[str]:
+        """Struct field names for a metaxy system `Map` column, taken from the active graph."""
+        from metaxy.models.constants import METAXY_DATA_VERSION_BY_FIELD, METAXY_PROVENANCE_BY_FIELD
+        from metaxy.models.feature import FeatureGraph
+
+        if column not in {METAXY_PROVENANCE_BY_FIELD, METAXY_DATA_VERSION_BY_FIELD}:
+            return []
+        definition = FeatureGraph.get_active().feature_definitions_by_key.get(feature_key)
+        if definition is None:
+            return []
+        return [f.key.to_struct_key() for f in definition.spec.fields]
+
     # Storage ------------------------------------------------------------------
 
     def _write_feature(
@@ -256,7 +291,7 @@ class LanceDBMetadataStore(MetadataStore):
             df: Narwhals Frame with metadata (already validated by base class)
         """
         # Convert Narwhals frame to Polars DataFrame
-        df_polars = collect_to_polars(df)
+        df_polars = self._maps_to_structs(collect_to_polars(df), feature_key)
 
         table_name = self._table_name(feature_key)
 
@@ -353,8 +388,7 @@ class LanceDBMetadataStore(MetadataStore):
         table = self._get_table(table_name)
         # LanceDB's to_polars() returns a Polars LazyFrame directly
         # (fixed in Polars via https://github.com/pola-rs/polars/pull/25654)
-        pl_lazy = table.to_polars()
-        nw_lazy = nw.from_native(pl_lazy)
+        nw_lazy = nw.from_native(self._structs_to_maps(table.to_polars()))
 
         if filters:
             nw_lazy = nw_lazy.filter(*filters)

--- a/src/metaxy/ext/polars/handlers/delta.py
+++ b/src/metaxy/ext/polars/handlers/delta.py
@@ -11,11 +11,9 @@ from typing import TYPE_CHECKING, Any, Literal, overload
 import narwhals as nw
 import polars as pl
 from narwhals.typing import Frame
-from packaging.version import Version
 from pydantic import Field
 
 from metaxy._decorators import public
-from metaxy.config import MetaxyConfig
 from metaxy.ext.polars.versioning import PolarsVersioningEngine
 from metaxy.metadata_store.base import MetadataStore, MetadataStoreConfig
 from metaxy.metadata_store.types import AccessMode
@@ -78,10 +76,6 @@ class DeltaMetadataStore(MetadataStore):
 
     It stores feature metadata in Delta Lake tables located under ``root_path``.
     It uses the Polars versioning engine for provenance calculations.
-
-    !!! tip
-        If Polars 1.37 or greater is installed, lazy Polars frames are sinked via
-        `LazyFrame.sink_delta`, avoiding unnecessary materialization.
 
     Example:
 
@@ -267,11 +261,7 @@ class DeltaMetadataStore(MetadataStore):
         Args:
             feature_key: Feature key to write to
             df: DataFrame with metadata
-            **kwargs: Backend-specific parameters that are passed to `write_delta` or `sink_delta`.
-
-        !!! tip
-            If Polars 1.37 or greater is installed, lazy Polars frames are sinked via
-            `LazyFrame.sink_delta`, avoiding unnecessary materialization.
+            **kwargs: Backend-specific parameters that are passed to `write_deltalake`.
         """
         table_uri = self._feature_uri(feature_key)
 
@@ -280,36 +270,7 @@ class DeltaMetadataStore(MetadataStore):
         mode = write_opts.pop("mode", "append")
         storage_options = write_opts.pop("storage_options", None)
 
-        if MetaxyConfig.get().enable_map_datatype:
-            self._write_with_map_columns(df, table_uri, mode, storage_options, write_opts)
-            return
-
-        # Check if we can use sink_delta (Polars >= 1.37, native Polars LazyFrame)
-        can_sink = (
-            df.implementation == nw.Implementation.POLARS
-            and isinstance(df, nw.LazyFrame)
-            and Version(pl.__version__) >= Version("1.37.0")
-        )
-
-        if can_sink:
-            lf_native = df.to_native()
-            assert isinstance(lf_native, pl.LazyFrame)
-
-            self._cast_enum_to_string(lf_native).sink_delta(
-                table_uri,
-                mode=mode,
-                storage_options=storage_options,
-                delta_write_options=write_opts or None,
-            )
-        else:
-            df_native = collect_to_polars(df)
-
-            self._cast_enum_to_string(df_native).write_delta(
-                table_uri,
-                mode=mode,
-                storage_options=storage_options,
-                delta_write_options=write_opts or None,
-            )
+        self._write_with_map_columns(df, table_uri, mode, storage_options, write_opts)
 
     def _write_with_map_columns(
         self,
@@ -432,8 +393,7 @@ class DeltaMetadataStore(MetadataStore):
             storage_options=self.storage_options or None,
         )
 
-        if MetaxyConfig.get().enable_map_datatype:
-            lf = self._read_map_columns(lf, feature_key)
+        lf = self._read_map_columns(lf, feature_key)
 
         # Convert to Narwhals
         nw_lazy = nw.from_native(lf)

--- a/src/metaxy/ext/polars/handlers/iceberg.py
+++ b/src/metaxy/ext/polars/handlers/iceberg.py
@@ -15,11 +15,9 @@ if TYPE_CHECKING:
 import narwhals as nw
 import polars as pl
 from narwhals.typing import Frame
-from packaging.version import Version
 from pydantic import Field
 
 from metaxy._decorators import public
-from metaxy.config import MetaxyConfig
 from metaxy.ext.polars.versioning import PolarsVersioningEngine
 from metaxy.metadata_store.base import MetadataStore, MetadataStoreConfig
 from metaxy.metadata_store.types import AccessMode
@@ -100,10 +98,6 @@ class IcebergMetadataStore(MetadataStore):
 
     Stores feature metadata in Iceberg tables managed by a PyIceberg catalog.
     It uses the Polars versioning engine for provenance calculations.
-
-    !!! tip
-        If Polars 1.39 or greater is installed, lazy Polars frames are sinked via
-        `LazyFrame.sink_iceberg`, avoiding unnecessary materialization.
 
     Example:
 
@@ -251,38 +245,10 @@ class IcebergMetadataStore(MetadataStore):
         Args:
             feature_key: Feature key to write to
             df: DataFrame with metadata
-            **kwargs: Forwarded to `sink_iceberg` or `Table.append`.
-
-        !!! tip
-            If Polars 1.39 or greater is installed, lazy Polars frames are sinked via
-            `LazyFrame.sink_iceberg`, avoiding unnecessary materialization.
+            **kwargs: Forwarded to `Table.append`.
         """
         self._ensure_namespace()
-        identifier = self._table_identifier(feature_key)
-
-        can_sink = (
-            df.implementation == nw.Implementation.POLARS
-            and isinstance(df, nw.LazyFrame)
-            and Version(pl.__version__) >= Version("1.39.0")
-        )
-
-        if MetaxyConfig.get().enable_map_datatype:
-            self._write_with_map_columns(df, identifier, **kwargs)
-        elif can_sink:
-            lf_native = df.to_native()
-            assert isinstance(lf_native, pl.LazyFrame)
-            arrow_schema = pl.DataFrame(schema=self._cast_enum_to_string(lf_native).collect_schema()).to_arrow().schema
-            iceberg_table = self._ensure_table(identifier, arrow_schema)
-            # sink_iceberg requires columns in the same order as the Iceberg table schema
-            schema_col_order = [f.name for f in iceberg_table.schema().as_arrow()]
-            self._cast_enum_to_string(lf_native).select(schema_col_order).sink_iceberg(
-                iceberg_table, mode="append", **kwargs
-            )
-        else:
-            df_polars = self._cast_enum_to_string(collect_to_polars(df))
-            arrow_table = df_polars.to_arrow()
-            iceberg_table = self._ensure_table(identifier, arrow_table.schema)
-            iceberg_table.append(arrow_table, **kwargs)
+        self._write_with_map_columns(df, self._table_identifier(feature_key), **kwargs)
 
     def _read_feature(
         self,
@@ -310,8 +276,7 @@ class IcebergMetadataStore(MetadataStore):
         iceberg_table = self.catalog.load_table(identifier)
         lf = pl.scan_iceberg(iceberg_table)
 
-        if MetaxyConfig.get().enable_map_datatype:
-            lf = self._read_map_columns(lf, iceberg_table)
+        lf = self._read_map_columns(lf, iceberg_table)
 
         nw_lazy = nw.from_native(lf)
 

--- a/src/metaxy/ext/postgresql/metadata_store.py
+++ b/src/metaxy/ext/postgresql/metadata_store.py
@@ -1,7 +1,8 @@
 """PostgreSQL metadata store with storage/compute separation.
 
 Uses PostgreSQL for storage and Polars for versioning compute.
-Metaxy system struct columns are round-tripped via JSON serialization.
+PostgreSQL has no native `Map` type, so Metaxy's `Map` versioning columns are decomposed into
+named `Struct` columns, JSON-serialized for storage, and reconstructed as `Map` on read.
 User struct columns are JSON-encoded on write and decode behavior on read depends on
 the effective SQL column type (JSON/JSONB).
 Always uses PolarsVersioningEngine since PostgreSQL lacks native struct support.
@@ -188,6 +189,38 @@ class PostgreSQLMetadataStore(IbisMetadataStore):
         transforms = [pl.col(col_name).struct.json_encode().alias(col_name) for col_name in struct_columns]
         return pl_df.with_columns(transforms)
 
+    # Map compatibility --------------------------------------------------------
+    # PostgreSQL has no native Map type, so Metaxy's Map columns are decomposed into
+    # named Structs (then JSON-encoded) on write and reconstructed as Map on read.
+
+    def _map_fallback_field_names(self, feature_key: FeatureKey) -> dict[str, list[str]]:
+        """Fallback Struct field names for the metaxy Map columns, from the active graph.
+
+        Used for empty result sets that carry no keys to infer field names from.
+        """
+        try:
+            plan = self._resolve_feature_plan(feature_key)
+        except (KeyError, RuntimeError):
+            return {}
+        field_names = [field_spec.key.to_struct_key() for field_spec in plan.feature.fields]
+        return {col_name: field_names for col_name in _METAXY_STRUCT_COLUMNS}
+
+    def _maps_to_structs(self, pl_df: pl.DataFrame, feature_key: FeatureKey) -> pl.DataFrame:
+        """Convert metaxy Map columns to named Struct columns for JSON encoding."""
+        from metaxy.utils._arrow_map import convert_maps_to_structs
+
+        return convert_maps_to_structs(
+            pl_df,
+            list(_METAXY_STRUCT_COLUMNS),
+            fallback_field_names=self._map_fallback_field_names(feature_key),
+        )
+
+    def _structs_to_maps(self, pl_df: pl.DataFrame) -> pl.DataFrame:
+        """Reconstruct metaxy Map columns from the Struct columns decoded from JSON."""
+        from metaxy.utils._arrow_map import convert_structs_to_maps
+
+        return convert_structs_to_maps(pl_df, list(_METAXY_STRUCT_COLUMNS))
+
     def _build_auto_create_schema(
         self,
         original_pl_df: pl.DataFrame,
@@ -274,7 +307,7 @@ class PostgreSQLMetadataStore(IbisMetadataStore):
         Uses Polars' struct.json_encode() to serialize structs to JSON strings.
         Stored SQL type depends on target table schema (JSON/JSONB vs TEXT).
         """
-        pl_df = collect_to_polars(df)
+        pl_df = self._maps_to_structs(collect_to_polars(df), feature_key)
         return nw.from_native(self._encode_struct_columns(pl_df))
 
     def _write_feature(
@@ -285,7 +318,7 @@ class PostgreSQLMetadataStore(IbisMetadataStore):
     ) -> None:
         """Write feature metadata, preserving JSONB for auto-created Struct columns."""
         table_name = self.get_table_name(feature_key)
-        original_pl_df = collect_to_polars(df)
+        original_pl_df = self._maps_to_structs(collect_to_polars(df), feature_key)
         transformed_pl_df = self._encode_struct_columns(original_pl_df)
 
         if table_name not in self.conn.list_tables():
@@ -532,5 +565,8 @@ class PostgreSQLMetadataStore(IbisMetadataStore):
             json_columns_to_parse,
             require_all_system_columns=columns is None and not self._is_system_table(feature_key),
         )
+
+        # Present the metaxy versioning columns as Map to callers, matching every other store.
+        pl_df = self._structs_to_maps(pl_df)
 
         return nw.from_native(pl_df.lazy())

--- a/src/metaxy/metadata_store/base.py
+++ b/src/metaxy/metadata_store/base.py
@@ -63,12 +63,8 @@ if TYPE_CHECKING:
 def _is_map_column(df: Frame, col_name: str) -> bool:
     """Check if a column in a narwhals frame is a Map type.
 
-    Returns False immediately if enable_map_datatype is not set.
     Delegates to find_map_columns for backend-specific detection.
     """
-    if not MetaxyConfig.get().enable_map_datatype:
-        return False
-
     from metaxy.utils.dataframes import find_map_columns
 
     return col_name in find_map_columns(df)
@@ -555,10 +551,10 @@ class MetadataStore(ABC):
             for upstream_key, df in upstream_by_key.items():
                 upstream_by_key[upstream_key] = switch_implementation_to_polars(df)
 
-        # Convert _by_field Struct columns to Map when enable_map_datatype is set.
+        # Convert _by_field Struct columns to Map.
         # User-provided samples may have these as Struct (the natural Polars literal form);
         # the store normalizes them to Map so downstream processing and output are consistent.
-        if MetaxyConfig.get().enable_map_datatype and samples_nw is not None:
+        if samples_nw is not None:
             import polars as pl
 
             native = samples_nw.to_native()

--- a/src/metaxy/utils/_arrow_map.py
+++ b/src/metaxy/utils/_arrow_map.py
@@ -11,9 +11,14 @@ from typing import TYPE_CHECKING, TypeVar, cast
 import polars as pl
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Mapping, Sequence
 
 PolarsFrameT = TypeVar("PolarsFrameT", pl.DataFrame, pl.LazyFrame)
+
+
+def _is_polars_map_dtype(dtype: pl.DataType) -> bool:
+    """Check whether a Polars dtype is the ``polars_map.Map`` extension type."""
+    return isinstance(dtype, pl.datatypes.classes.BaseExtension) and getattr(dtype, "_name", None) == "polars_map.map"
 
 
 def convert_structs_to_maps(df: PolarsFrameT, columns: Sequence[str]) -> PolarsFrameT:
@@ -49,6 +54,58 @@ def convert_structs_to_maps(df: PolarsFrameT, columns: Sequence[str]) -> PolarsF
     if not map_exprs:
         return df
     return cast(PolarsFrameT, df.with_columns(map_exprs))  # ty: ignore[invalid-argument-type]
+
+
+def convert_maps_to_structs(
+    df: PolarsFrameT,
+    columns: Sequence[str],
+    *,
+    fallback_field_names: Mapping[str, Sequence[str]] | None = None,
+) -> PolarsFrameT:
+    """Convert `polars_map.Map` columns to named `Struct` columns.
+
+    This is the inverse of [`convert_structs_to_maps`][] and lets stores that lack a native
+    `Map` type persist Metaxy's `Map` columns as `Struct` (or a `Struct`-derived encoding).
+
+    Field names are taken from the keys present in each column. When a column has no keys
+    (e.g. an empty frame), `fallback_field_names` supplies the names so the output schema
+    stays stable. Columns that are not `Map`-typed are skipped. Native
+    `List(Struct({key, value}))` columns are normalized to `Map` first.
+
+    Args:
+        df: Polars DataFrame or LazyFrame.
+        columns: Column names to convert.
+        fallback_field_names: Per-column field names used when a column carries no keys.
+    """
+    import polars_map  # noqa: F401  # registers the `.map` accessor
+
+    df = convert_maps_to_polars_map(df, columns)
+    schema = df.collect_schema() if isinstance(df, pl.LazyFrame) else df.schema
+
+    struct_exprs: list[pl.Expr] = []
+    for col_name in columns:
+        if col_name not in schema or not _is_polars_map_dtype(schema[col_name]):
+            continue
+
+        keys_expr = pl.col(col_name).map.keys().explode().drop_nulls().unique().sort()  # ty: ignore[unresolved-attribute]
+        keys_frame = df.select(keys_expr)  # ty: ignore[invalid-argument-type]
+        if isinstance(keys_frame, pl.LazyFrame):
+            keys_frame = keys_frame.collect()
+        field_names = keys_frame.to_series().to_list()
+        if not field_names and fallback_field_names:
+            field_names = list(fallback_field_names.get(col_name, []))
+        if not field_names:
+            continue
+
+        struct_exprs.append(
+            pl.struct(
+                [pl.col(col_name).map.get(name).alias(name) for name in field_names]  # ty: ignore[unresolved-attribute]
+            ).alias(col_name)
+        )
+
+    if not struct_exprs:
+        return df
+    return cast(PolarsFrameT, df.with_columns(struct_exprs))  # ty: ignore[invalid-argument-type]
 
 
 def convert_maps_to_polars_map(

--- a/src/metaxy/utils/dataframes.py
+++ b/src/metaxy/utils/dataframes.py
@@ -24,14 +24,8 @@ def _is_polars_map_dtype(dtype: pl.DataType) -> bool:
 def find_map_columns(df: Frame) -> list[str]:
     """Return column names that have a Map type in the underlying frame.
 
-    Returns empty list when enable_map_datatype is not set.
     Uses narwhals-map's Map dtype for detection across all backends.
     """
-    from metaxy.config import MetaxyConfig
-
-    if not MetaxyConfig.get().enable_map_datatype:
-        return []
-
     from narwhals_map import Map
 
     schema = df.collect_schema() if isinstance(df, nw.LazyFrame) else df.schema
@@ -47,7 +41,7 @@ def has_polars_map_columns(df: pl.DataFrame | pl.LazyFrame) -> bool:
 def collect_to_polars(frame: PolarsCompatibleFrame) -> pl.DataFrame:
     """Helper to convert a frame into an eager Polars DataFrame.
 
-    Preserves `Map` columns as `polars_map.Map` when `MetaxyConfig.enable_map_datatype` is set.
+    Preserves `Map` columns as `polars_map.Map`.
 
     Args:
         frame: The Narwhals frame to convert.
@@ -90,7 +84,7 @@ def collect_to_arrow(frame: PolarsCompatibleFrame) -> pa.Table:
 def lazy_frame_to_polars(frame: nw.LazyFrame[Any]) -> pl.LazyFrame:
     """Helper to convert a Narwhals lazy frame into a Polars lazy frame.
 
-    Preserves `polars_map.Map` columns when `MetaxyConfig.enable_map_datatype` is set.
+    Preserves `polars_map.Map` columns.
     If the Narwhals LazyFrame is already backed by Polars, this is a no-op.
     """
     if frame.implementation == nw.Implementation.POLARS:
@@ -111,11 +105,7 @@ def switch_implementation_to_polars(frame: FrameT) -> FrameT:
         return frame
 
     # Detect map columns before conversion (they lose their type in Polars)
-    from metaxy.config import MetaxyConfig
-
-    map_columns: list[str] = []
-    if MetaxyConfig.get().enable_map_datatype:
-        map_columns = find_map_columns(frame)
+    map_columns = find_map_columns(frame)
 
     if isinstance(frame, nw.DataFrame):
         result = nw.from_native(frame.to_polars())

--- a/src/metaxy/versioning/engine.py
+++ b/src/metaxy/versioning/engine.py
@@ -218,35 +218,6 @@ class VersioningEngine(ABC):
         """
         raise NotImplementedError()
 
-    def build_struct_column(
-        self,
-        df: FrameT,
-        struct_name: str,
-        field_columns: dict[str, str],
-    ) -> FrameT:
-        """Build a metadata column from existing columns.
-
-        Args:
-            df: Input DataFrame.
-            struct_name: Name for the new metadata column.
-            field_columns: Mapping of struct field names to source column names.
-
-        Returns:
-            DataFrame with a new Struct column, or a Map column when
-            ``enable_map_datatype`` is set.
-        """
-        if MetaxyConfig.get().enable_map_datatype:
-            return self.build_map_column(df, struct_name, field_columns)
-
-        return cast(
-            FrameT,
-            df.with_columns(  # ty: ignore[invalid-argument-type]
-                nw.struct([nw.col(src_col).alias(field_name) for field_name, src_col in field_columns.items()]).alias(
-                    struct_name
-                )
-            ),
-        )
-
     @staticmethod
     @abstractmethod
     def build_map_column(
@@ -408,9 +379,9 @@ class VersioningEngine(ABC):
             *aggregated_cols.values(),
         )
 
-        # Build new struct columns from hashed fields
-        df = self.build_struct_column(df, renamed_data_version_by_field_col, hashed_field_cols)
-        df = self.build_struct_column(
+        # Build new Map columns from hashed fields
+        df = self.build_map_column(df, renamed_data_version_by_field_col, hashed_field_cols)
+        df = self.build_map_column(
             df,
             renamed_prov_by_field_col,
             hashed_field_cols,
@@ -514,8 +485,8 @@ class VersioningEngine(ABC):
                 truncate_length=hash_length,
             )
 
-        # Build provenance_by_field struct
-        df = self.build_struct_column(df, METAXY_PROVENANCE_BY_FIELD, temp_hash_cols)  # ty: ignore[invalid-argument-type]
+        # Build provenance_by_field Map column
+        df = self.build_map_column(df, METAXY_PROVENANCE_BY_FIELD, temp_hash_cols)  # ty: ignore[invalid-argument-type]
 
         # Compute sample-level provenance hash
         df = self.hash_struct_version_column(df, hash_algorithm=hash_algo)

--- a/src/metaxy/versioning/types.py
+++ b/src/metaxy/versioning/types.py
@@ -86,7 +86,7 @@ class Increment(NamedTuple):
     def to_polars(self) -> PolarsIncrement:
         """Convert to Polars.
 
-        Preserves `polars_map.Map` columns when `MetaxyConfig.enable_map_datatype` is set.
+        Preserves `polars_map.Map` columns.
         """
         return PolarsIncrement(
             new=collect_to_polars(self.new),

--- a/tests/cli/test_cli_metadata.py
+++ b/tests/cli/test_cli_metadata.py
@@ -5,8 +5,9 @@ from pathlib import Path
 
 import polars as pl
 import pytest
+from metaxy.utils import collect_to_polars
 
-from metaxy_testing import TempMetaxyProject
+from metaxy_testing import TempMetaxyProject, by_field_maps_to_structs
 
 
 @pytest.mark.parametrize("output_format", ["plain", "json"])
@@ -56,7 +57,7 @@ def test_metadata_status_up_to_date(
             increment = store.resolve_update(feature_key, lazy=False)
 
             # Write the computed metadata to the store
-            store.write(feature_key, increment.new.to_polars())
+            store.write(feature_key, collect_to_polars(increment.new))
 
         # Check status for the non-root feature
         result = metaxy_project.run_cli(
@@ -411,7 +412,7 @@ def test_metadata_status_with_explicit_store(
             increment = store.resolve_update(feature_key, lazy=False)
 
             # Write the computed metadata to the store
-            store.write(feature_key, increment.new.to_polars())
+            store.write(feature_key, collect_to_polars(increment.new))
 
         # Check status with explicit store
         result = metaxy_project.run_cli(
@@ -737,7 +738,7 @@ def test_metadata_status_with_global_filter(
             # Resolve the full increment first
             increment = store.resolve_update(feature_key, lazy=False)
             # Filter to only category A samples and write
-            added_df = increment.new.to_polars().filter(pl.col("category") == "A")
+            added_df = collect_to_polars(increment.new).filter(pl.col("category") == "A")
             store.write(feature_key, added_df)
 
         # Check status with global-filter for category A - should be up-to-date
@@ -893,7 +894,7 @@ def test_metadata_status_with_multiple_global_filters(
             feature_key = FeatureKey(["video", "files"])
             # feature_cls removed - using feature_key directly
             increment = store.resolve_update(feature_key, lazy=False)
-            store.write(feature_key, increment.new.to_polars())
+            store.write(feature_key, collect_to_polars(increment.new))
 
         # Check status with multiple global-filters: category A AND status active
         # Should match sample_uids 1 and 5
@@ -1160,7 +1161,7 @@ def test_metadata_status_with_progress_flag(
             feature_key = FeatureKey(["video", "files"])
             # feature_cls removed - using feature_key directly
             increment = store.resolve_update(feature_key, lazy=False)
-            partial_data = increment.new.to_polars().head(2)
+            partial_data = collect_to_polars(increment.new).head(2)
             store.write(feature_key, partial_data)
 
         # Check status with --progress flag
@@ -1240,7 +1241,7 @@ def test_metadata_status_verbose_includes_progress(
             feature_key = FeatureKey(["video", "files"])
             # feature_cls removed - using feature_key directly
             increment = store.resolve_update(feature_key, lazy=False)
-            partial_data = increment.new.to_polars().head(1)
+            partial_data = collect_to_polars(increment.new).head(1)
             store.write(feature_key, partial_data)
 
         # Check status with --verbose (should also include progress)
@@ -1361,7 +1362,7 @@ def test_metadata_status_progress_100_percent(
             feature_key = FeatureKey(["video", "files"])
             # feature_cls removed - using feature_key directly
             increment = store.resolve_update(feature_key, lazy=False)
-            store.write(feature_key, increment.new.to_polars())
+            store.write(feature_key, collect_to_polars(increment.new))
 
         # Check status with --progress flag
         result = metaxy_project.run_cli(
@@ -2929,7 +2930,7 @@ def test_metadata_status_stale_if_basic(
         with graph.use(), store.open("w"):
             feature_key = FeatureKey(["video", "files"])
             increment = store.resolve_update(feature_key, lazy=False)
-            downstream_df = increment.new.to_polars()
+            downstream_df = collect_to_polars(increment.new)
 
             extra_df = pl.DataFrame(
                 {
@@ -3026,7 +3027,7 @@ def test_metadata_status_stale_if_multiple_predicates(
         with graph.use(), store.open("w"):
             feature_key = FeatureKey(["video", "files"])
             increment = store.resolve_update(feature_key, lazy=False)
-            downstream_df = increment.new.to_polars()
+            downstream_df = collect_to_polars(increment.new)
 
             extra_df = pl.DataFrame(
                 {
@@ -3124,7 +3125,7 @@ def test_metadata_rebase_command(metaxy_project: TempMetaxyProject, capsys: pyte
         with graph.use(), store.open("w"):
             downstream_key = FeatureKey(["video", "downstream"])
             increment = store.resolve_update(downstream_key)
-            store.write(downstream_key, increment.new.to_polars())
+            store.write(downstream_key, collect_to_polars(increment.new))
             old_feature_version = graph.get_feature_version(downstream_key)
 
             # Push v1 graph snapshot so rebase can look up graphs
@@ -3196,21 +3197,22 @@ def test_metadata_rebase_command(metaxy_project: TempMetaxyProject, capsys: pyte
 
         # Read back and verify versioning columns
         with graph.use(), store.open("r"):
-            rebased = (
+            rebased = collect_to_polars(
                 store.read(
                     downstream_key,
                     with_feature_history=True,
                     filters=[nw.col("metaxy_feature_version") == new_feature_version],
                 )
-                .collect()
-                .to_polars()
             )
             assert rebased.height == 3
             assert rebased["metaxy_feature_version"].unique().to_list() == [new_feature_version]
 
-            # provenance_by_field should have entries for all downstream fields
+            # provenance_by_field should have entries for all downstream fields.
+            # The metaxy *_by_field columns are stored as Map, so convert them back to
+            # Struct to inspect field-keyed hashes as plain dicts.
             expected_version_by_field = graph.get_feature_version_by_field(downstream_key)
-            for row_pbf in rebased["metaxy_provenance_by_field"].to_list():
+            rebased_structs = by_field_maps_to_structs(rebased)
+            for row_pbf in rebased_structs["metaxy_provenance_by_field"].to_list():
                 for field_key in expected_version_by_field:
                     assert field_key in row_pbf
 
@@ -3220,14 +3222,12 @@ def test_metadata_rebase_command(metaxy_project: TempMetaxyProject, capsys: pyte
             assert rebased["metaxy_data_version"].to_list() == provenance_values
 
             # No rows should remain with the old feature version
-            old_rows = (
+            old_rows = collect_to_polars(
                 store.read(
                     downstream_key,
                     with_feature_history=True,
                     filters=[nw.col("metaxy_feature_version") == old_feature_version],
                 )
-                .collect()
-                .to_polars()
             )
             assert old_rows.height == 0
 
@@ -3278,7 +3278,7 @@ def test_metadata_rebase_defaults_to_current_version(
         with graph.use(), store.open("w"):
             downstream_key = FeatureKey(["video", "downstream"])
             increment = store.resolve_update(downstream_key)
-            store.write(downstream_key, increment.new.to_polars())
+            store.write(downstream_key, collect_to_polars(increment.new))
             old_feature_version = graph.get_feature_version(downstream_key)
 
     # Create v2 with new code_version
@@ -3338,21 +3338,22 @@ def test_metadata_rebase_defaults_to_current_version(
 
         # Verify rebased rows have the new feature version and correct provenance
         with graph.use(), store.open("r"):
-            rebased = (
+            rebased = collect_to_polars(
                 store.read(
                     downstream_key,
                     with_feature_history=True,
                     filters=[nw.col("metaxy_feature_version") == new_feature_version],
                 )
-                .collect()
-                .to_polars()
             )
             assert rebased.height == 3
             assert rebased["metaxy_feature_version"].unique().to_list() == [new_feature_version]
 
-            # provenance_by_field should have entries for all downstream fields
+            # provenance_by_field should have entries for all downstream fields.
+            # The metaxy *_by_field columns are stored as Map, so convert them back to
+            # Struct to inspect field-keyed hashes as plain dicts.
             expected_version_by_field = graph.get_feature_version_by_field(downstream_key)
-            for row_pbf in rebased["metaxy_provenance_by_field"].to_list():
+            rebased_structs = by_field_maps_to_structs(rebased)
+            for row_pbf in rebased_structs["metaxy_provenance_by_field"].to_list():
                 for field_key in expected_version_by_field:
                     assert field_key in row_pbf
 

--- a/tests/ext/clickhouse/test_native.py
+++ b/tests/ext/clickhouse/test_native.py
@@ -3,12 +3,14 @@
 import ibis.backends.clickhouse  # noqa: F401
 import ibis.expr.datatypes as dt
 import polars as pl
+import polars_map  # noqa: F401  # registers the `.map` accessor on Polars Series
 import pytest
 from metaxy import FeatureDefinition, HashAlgorithm
 from metaxy.ext.clickhouse import ClickHouseMetadataStore
 from metaxy.metadata_store import MetadataStore
 from metaxy.models.feature import FeatureGraph
 from metaxy.utils import collect_to_polars
+from polars_map import Map
 
 from tests.metadata_stores.shared import (
     CRUDTests,
@@ -408,14 +410,11 @@ def test_clickhouse_map_column_type(
     test_graph: FeatureGraph,
     test_features: dict[str, FeatureDefinition],
 ) -> None:
-    """Test that ClickHouse Map(K,V) columns are converted to Struct on read.
+    """Test that ClickHouse Map(String, String) columns are read back as native Map.
 
     When tables have Map(String, String) columns (common in ClickHouse for
-    key-value data), the store should convert them to Struct for compatibility
-    with Narwhals/Polars downstream processing.
-
-    This also tests the write path: Polars Struct columns should be converted
-    to Map-compatible format when inserting into tables with Map columns.
+    key-value data), the store reads them back as native Map columns, which
+    materialize as ``polars_map.Map`` in Polars.
     """
     feature_cls = test_features["UpstreamFeatureA"]
     feature_key = feature_cls.spec.key
@@ -468,22 +467,20 @@ def test_clickhouse_map_column_type(
         """
         )
 
-        # Read via _read_feature
-        # This uses transform_after_read which should convert Map to Struct
+        # Read via _read_feature. Map columns come back as native Map.
         read_result = store._read_feature(feature_cls)
         assert read_result is not None
-        result = collect_to_polars(read_result)
+        result = collect_to_polars(read_result).sort("sample_uid")
 
         assert len(result) == 2
         assert set(result["sample_uid"].to_list()) == {1, 2}
 
-        # Map columns should be converted to Struct (dict in Python)
-        provenance = result["metaxy_provenance_by_field"][0]
-        assert isinstance(provenance, dict), f"Expected dict, got {type(provenance)}"
-        assert "frames" in provenance
-        assert "audio" in provenance
-        assert provenance["frames"] == "hash1"
-        assert provenance["audio"] == "hash2"
+        # Map columns materialize as polars_map.Map
+        assert result.schema["metaxy_provenance_by_field"] == Map(pl.String(), pl.String())
+        frames = result["metaxy_provenance_by_field"].map.get("frames").to_list()  # ty: ignore[unresolved-attribute]
+        audio = result["metaxy_provenance_by_field"].map.get("audio").to_list()  # ty: ignore[unresolved-attribute]
+        assert frames == ["hash1", "hash3"]
+        assert audio == ["hash2", "hash4"]
 
         # Clean up
         conn.drop_table(table_name)
@@ -496,16 +493,9 @@ def test_clickhouse_map_column_empty_table_read(
 ) -> None:
     """Test reading from an EMPTY table with Map(String, String) columns.
 
-    This tests the critical scenario where:
-    1. A table exists with Map(String, String) columns (e.g., metaxy_data_version_by_field)
-    2. The table has NO data yet (empty)
-    3. transform_after_read converts Map -> Struct
-    4. The Struct schema must still be correctly typed even when the Map is empty
-
-    The bug was that when converting Map to Struct for an empty table, Ibis
-    used map[key] which validates keys exist, failing with KeyError.
-
-    The fix uses map.get(key, "") instead of map[key] to safely handle empty maps.
+    Reading an empty table with native Map columns should return an empty
+    result (or None) without raising, with the Map columns read back as
+    native Map.
     """
     feature_cls = test_features["UpstreamFeatureA"]
     feature_key = feature_cls.spec.key
@@ -537,10 +527,7 @@ def test_clickhouse_map_column_empty_table_read(
         """
         )
 
-        # Try to read from the empty table
-        # This should NOT raise KeyError even though the Map is empty
-        # The error was: KeyError: 'frames'
-        # Because the Map->Struct conversion couldn't handle empty maps
+        # Reading from the empty table should not raise, even though the Map is empty
         read_result = store._read_feature(feature_cls)
 
         # Reading from an empty table should return None or empty result
@@ -624,16 +611,15 @@ def test_clickhouse_map_column_resolve_update_write(
         # Read back and verify
         read_result = store._read_feature(feature_cls)
         assert read_result is not None
-        result = collect_to_polars(read_result)
+        result = collect_to_polars(read_result).sort("sample_uid")
 
         assert len(result) == 3
         assert set(result["sample_uid"].to_list()) == {1, 2, 3}
 
-        # Map columns should be converted back to Struct (dict in Python)
-        provenance = result["metaxy_provenance_by_field"][0]
-        assert isinstance(provenance, dict), f"Expected dict, got {type(provenance)}"
-        assert "frames" in provenance
-        assert "audio" in provenance
+        # Map columns are read back as native Map
+        assert result.schema["metaxy_provenance_by_field"] == Map(pl.String(), pl.String())
+        frames = result["metaxy_provenance_by_field"].map.get("frames").to_list()  # ty: ignore[unresolved-attribute]
+        assert frames == ["hash1", "hash3", "hash5"]
 
         # Clean up
         conn.drop_table(table_name)
@@ -644,19 +630,13 @@ def test_clickhouse_map_column_write_from_ibis_struct(
     test_graph: FeatureGraph,
     test_features: dict[str, FeatureDefinition],
 ) -> None:
-    """Test writing Ibis-backed DataFrame with Struct columns to Map columns.
+    """Test writing an Ibis-backed DataFrame with Map columns to Map columns.
 
     This tests the scenario where metadata is computed using Ibis (e.g., from
-    a SQL query or join), resulting in a Narwhals DataFrame backed by Ibis
-    with Struct columns for metaxy_provenance_by_field.
-
-    The bug was that _transform_struct_to_map only handled Polars DataFrames,
-    so Ibis-backed DataFrames with Struct columns were passed through unchanged,
-    causing ClickHouse to fail with:
-        "CAST AS Map from tuple requires 2 elements"
-
-    The fix adds _transform_ibis_struct_to_map which uses ibis.map() to convert
-    Ibis Struct columns to Map columns.
+    a SQL query or join), and metaxy_provenance_by_field / metaxy_data_version_by_field
+    are built as native Map columns via the versioning engine's build_map_column.
+    The Ibis Map columns are written to ClickHouse Map columns and read back as
+    native Map.
     """
     import ibis
     import narwhals as nw
@@ -706,19 +686,19 @@ def test_clickhouse_map_column_write_from_ibis_struct(
             }
         )
 
-        # Wrap in Narwhals and use the actual versioning engine to build struct
+        # Wrap in Narwhals and use the actual versioning engine to build the Map columns
         nw_df = nw.from_native(ibis_table, eager_only=False)
 
-        # Use the store's versioning engine to build the struct column
-        # This is exactly how resolve_update builds metaxy_provenance_by_field
+        # Use the store's versioning engine to build the Map columns.
+        # This is exactly how resolve_update builds metaxy_provenance_by_field.
         with store.create_versioning_engine(plan, implementation=nw.Implementation.IBIS) as engine:
-            # Build struct using the engine's method (same as production code)
-            nw_df = engine.build_struct_column(
+            # Build the Map columns using the engine's method (same as production code)
+            nw_df = engine.build_map_column(
                 nw_df,
                 METAXY_PROVENANCE_BY_FIELD,
                 {"frames": "_hash_frames", "audio": "_hash_audio"},
             )
-            nw_df = engine.build_struct_column(
+            nw_df = engine.build_map_column(
                 nw_df,
                 METAXY_DATA_VERSION_BY_FIELD,
                 {"frames": "_hash_frames", "audio": "_hash_audio"},
@@ -730,26 +710,22 @@ def test_clickhouse_map_column_write_from_ibis_struct(
         # Verify it's still Ibis-backed
         assert nw_df.implementation == nw.Implementation.IBIS
 
-        # Write to the store - this should transform Ibis Struct -> Map
-        # Before the fix, this raised:
-        # "CAST AS Map from tuple requires 2 elements. Left type: Tuple(Nullable(String)), right type: Map(String, String)"
+        # Write the Ibis-backed Map columns to the store
         store.write(feature_cls, nw_df)
 
         # Read back and verify
         read_result = store._read_feature(feature_cls)
         assert read_result is not None
-        result = collect_to_polars(read_result)
+        result = collect_to_polars(read_result).sort("sample_uid")
 
         assert len(result) == 3
         assert set(result["sample_uid"].to_list()) == {1, 2, 3}
 
-        # Map columns should be converted back to Struct (dict in Python)
-        provenance = result["metaxy_provenance_by_field"][0]
-        assert isinstance(provenance, dict), f"Expected dict, got {type(provenance)}"
-        assert "frames" in provenance
-        assert "audio" in provenance
-        assert provenance["frames"] == "hash1"
-        assert provenance["audio"] == "hash_a1"
+        # Map columns are read back as native Map
+        assert result.schema["metaxy_provenance_by_field"] == Map(pl.String(), pl.String())
+        prov = [{e["key"]: e["value"] for e in row} for row in result["metaxy_provenance_by_field"].to_list()]
+        assert [p["frames"] for p in prov] == ["hash1", "hash2", "hash3"]
+        assert [p["audio"] for p in prov] == ["hash_a1", "hash_a2", "hash_a3"]
 
         # Clean up
         conn.drop_table(table_name)
@@ -760,20 +736,17 @@ def test_clickhouse_user_defined_map_column(
     test_graph: FeatureGraph,
     test_features: dict[str, FeatureDefinition],
 ) -> None:
-    """Test that user-defined Map(String, T) columns are preserved (not transformed).
+    """Test that user-defined Map(String, T) columns are read back as native Map.
 
-    Users may define their own Map columns in ClickHouse tables. Unlike metaxy's
-    system columns (metaxy_provenance_by_field, metaxy_data_version_by_field),
-    user Map columns are NOT converted to Struct.
-
-    In Polars, ClickHouse Map columns appear as List[Struct{key, value}] because
-    that's how Arrow serializes Map types. This is different from metaxy columns
-    which are explicitly converted to named Struct for downstream compatibility.
+    Users may define their own Map columns in ClickHouse tables. Both metaxy's
+    system columns (metaxy_provenance_by_field, metaxy_data_version_by_field) and
+    user-defined Map columns are read back as native Map, materialized as
+    ``polars_map.Map`` in Polars.
 
     This test verifies:
     1. User Map columns are readable (no Ibis/PyArrow errors)
-    2. User Map columns remain as List[Struct{key,value}] format (not dict)
-    3. Metaxy Map columns are converted to dict (Struct)
+    2. User Map columns materialize as polars_map.Map
+    3. Metaxy Map columns materialize as polars_map.Map
     """
     feature_cls = test_features["UpstreamFeatureA"]
     feature_key = feature_cls.spec.key
@@ -826,525 +799,23 @@ def test_clickhouse_user_defined_map_column(
         """
         )
 
-        # Read via _read_feature
-        # This uses transform_after_read which should:
-        # - Convert metaxy Map columns to Struct (dict)
-        # - Leave user_metadata Map column as-is (List[Struct{key,value}])
+        # Read via _read_feature. Both metaxy and user Map columns come back as native Map.
         read_result = store._read_feature(feature_cls)
         assert read_result is not None
-        result = collect_to_polars(read_result)
+        result = collect_to_polars(read_result).sort("sample_uid")
 
         assert len(result) == 2
         assert set(result["sample_uid"].to_list()) == {1, 2}
 
-        # Metaxy Map columns should be converted to Struct (dict in Python)
-        provenance = result["metaxy_provenance_by_field"][0]
-        assert isinstance(provenance, dict), f"Expected dict, got {type(provenance)}"
-        assert provenance["frames"] == "hash1"
-
-        # User Map column remains as List[Struct{key,value}] in Polars
-        # This is the Arrow Map representation - NOT converted to dict
-        user_meta = result["user_metadata"][0]
-        # In Polars, each row's Map value is a Series of struct{key, value}
-        assert isinstance(user_meta, pl.Series), f"Expected pl.Series, got {type(user_meta)}"
-        # Verify we can access the data
-        assert len(user_meta) == 2  # Two key-value pairs: source, quality
-
-        # Clean up
-        conn.drop_table(table_name)
-
-
-def test_clickhouse_auto_cast_struct_for_map_true(
-    clickhouse_store_no_autocreate: ClickHouseMetadataStore,
-    test_graph: FeatureGraph,
-    test_features: dict[str, FeatureDefinition],
-) -> None:
-    """Test auto_cast_struct_for_map=True converts user Struct columns to Map on write.
-
-    When auto_cast_struct_for_map=True (default), DataFrame Struct columns are
-    automatically converted to Map format when the corresponding ClickHouse column
-    is Map type. This allows users to write Polars Struct data directly to Map columns.
-    """
-    feature_cls = test_features["UpstreamFeatureA"]
-    feature_key = feature_cls.spec.key
-
-    # auto_cast_struct_for_map=True is the default
-    with clickhouse_store_no_autocreate.open("w") as store:
-        conn = store.conn
-        table_name = store.get_table_name(feature_key)
-
-        # Clean up if exists
-        if table_name in conn.list_tables():
-            conn.drop_table(table_name)
-
-        # Create table with user Map column
-        conn.raw_sql(  # ty: ignore[unresolved-attribute]
-            f"""
-            CREATE TABLE {table_name} (
-                sample_uid Int64,
-                user_tags Map(String, String),
-                metaxy_provenance_by_field Map(String, String),
-                metaxy_provenance String,
-                metaxy_feature_version String,
-                metaxy_project_version String,
-                metaxy_data_version_by_field Map(String, String),
-                metaxy_data_version String,
-                metaxy_created_at DateTime64(6, 'UTC'),
-                metaxy_updated_at DateTime64(6, 'UTC'),
-                metaxy_deleted_at Nullable(DateTime64(6, 'UTC')),
-                metaxy_materialization_id String            ) ENGINE = MergeTree()
-            ORDER BY sample_uid
-        """
-        )
-
-        # Create DataFrame with user Struct column (user_tags)
-        samples = pl.DataFrame(
-            {
-                "sample_uid": [1, 2],
-                "user_tags": [
-                    {"env": "prod", "team": "ml"},
-                    {"env": "staging", "team": "data"},
-                ],
-                "metaxy_provenance_by_field": [
-                    {"frames": "hash1", "audio": "hash2"},
-                    {"frames": "hash3", "audio": "hash4"},
-                ],
-            }
-        )
-
-        # Write should succeed - user Struct is auto-converted to Map
-        store.write(feature_cls, samples)
-
-        # Read back and verify data was written
-        read_result = store._read_feature(feature_cls)
-        assert read_result is not None
-        result = collect_to_polars(read_result)
-
-        assert len(result) == 2
-        assert set(result["sample_uid"].to_list()) == {1, 2}
-
-        # Verify user_tags Map data is readable (as List[Struct{key,value}] in Polars)
-        user_tags = result["user_tags"][0]
-        assert isinstance(user_tags, pl.Series), f"Expected pl.Series, got {type(user_tags)}"
-        # Convert to dict for easier assertion
-        tags_dict = {row["key"]: row["value"] for row in user_tags.to_list()}
-        assert tags_dict["env"] == "prod"
-        assert tags_dict["team"] == "ml"
-
-        # Clean up
-        conn.drop_table(table_name)
-
-
-def test_clickhouse_auto_cast_struct_for_map_false(
-    clickhouse_db: str, test_graph: FeatureGraph, test_features: dict[str, FeatureDefinition]
-) -> None:
-    """Test auto_cast_struct_for_map=False does NOT convert user Struct columns.
-
-    When auto_cast_struct_for_map=False, only metaxy system columns are converted.
-    User Struct columns are not converted, which will cause ClickHouse insert to fail
-    when the target column is Map type (ClickHouse can't insert Struct into Map).
-    """
-    feature_cls = test_features["UpstreamFeatureA"]
-    feature_key = feature_cls.spec.key
-
-    with ClickHouseMetadataStore(clickhouse_db, auto_create_tables=False, auto_cast_struct_for_map=False).open(
-        "w"
-    ) as store:
-        conn = store.conn
-        table_name = store.get_table_name(feature_key)
-
-        # Clean up if exists
-        if table_name in conn.list_tables():
-            conn.drop_table(table_name)
-
-        # Create table with user Map column
-        conn.raw_sql(  # ty: ignore[unresolved-attribute]
-            f"""
-            CREATE TABLE {table_name} (
-                sample_uid Int64,
-                user_tags Map(String, String),
-                metaxy_provenance_by_field Map(String, String),
-                metaxy_provenance String,
-                metaxy_feature_version String,
-                metaxy_project_version String,
-                metaxy_data_version_by_field Map(String, String),
-                metaxy_data_version String,
-                metaxy_created_at DateTime64(6, 'UTC'),
-                metaxy_updated_at DateTime64(6, 'UTC'),
-                metaxy_deleted_at Nullable(DateTime64(6, 'UTC')),
-                metaxy_materialization_id String            ) ENGINE = MergeTree()
-            ORDER BY sample_uid
-        """
-        )
-
-        # Create DataFrame with user Struct column
-        samples = pl.DataFrame(
-            {
-                "sample_uid": [1],
-                "user_tags": [{"env": "prod", "team": "ml"}],
-                "metaxy_provenance_by_field": [{"frames": "hash1", "audio": "hash2"}],
-            }
-        )
-
-        # Write should FAIL because user Struct won't be converted to Map
-        # ClickHouse will reject the insert with a type mismatch error
-        with pytest.raises(Exception):  # Ibis/ClickHouse error on type mismatch
-            store.write(feature_cls, samples)
-
-        # Clean up
-        if table_name in conn.list_tables():
-            conn.drop_table(table_name)
-
-
-def test_clickhouse_auto_cast_struct_for_map_ibis_dataframe(
-    clickhouse_store_no_autocreate: ClickHouseMetadataStore,
-    test_graph: FeatureGraph,
-    test_features: dict[str, FeatureDefinition],
-) -> None:
-    """Test auto_cast_struct_for_map=True works with Ibis-backed DataFrames.
-
-    This test verifies that user-defined Struct columns in Ibis DataFrames
-    are correctly converted to Map format when writing to ClickHouse Map columns.
-    """
-    import ibis
-    import narwhals as nw
-
-    feature_cls = test_features["UpstreamFeatureA"]
-    feature_key = feature_cls.spec.key
-
-    with clickhouse_store_no_autocreate.open("w") as store:
-        conn = store.conn
-        table_name = store.get_table_name(feature_key)
-
-        # Clean up if exists
-        if table_name in conn.list_tables():
-            conn.drop_table(table_name)
-
-        # Create table with user Map column
-        conn.raw_sql(  # ty: ignore[unresolved-attribute]
-            f"""
-            CREATE TABLE {table_name} (
-                sample_uid Int64,
-                user_tags Map(String, String),
-                metaxy_provenance_by_field Map(String, String),
-                metaxy_provenance String,
-                metaxy_feature_version String,
-                metaxy_project_version String,
-                metaxy_data_version_by_field Map(String, String),
-                metaxy_data_version String,
-                metaxy_created_at DateTime64(6, 'UTC'),
-                metaxy_updated_at DateTime64(6, 'UTC'),
-                metaxy_deleted_at Nullable(DateTime64(6, 'UTC')),
-                metaxy_materialization_id String            ) ENGINE = MergeTree()
-            ORDER BY sample_uid
-        """
-        )
-
-        # Create an Ibis memtable with columns to build structs from
-        ibis_table = ibis.memtable(
-            {
-                "sample_uid": [1, 2],
-                "_tag_env": ["prod", "staging"],
-                "_tag_team": ["ml", "data"],
-                "_prov_frames": ["hash1", "hash2"],
-                "_prov_audio": ["hash_a1", "hash_a2"],
-            }
-        )
-
-        # Build struct columns using ibis.struct()
-        ibis_table = ibis_table.mutate(
-            user_tags=ibis.struct({"env": ibis_table["_tag_env"], "team": ibis_table["_tag_team"]}),
-            metaxy_provenance_by_field=ibis.struct(
-                {
-                    "frames": ibis_table["_prov_frames"],
-                    "audio": ibis_table["_prov_audio"],
-                }
-            ),
-        )
-        ibis_table = ibis_table.drop("_tag_env", "_tag_team", "_prov_frames", "_prov_audio")
-
-        # Wrap in Narwhals
-        nw_df = nw.from_native(ibis_table, eager_only=False)
-
-        # Verify it's Ibis-backed
-        assert nw_df.implementation == nw.Implementation.IBIS
-
-        # Write should succeed - both user and metaxy Struct columns are converted to Map
-        store.write(feature_cls, nw_df)
-
-        # Read back and verify
-        read_result = store._read_feature(feature_cls)
-        assert read_result is not None
-        result = collect_to_polars(read_result)
-
-        assert len(result) == 2
-        assert set(result["sample_uid"].to_list()) == {1, 2}
-
-        # Verify user_tags Map data is readable
-        user_tags = result["user_tags"][0]
-        assert isinstance(user_tags, pl.Series), f"Expected pl.Series, got {type(user_tags)}"
-        tags_dict = {row["key"]: row["value"] for row in user_tags.to_list()}
-        assert tags_dict["env"] == "prod"
-        assert tags_dict["team"] == "ml"
-
-        # Verify metaxy columns still work
-        provenance = result["metaxy_provenance_by_field"][0]
-        assert isinstance(provenance, dict), f"Expected dict, got {type(provenance)}"
-        assert provenance["frames"] == "hash1"
-
-        # Clean up
-        conn.drop_table(table_name)
-
-
-def test_clickhouse_auto_cast_struct_for_map_non_string_values(
-    clickhouse_store_no_autocreate: ClickHouseMetadataStore,
-    test_graph: FeatureGraph,
-    test_features: dict[str, FeatureDefinition],
-) -> None:
-    """Test auto_cast_struct_for_map with non-string Map value types.
-
-    This test verifies that when a ClickHouse table has Map(String, Int64) columns,
-    Struct fields are correctly cast to Int64 before insertion.
-    """
-    feature_cls = test_features["UpstreamFeatureA"]
-    feature_key = feature_cls.spec.key
-
-    with clickhouse_store_no_autocreate.open("w") as store:
-        conn = store.conn
-        table_name = store.get_table_name(feature_key)
-
-        # Clean up if exists
-        if table_name in conn.list_tables():
-            conn.drop_table(table_name)
-
-        # Create table with Map(String, Int64) column for counts
-        conn.raw_sql(  # ty: ignore[unresolved-attribute]
-            f"""
-            CREATE TABLE {table_name} (
-                sample_uid Int64,
-                field_counts Map(String, Int64),
-                metaxy_provenance_by_field Map(String, String),
-                metaxy_provenance String,
-                metaxy_feature_version String,
-                metaxy_project_version String,
-                metaxy_data_version_by_field Map(String, String),
-                metaxy_data_version String,
-                metaxy_created_at DateTime64(6, 'UTC'),
-                metaxy_updated_at DateTime64(6, 'UTC'),
-                metaxy_deleted_at Nullable(DateTime64(6, 'UTC')),
-                metaxy_materialization_id String            ) ENGINE = MergeTree()
-            ORDER BY sample_uid
-        """
-        )
-
-        # Create DataFrame with Struct column containing integers
-        samples = pl.DataFrame(
-            {
-                "sample_uid": [1, 2],
-                "field_counts": [
-                    {"frames_count": 10, "audio_count": 5},
-                    {"frames_count": 20, "audio_count": 8},
-                ],
-                "metaxy_provenance_by_field": [
-                    {"frames": "hash1", "audio": "hash2"},
-                    {"frames": "hash3", "audio": "hash4"},
-                ],
-            }
-        )
-
-        # Write should succeed - Struct int values are cast to Int64 for Map(String, Int64)
-        store.write(feature_cls, samples)
-
-        # Read back and verify
-        read_result = store._read_feature(feature_cls)
-        assert read_result is not None
-        result = collect_to_polars(read_result)
-
-        assert len(result) == 2
-
-        # Verify field_counts Map data has correct integer values
-        field_counts = result["field_counts"][0]
-        assert isinstance(field_counts, pl.Series), f"Expected pl.Series, got {type(field_counts)}"
-        counts_dict = {row["key"]: row["value"] for row in field_counts.to_list()}
-        assert counts_dict["frames_count"] == 10
-        assert counts_dict["audio_count"] == 5
-
-        # Clean up
-        conn.drop_table(table_name)
-
-
-def test_clickhouse_auto_cast_struct_for_map_empty_struct(
-    clickhouse_store_no_autocreate: ClickHouseMetadataStore,
-    test_graph: FeatureGraph,
-    test_features: dict[str, FeatureDefinition],
-) -> None:
-    """Test auto_cast_struct_for_map handles empty structs gracefully.
-
-    Empty structs (struct[0] with no fields) should be skipped during
-    transformation since they can't be converted to a Map.
-    """
-    feature_cls = test_features["UpstreamFeatureA"]
-    feature_key = feature_cls.spec.key
-
-    with clickhouse_store_no_autocreate.open("w") as store:
-        conn = store.conn
-        table_name = store.get_table_name(feature_key)
-
-        # Clean up if exists
-        if table_name in conn.list_tables():
-            conn.drop_table(table_name)
-
-        # Create table with Map column for empty struct
-        conn.raw_sql(  # ty: ignore[unresolved-attribute]
-            f"""
-            CREATE TABLE {table_name} (
-                sample_uid Int64,
-                empty_metadata Map(String, String),
-                metaxy_provenance_by_field Map(String, String),
-                metaxy_provenance String,
-                metaxy_feature_version String,
-                metaxy_project_version String,
-                metaxy_data_version_by_field Map(String, String),
-                metaxy_data_version String,
-                metaxy_created_at DateTime64(6, 'UTC'),
-                metaxy_updated_at DateTime64(6, 'UTC'),
-                metaxy_deleted_at Nullable(DateTime64(6, 'UTC')),
-                metaxy_materialization_id String            ) ENGINE = MergeTree()
-            ORDER BY sample_uid
-        """
-        )
-
-        # Create DataFrame with empty Struct column (struct[0])
-        # This simulates the preview_summary: <struct[0]> {}, {} case
-        empty_struct_schema = pl.Struct([])  # Empty struct with no fields
-        samples = pl.DataFrame(
-            {
-                "sample_uid": [1, 2],
-                "empty_metadata": pl.Series([{}, {}]).cast(empty_struct_schema),
-                "metaxy_provenance_by_field": [
-                    {"frames": "hash1", "audio": "hash2"},
-                    {"frames": "hash3", "audio": "hash4"},
-                ],
-            }
-        )
-
-        # Verify the empty struct has no fields
-        assert isinstance(samples.schema["empty_metadata"], pl.Struct)
-        assert len(samples.schema["empty_metadata"].fields) == 0
-
-        # Write should succeed - empty struct is skipped, other structs converted
-        store.write(feature_cls, samples)
-
-        # Read back and verify data was written
-        read_result = store._read_feature(feature_cls)
-        assert read_result is not None
-        result = collect_to_polars(read_result)
-
-        assert len(result) == 2
-        assert set(result["sample_uid"].to_list()) == {1, 2}
-
-        # Clean up
-        conn.drop_table(table_name)
-
-
-def test_clickhouse_auto_cast_struct_for_map_null_values(
-    clickhouse_db: str, test_graph: FeatureGraph, test_features: dict[str, FeatureDefinition]
-) -> None:
-    """Test that Struct columns with NULL values are handled correctly.
-
-    When a Polars Struct has fields with NULL values (e.g., `{'a': 1, 'b': None}`),
-    and the target ClickHouse column is Map(String, Int64) (non-nullable values),
-    the NULL entries should be filtered out since ClickHouse Maps don't support
-    NULL values unless explicitly declared as Nullable.
-
-    This tests the fix for the error:
-    "Cannot convert NULL value to non-Nullable type: while converting source
-    column selected_frame_indices to destination column selected_frame_indices"
-    """
-    feature_cls = test_features["UpstreamFeatureA"]
-    feature_key = feature_cls.spec.key
-
-    with ClickHouseMetadataStore(clickhouse_db, auto_create_tables=False, auto_cast_struct_for_map=True).open(
-        "w"
-    ) as store:
-        conn = store.conn
-        table_name = store.get_table_name(feature_key)
-
-        # Clean up if exists
-        if table_name in conn.list_tables():
-            conn.drop_table(table_name)
-
-        # Create table with Map(String, Int64) column - non-nullable values
-        conn.raw_sql(  # ty: ignore[unresolved-attribute]
-            f"""
-            CREATE TABLE {table_name} (
-                sample_uid Int64,
-                selected_frame_indices Map(String, Int64),
-                metaxy_provenance_by_field Map(String, String),
-                metaxy_provenance String,
-                metaxy_feature_version String,
-                metaxy_project_version String,
-                metaxy_data_version_by_field Map(String, String),
-                metaxy_data_version String,
-                metaxy_created_at DateTime64(6, 'UTC'),
-                metaxy_updated_at DateTime64(6, 'UTC'),
-                metaxy_deleted_at Nullable(DateTime64(6, 'UTC')),
-                metaxy_materialization_id String            ) ENGINE = MergeTree()
-            ORDER BY sample_uid
-        """
-        )
-
-        # Create DataFrame with Struct column containing NULL values
-        # This simulates: selected_frame_indices: {'eyes_open_true': 38, 'eyes_open_false': None}
-        samples = pl.DataFrame(
-            {
-                "sample_uid": [1, 2],
-                "selected_frame_indices": [
-                    {
-                        "eyes_open_true": 38,
-                        "eyes_open_false": None,
-                        "head_pitch_min": 5,
-                    },
-                    {
-                        "eyes_open_true": None,
-                        "eyes_open_false": 67,
-                        "head_pitch_min": None,
-                    },
-                ],
-                "metaxy_provenance_by_field": [
-                    {"frames": "hash1", "audio": "hash2"},
-                    {"frames": "hash3", "audio": "hash4"},
-                ],
-            }
-        )
-
-        # Verify the struct has nullable int fields
-        struct_type = samples.schema["selected_frame_indices"]
-        assert isinstance(struct_type, pl.Struct)
-
-        # Write should succeed - NULL values are filtered out
-        store.write(feature_cls, samples)
-
-        # Read back and verify data was written
-        read_result = store._read_feature(feature_cls)
-        assert read_result is not None
-        result = collect_to_polars(read_result)
-
-        assert len(result) == 2
-        assert set(result["sample_uid"].to_list()) == {1, 2}
-
-        # Verify the Map data - NULL entries should be filtered out
-        # Row 1: {'eyes_open_true': 38, 'head_pitch_min': 5} (eyes_open_false filtered)
-        # Row 2: {'eyes_open_false': 67} (eyes_open_true and head_pitch_min filtered)
-        row1 = result.filter(pl.col("sample_uid") == 1)["selected_frame_indices"][0]
-        row2 = result.filter(pl.col("sample_uid") == 2)["selected_frame_indices"][0]
-
-        # Convert list of {key, value} structs to dict for easier checking
-        row1_dict = {item["key"]: item["value"] for item in row1}
-        row2_dict = {item["key"]: item["value"] for item in row2}
-
-        assert row1_dict == {"eyes_open_true": 38, "head_pitch_min": 5}
-        assert row2_dict == {"eyes_open_false": 67}
+        # Metaxy Map columns materialize as polars_map.Map
+        assert result.schema["metaxy_provenance_by_field"] == Map(pl.String(), pl.String())
+        frames = result["metaxy_provenance_by_field"].map.get("frames").to_list()  # ty: ignore[unresolved-attribute]
+        assert frames == ["hash1", "hash3"]
+
+        # User Map column also materializes as polars_map.Map
+        assert result.schema["user_metadata"] == Map(pl.String(), pl.String())
+        sources = result["user_metadata"].map.get("source").to_list()  # ty: ignore[unresolved-attribute]
+        assert sources == ["camera1", "camera2"]
 
         # Clean up
         conn.drop_table(table_name)

--- a/tests/ext/duckdb/test_native.py
+++ b/tests/ext/duckdb/test_native.py
@@ -112,7 +112,7 @@ class TestDuckDBPreCreatedMapTable:
         """)
         con.close()
 
-        config = MetaxyConfig(enable_map_datatype=True, auto_create_tables=False)
+        config = MetaxyConfig(auto_create_tables=False)
         with config.use():
             metadata = pl.DataFrame(
                 {
@@ -167,7 +167,7 @@ class TestDuckDBPreCreatedMapTable:
         """)
         con.close()
 
-        config = MetaxyConfig(enable_map_datatype=True, auto_create_tables=False)
+        config = MetaxyConfig(auto_create_tables=False)
         with config.use():
             user_map = pl.Series(
                 "user_tags",
@@ -247,7 +247,7 @@ class TestDuckDBPreCreatedMapTable:
         raw_con.close()
 
         # Write using Ibis-backed frame (via the store's own read -> write roundtrip)
-        config = MetaxyConfig(enable_map_datatype=True, auto_create_tables=False)
+        config = MetaxyConfig(auto_create_tables=False)
         with config.use():
             with store.open("w") as s:
                 s.write(feature, metadata)

--- a/tests/ext/iceberg/test_native.py
+++ b/tests/ext/iceberg/test_native.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import patch
 
 import polars as pl
 import pytest
@@ -12,7 +11,7 @@ from metaxy.ext.polars.handlers.iceberg import IcebergMetadataStore
 from metaxy.metadata_store import MetadataStore
 from metaxy.models.feature_definition import FeatureDefinition
 from metaxy.models.types import FeatureKey
-from packaging.version import Version
+from metaxy.utils import collect_to_polars
 
 from tests.metadata_stores.shared import (
     CRUDTests,
@@ -130,14 +129,14 @@ def test_iceberg_custom_namespace(
         assert ("metaxy",) not in store.catalog.list_namespaces()
 
 
-@pytest.mark.skipif(
-    Version(pl.__version__) < Version("1.39.0"),
-    reason="sink_iceberg requires Polars >= 1.39.0",
-)
-def test_iceberg_sink_lazyframe(
+def test_iceberg_write_lazyframe(
     iceberg_store: IcebergMetadataStore, test_features: dict[str, FeatureDefinition]
 ) -> None:
-    """Verify LazyFrame.sink_iceberg is used for lazy writes."""
+    """Verify lazy writes are materialized and round-trip correctly.
+
+    The Map conversion path collects lazy frames to Arrow before appending, so a
+    LazyFrame input is written and read back with the expected rows.
+    """
     feature_cls = test_features["UpstreamFeatureA"]
 
     metadata_lazy = pl.LazyFrame(
@@ -152,10 +151,9 @@ def test_iceberg_sink_lazyframe(
     )
 
     with iceberg_store.open("w") as store:
-        with patch.object(pl.LazyFrame, "sink_iceberg", autospec=True) as mock_sink:
-            mock_sink.side_effect = lambda self_lf, *args, **kwargs: None
-            store.write(feature_cls, metadata_lazy)
-        mock_sink.assert_called_once()
-        args, kwargs = mock_sink.call_args
-        assert len(args) == 2
-        assert kwargs == {"mode": "append"}
+        store.write(feature_cls, metadata_lazy)
+
+        result = store.read(feature_cls)
+        assert result is not None
+        df = collect_to_polars(result).sort("sample_uid")
+        assert df["sample_uid"].to_list() == [1, 2, 3]

--- a/tests/ext/postgres/test_native.py
+++ b/tests/ext/postgres/test_native.py
@@ -16,7 +16,9 @@ from metaxy.models.constants import METAXY_DATA_VERSION_BY_FIELD, METAXY_PROVENA
 from metaxy.models.feature import FeatureGraph, current_graph
 from metaxy.models.types import FeatureKey
 from metaxy.utils import collect_to_polars
+from metaxy.utils._arrow_map import convert_maps_to_structs
 from metaxy.versioning.types import HashAlgorithm
+from polars_map import Map
 
 from tests.ext.postgres.conftest import _with_search_path
 from tests.metadata_stores.shared import (
@@ -183,9 +185,13 @@ def test_postgresql_struct_to_jsonb_roundtrip(
         )
         store.write(test_features["UpstreamFeatureA"], original_metadata)
 
-        # Read data back and verify full roundtrip of user-provided columns
-        # JSONB does not preserve struct field order, so compare with check_dtypes=False
+        # Read data back and verify full roundtrip of user-provided columns.
+        # The Metaxy system column comes back as polars_map.Map, so normalize it
+        # back to Struct before comparing. JSONB does not preserve struct field
+        # order, so compare with check_dtypes=False.
         result = collect_to_polars(store.read(test_features["UpstreamFeatureA"]))
+        assert result.schema[METAXY_PROVENANCE_BY_FIELD] == Map(pl.String(), pl.String())
+        result = convert_maps_to_structs(result, [METAXY_PROVENANCE_BY_FIELD])
         result_sorted = result.sort("sample_uid").select(original_metadata.columns)
         pl.testing.assert_frame_equal(result_sorted, original_metadata.sort("sample_uid"), check_dtypes=False)
 
@@ -319,7 +325,7 @@ def test_postgresql_auto_cast_false_only_decodes_system_columns_on_read(
 
         result = collect_to_polars(store.read(feature)).sort("sample_uid")
 
-        assert isinstance(result.schema[METAXY_PROVENANCE_BY_FIELD], pl.Struct)
+        assert result.schema[METAXY_PROVENANCE_BY_FIELD] == Map(pl.String(), pl.String())
         assert result.schema["user_struct"] == pl.Utf8
         assert result.sort("sample_uid")["user_struct"].to_list() == [
             '{"model":"resnet","version":"1"}',
@@ -406,7 +412,7 @@ def test_postgresql_user_defined_jsonb_column(
 
         result = collect_to_polars(store.read(feature)).sort("sample_uid")
 
-        assert isinstance(result.schema[METAXY_PROVENANCE_BY_FIELD], pl.Struct)
+        assert result.schema[METAXY_PROVENANCE_BY_FIELD] == Map(pl.String(), pl.String())
         assert isinstance(result.schema["user_metadata"], pl.Struct)
         assert result["user_metadata"].to_list() == [
             {"source": "camera1", "quality": "high", "resolution": None},
@@ -759,8 +765,10 @@ def test_postgresql_auto_create_struct_columns_use_jsonb(
             f"SELECT pg_typeof(user_struct)::text FROM {table_name} ORDER BY sample_uid"
         ).fetchall()
 
-        assert isinstance(result_sorted.schema[METAXY_PROVENANCE_BY_FIELD], pl.Struct)
-        assert result_sorted[METAXY_PROVENANCE_BY_FIELD].to_list() == [
+        assert result_sorted.schema[METAXY_PROVENANCE_BY_FIELD] == Map(pl.String(), pl.String())
+        assert convert_maps_to_structs(result_sorted, [METAXY_PROVENANCE_BY_FIELD])[
+            METAXY_PROVENANCE_BY_FIELD
+        ].to_list() == [
             {"frames": "h1", "audio": "h2"},
             {"frames": "h3", "audio": "h4"},
         ]
@@ -805,9 +813,13 @@ def test_postgresql_auto_cast_struct_for_jsonb_all_null_values(
             f"SELECT pg_typeof(user_struct)::text FROM {table_name} ORDER BY sample_uid"
         ).fetchall()
 
-        # Metaxy system columns should decode back to Struct with expected fields
+        # Metaxy system columns should decode back to Map, with field names still
+        # recoverable as Struct keys.
         for system_column in (METAXY_PROVENANCE_BY_FIELD, METAXY_DATA_VERSION_BY_FIELD):
-            system_dtype = result.schema[system_column]
+            assert result.schema[system_column] == Map(pl.String(), pl.String())
+        system_structs = convert_maps_to_structs(result, [METAXY_PROVENANCE_BY_FIELD, METAXY_DATA_VERSION_BY_FIELD])
+        for system_column in (METAXY_PROVENANCE_BY_FIELD, METAXY_DATA_VERSION_BY_FIELD):
+            system_dtype = system_structs.schema[system_column]
             assert isinstance(system_dtype, pl.Struct)
             assert {field.name for field in system_dtype.fields} == {"frames", "audio"}
 
@@ -883,7 +895,7 @@ def test_postgresql_auto_cast_struct_for_jsonb_user_jsonb_all_null_values(
 
         result = collect_to_polars(store.read(feature)).sort("sample_uid")
 
-        assert isinstance(result.schema[METAXY_PROVENANCE_BY_FIELD], pl.Struct)
+        assert result.schema[METAXY_PROVENANCE_BY_FIELD] == Map(pl.String(), pl.String())
         assert result.schema["user_struct"] == pl.Utf8
         assert result["user_struct"].to_list() == [None, None]
         assert raw_types == [("jsonb",), ("jsonb",)]
@@ -913,7 +925,10 @@ def test_postgresql_auto_cast_struct_for_jsonb_false_all_null_values(
         result = collect_to_polars(store.read(test_features["UpstreamFeatureA"])).sort("sample_uid")
 
         for system_column in (METAXY_PROVENANCE_BY_FIELD, METAXY_DATA_VERSION_BY_FIELD):
-            system_dtype = result.schema[system_column]
+            assert result.schema[system_column] == Map(pl.String(), pl.String())
+        system_structs = convert_maps_to_structs(result, [METAXY_PROVENANCE_BY_FIELD, METAXY_DATA_VERSION_BY_FIELD])
+        for system_column in (METAXY_PROVENANCE_BY_FIELD, METAXY_DATA_VERSION_BY_FIELD):
+            system_dtype = system_structs.schema[system_column]
             assert isinstance(system_dtype, pl.Struct)
             assert {field.name for field in system_dtype.fields} == {"frames", "audio"}
 
@@ -1099,13 +1114,14 @@ def test_postgresql_read_missing_feature_schema_decodes_system_columns(
             )
         ).sort("sample_uid")
 
-        assert isinstance(result.schema[METAXY_PROVENANCE_BY_FIELD], pl.Struct)
-        assert isinstance(result.schema[METAXY_DATA_VERSION_BY_FIELD], pl.Struct)
-        assert result[METAXY_PROVENANCE_BY_FIELD].to_list() == [
+        assert result.schema[METAXY_PROVENANCE_BY_FIELD] == Map(pl.String(), pl.String())
+        assert result.schema[METAXY_DATA_VERSION_BY_FIELD] == Map(pl.String(), pl.String())
+        system_structs = convert_maps_to_structs(result, [METAXY_PROVENANCE_BY_FIELD, METAXY_DATA_VERSION_BY_FIELD])
+        assert system_structs[METAXY_PROVENANCE_BY_FIELD].to_list() == [
             {"frames": "h1", "audio": "h2"},
             {"frames": "h3", "audio": "h4"},
         ]
-        assert result[METAXY_DATA_VERSION_BY_FIELD].to_list() == [
+        assert system_structs[METAXY_DATA_VERSION_BY_FIELD].to_list() == [
             {"frames": "v1", "audio": "v2"},
             {"frames": "v3", "audio": "v4"},
         ]
@@ -1283,8 +1299,8 @@ def test_postgresql_known_feature_empty_result_preserves_system_struct_schema(
         )
 
         assert result.is_empty()
-        assert isinstance(result.schema[METAXY_PROVENANCE_BY_FIELD], pl.Struct)
-        assert isinstance(result.schema[METAXY_DATA_VERSION_BY_FIELD], pl.Struct)
+        assert result.schema[METAXY_PROVENANCE_BY_FIELD] == Map(pl.String(), pl.String())
+        assert result.schema[METAXY_DATA_VERSION_BY_FIELD] == Map(pl.String(), pl.String())
 
 
 def test_postgresql_read_missing_feature_schema_empty_result_returns_empty(

--- a/tests/ext/ray/conftest.py
+++ b/tests/ext/ray/conftest.py
@@ -83,11 +83,10 @@ def ray_config(tmp_path: Path, delta_store: DeltaMetadataStore) -> mx.MetaxyConf
 
 @pytest.fixture
 def ray_map_config(tmp_path: Path, delta_store: DeltaMetadataStore) -> mx.MetaxyConfig:
-    """Create a MetaxyConfig with enable_map_datatype=True."""
+    """Create a MetaxyConfig for the Map datatype tests."""
     return mx.MetaxyConfig(
         project="test",
         entrypoints=[RAY_FEATURES_MODULE],
-        enable_map_datatype=True,
         stores={
             "dev": StoreConfig(
                 type="metaxy.ext.polars.handlers.delta.DeltaMetadataStore",

--- a/tests/ext/ray/test_datasource.py
+++ b/tests/ext/ray/test_datasource.py
@@ -11,6 +11,7 @@ import pyarrow as pa
 import pytest
 import ray
 from metaxy.ext.polars.handlers.delta import DeltaMetadataStore
+from metaxy.utils import collect_to_polars
 from polars_map import Map
 
 from metaxy_testing import RAY_FEATURES_MODULE
@@ -18,6 +19,25 @@ from metaxy_testing import RAY_FEATURES_MODULE
 from .conftest import DERIVED_FEATURE_KEY, FEATURE_KEY, make_test_data
 
 MAP_STR_STR = Map(pl.String(), pl.String())
+
+
+def _map_row_value_to_dict(map_value: object) -> dict[str, str]:
+    """Decode a Ray row's Map column value into a plain ``dict``.
+
+    Under the always-on Map datatype, Ray materializes an Arrow map column as a
+    list of ``(key, value)`` entries. The ``{"key", "value"}`` dict form and a
+    plain ``dict`` are handled defensively.
+    """
+    if isinstance(map_value, dict):
+        return {str(key): str(value) for key, value in map_value.items()}
+    result: dict[str, str] = {}
+    for entry in map_value:  # ty: ignore[not-iterable]
+        if isinstance(entry, dict):
+            result[entry["key"]] = entry["value"]
+        else:
+            key, value = entry
+            result[key] = value
+    return result
 
 
 def test_datasource_reads_metadata(
@@ -362,7 +382,17 @@ def test_datasource_and_datasink_end_to_end(
         row["value"] = row["value"] * 2
         # Update provenance to reflect the transformation
         row["metaxy_provenance"] = f"transformed_{row['metaxy_provenance']}"
-        row["metaxy_provenance_by_field"] = {"value": f"transformed_{row['metaxy_provenance_by_field']['value']}"}
+        # With the always-on Map datatype, the by-field columns arrive as Arrow
+        # map row-values: a list of (key, value) entries. Decode the provenance
+        # map, apply the transformation, and write every by-field map back as a
+        # plain dict, which Ray infers as a Struct and the store converts to Map
+        # on write. The data-version map must be normalized too, otherwise it
+        # stays a raw list-of-entries and clashes with the Struct provenance
+        # inside the store's write path.
+        provenance_by_field = _map_row_value_to_dict(row["metaxy_provenance_by_field"])
+        row["metaxy_provenance_by_field"] = {"value": f"transformed_{provenance_by_field['value']}"}
+        if "metaxy_data_version_by_field" in row:
+            row["metaxy_data_version_by_field"] = _map_row_value_to_dict(row["metaxy_data_version_by_field"])
         return row
 
     transformed_ds = read_ds.map(transform_row)
@@ -377,13 +407,20 @@ def test_datasource_and_datasink_end_to_end(
 
     # Verify the result by reading from destination
     with dest_store:
-        result = dest_store.read(FEATURE_KEY)
-        df = result.collect()
+        df = collect_to_polars(dest_store.read(FEATURE_KEY)).sort("sample_uid")
 
-        assert len(df) == 3
-        assert set(df["sample_uid"].to_list()) == {"a", "b", "c"}
-        # Values should be doubled
-        assert set(df["value"].to_list()) == {20, 40, 60}
+    assert len(df) == 3
+    assert df["sample_uid"].to_list() == ["a", "b", "c"]
+    # Values should be doubled
+    assert df["value"].to_list() == [20, 40, 60]
+    # The transformed per-field provenance survives the round-trip as a Map,
+    # carrying the "transformed_" prefix applied to each original hash.
+    assert df.schema["metaxy_provenance_by_field"] == MAP_STR_STR
+    assert df["metaxy_provenance_by_field"].map.get("value").to_list() == [  # ty: ignore[unresolved-attribute]
+        "transformed_hash_10",
+        "transformed_hash_20",
+        "transformed_hash_30",
+    ]
 
 
 def test_datasource_incremental_all_new(

--- a/tests/ext/sqlmodel/test_native.py
+++ b/tests/ext/sqlmodel/test_native.py
@@ -33,6 +33,8 @@ from metaxy_testing.models import SampleFeatureSpec
 from sqlmodel import Field
 from syrupy.assertion import SnapshotAssertion
 
+from metaxy_testing import by_field_maps_to_structs
+
 # Basic Creation and Registration Tests
 
 
@@ -724,8 +726,11 @@ def test_sqlmodel_feature_with_duckdb_store(tmp_path: Path, snapshot: SnapshotAs
         assert "metaxy_feature_version" in result_df.columns
         assert all(v == VideoFeature.feature_version() for v in result_df["metaxy_feature_version"].to_list())
 
-        # Snapshot result (exclude timestamps which vary between runs)
-        result_for_snapshot = result_df.drop("metaxy_created_at", "metaxy_updated_at").to_dicts()
+        # Snapshot result (exclude timestamps which vary between runs).
+        # Metaxy Map columns are rendered as Structs so the snapshot stays a readable field->hash mapping.
+        result_for_snapshot = by_field_maps_to_structs(
+            result_df.drop("metaxy_created_at", "metaxy_updated_at")
+        ).to_dicts()
         assert result_for_snapshot == snapshot
 
 
@@ -918,12 +923,13 @@ def test_sqlmodel_duckdb_custom_id_columns(tmp_path: Path, snapshot: SnapshotAss
         )
         assert sorted(child_composite_keys) == [(1, 10), (1, 20), (2, 10), (2, 30)]
 
-        # Snapshot results (exclude timestamps which vary between runs)
+        # Snapshot results (exclude timestamps which vary between runs).
+        # Metaxy Map columns are rendered as Structs so the snapshot stays a readable field->hash mapping.
         assert {
-            "parent": parent_result_df.drop("metaxy_created_at", "metaxy_updated_at")
+            "parent": by_field_maps_to_structs(parent_result_df.drop("metaxy_created_at", "metaxy_updated_at"))
             .sort(["user_id", "session_id"])
             .to_dicts(),
-            "child": child_result_df.drop("metaxy_created_at", "metaxy_updated_at")
+            "child": by_field_maps_to_structs(child_result_df.drop("metaxy_created_at", "metaxy_updated_at"))
             .sort(["user_id", "session_id"])
             .to_dicts(),
         } == snapshot

--- a/tests/metadata_stores/core/test_fallback_stores.py
+++ b/tests/metadata_stores/core/test_fallback_stores.py
@@ -27,6 +27,7 @@ from metaxy.metadata_store import (
 )
 from metaxy.metadata_store.warnings import PolarsMaterializationWarning
 from metaxy.models.feature import FeatureGraph
+from metaxy.utils import collect_to_polars
 from metaxy.versioning.types import HashAlgorithm
 from metaxy_testing.models import SampleFeatureSpec
 from metaxy_testing.pytest_helpers import skip_exception
@@ -37,6 +38,7 @@ from metaxy_testing import (
     HashAlgorithmCases,
     add_metaxy_provenance_column,
     assert_all_results_equal,
+    by_field_maps_to_structs,
 )
 
 # ============= HELPERS =============
@@ -220,9 +222,8 @@ def test_fallback_store_warning_issued(
                     result = primary_store.resolve_update(DownstreamFeature)
 
             # Collect field provenances for comparison
-            added_sorted = (result.new.to_polars() if isinstance(result.new, nw.DataFrame) else result.added).sort(
-                "sample_uid"
-            )
+            added = collect_to_polars(result.new) if isinstance(result.new, nw.DataFrame) else result.added
+            added_sorted = by_field_maps_to_structs(added).sort("sample_uid")
             versions = added_sorted["metaxy_provenance_by_field"].to_list()
 
             results[(primary_store_type, fallback_store_type, versioning_engine)] = {
@@ -356,8 +357,12 @@ def test_fallback_store_switches_to_polars_components(
             result_local = store_all_local.resolve_update(DownstreamFeature)
 
         # Collect field provenances from result
-        added_local = result_local.new.to_polars() if isinstance(result_local.new, nw.DataFrame) else result_local.added
-        versions_local = added_local.sort("sample_uid")["metaxy_provenance_by_field"].to_list()
+        added_local = (
+            collect_to_polars(result_local.new) if isinstance(result_local.new, nw.DataFrame) else result_local.added
+        )
+        versions_local = (
+            by_field_maps_to_structs(added_local).sort("sample_uid")["metaxy_provenance_by_field"].to_list()
+        )
 
         results[(primary_store_type, fallback_store_type, "all_local")] = {
             "added": len(result_local.new),
@@ -397,9 +402,13 @@ def test_fallback_store_switches_to_polars_components(
 
         # Collect field provenances from result
         added_fallback = (
-            result_fallback.new.to_polars() if isinstance(result_fallback.new, nw.DataFrame) else result_fallback.added
+            collect_to_polars(result_fallback.new)
+            if isinstance(result_fallback.new, nw.DataFrame)
+            else result_fallback.added
         )
-        versions_fallback = added_fallback.sort("sample_uid")["metaxy_provenance_by_field"].to_list()
+        versions_fallback = (
+            by_field_maps_to_structs(added_fallback).sort("sample_uid")["metaxy_provenance_by_field"].to_list()
+        )
 
         results[(primary_store_type, fallback_store_type, "with_fallback")] = {
             "added": len(result_fallback.new),

--- a/tests/metadata_stores/core/test_hash_algorithms.py
+++ b/tests/metadata_stores/core/test_hash_algorithms.py
@@ -20,14 +20,16 @@ import pytest
 from metaxy import BaseFeature, FeatureDep, FeatureGraph
 from metaxy.config import MetaxyConfig
 from metaxy.ext.polars.handlers.delta import DeltaMetadataStore
+from metaxy.utils import collect_to_polars
 from metaxy.versioning.types import HashAlgorithm
 from metaxy_testing.models import SampleFeature, SampleFeatureSpec
 from metaxy_testing.parametric import (
     downstream_metadata_strategy,
 )
+from polars_map import Map
 from pytest_cases import parametrize_with_cases
 
-from metaxy_testing import HashAlgorithmCases
+from metaxy_testing import HashAlgorithmCases, by_field_maps_to_structs
 
 # ============= TEST: HASH ALGORITHM CORRECTNESS =============
 
@@ -268,16 +270,16 @@ def test_field_level_provenance_structure(
             project_version=graph.project_version,
         )
 
-        result = increment.new.lazy().collect().to_polars()
+        result = collect_to_polars(increment.new)
 
         # Check provenance_by_field structure
         provenance_by_field = result["metaxy_provenance_by_field"]
 
-        # Verify it's a struct column
-        assert provenance_by_field.dtype == pl.Struct, "provenance_by_field should be a Struct column"
+        # Verify it's a Map column
+        assert provenance_by_field.dtype == Map(pl.String(), pl.String()), "provenance_by_field should be a Map column"
 
-        # Unnest to check field structure
-        unnested = result.unnest("metaxy_provenance_by_field")
+        # Convert Map -> Struct, then unnest to check field structure
+        unnested = by_field_maps_to_structs(result).unnest("metaxy_provenance_by_field")
 
         # Check that we have one column per child field
         expected_fields = {"result_x", "result_y"}

--- a/tests/metadata_stores/core/test_input_progress.py
+++ b/tests/metadata_stores/core/test_input_progress.py
@@ -18,6 +18,7 @@ from metaxy import (
 )
 from metaxy.metadata_store import MetadataStore
 from metaxy.models.lineage import LineageRelationship
+from metaxy.utils import collect_to_polars
 from metaxy_testing.models import SampleFeatureSpec
 
 from metaxy_testing import add_metaxy_provenance_column
@@ -146,7 +147,7 @@ class TestCalculateInputProgress:
 
             # Write downstream metadata for only 3 samples
             increment = store.resolve_update(Downstream, lazy=False)
-            partial_data = increment.new.to_polars().head(3)
+            partial_data = collect_to_polars(increment.new).head(3)
             store.write(Downstream, partial_data)
 
             # Check progress - should be 30% (3/10)
@@ -238,7 +239,7 @@ class TestCalculateInputProgress:
 
             # Write downstream for 2 out of 3 samples
             increment = store.resolve_update(Downstream, lazy=False)
-            partial_data = increment.new.to_polars().head(2)
+            partial_data = collect_to_polars(increment.new).head(2)
             store.write(Downstream, partial_data)
 
             # Check progress - should be 66.67% (2/3)
@@ -307,7 +308,7 @@ class TestCalculateInputProgress:
 
             # Write downstream for only 1 hour (1 out of 2 groups)
             increment = store.resolve_update(HourlyStats, lazy=False)
-            partial_data = increment.new.to_polars().head(1)
+            partial_data = collect_to_polars(increment.new).head(1)
             store.write(HourlyStats, partial_data)
 
             # Progress should count by aggregation groups, not individual readings
@@ -368,7 +369,7 @@ class TestCalculateInputProgress:
                 }
             )
             # Read upstream from store to get metaxy_data_version_by_field column
-            upstream_from_store = store.read(Video).collect().to_polars()
+            upstream_from_store = collect_to_polars(store.read(Video))
             # Join with upstream to get provenance info
             frames_with_upstream = frames_data.join(
                 upstream_from_store.select(
@@ -433,7 +434,7 @@ class TestCalculateInputProgress:
 
             # Write downstream for 2 out of 4 samples
             increment = store.resolve_update(Downstream, lazy=False)
-            partial_data = increment.new.to_polars().head(2)
+            partial_data = collect_to_polars(increment.new).head(2)
             store.write(Downstream, partial_data)
 
             # Check progress - should be 50% (2/4)
@@ -500,7 +501,7 @@ class TestCalculateInputProgress:
 
             # Write downstream for 1 out of 3 samples
             increment = store.resolve_update(Downstream, lazy=False)
-            partial_data = increment.new.to_polars().head(1)
+            partial_data = collect_to_polars(increment.new).head(1)
             store.write(Downstream, partial_data)
 
             # Check progress - should be 33.33% (1/3)

--- a/tests/metadata_stores/core/test_provenance_snapshot.py
+++ b/tests/metadata_stores/core/test_provenance_snapshot.py
@@ -52,8 +52,11 @@ def test_provenance_snapshot(
         METAXY_PROVENANCE,
         METAXY_PROVENANCE_BY_FIELD,
     )
+    from metaxy.utils import collect_to_polars
     from metaxy.versioning.types import HashAlgorithm
     from metaxy_testing.models import SampleFeatureSpec
+
+    from metaxy_testing import by_field_maps_to_structs
 
     graph = FeatureGraph()
 
@@ -279,11 +282,11 @@ def test_provenance_snapshot(
         id_columns = list(child_plan.feature.id_columns)
         available_cols = [c for c in id_columns + provenance_cols if c in added_df.columns]
 
-        # Sort for deterministic output and convert to dicts
-        result_df = added_df.select(available_cols).sort(available_cols)
-        # Convert to native Polars for to_dicts()
-        result_pl = result_df.to_native()
-        snapshot_data = result_pl.to_dicts()
+        # The versioning engine emits the *_by_field columns as polars_map.Map. Preserve
+        # them through collection, convert back to Struct for readable snapshot dicts, then
+        # sort on the (now Struct) columns for deterministic output.
+        result_pl = by_field_maps_to_structs(collect_to_polars(added_df).select(available_cols))
+        snapshot_data = result_pl.sort(available_cols).to_dicts()
 
         # Assert against snapshot
         assert snapshot_data == snapshot

--- a/tests/metadata_stores/core/test_rebase.py
+++ b/tests/metadata_stores/core/test_rebase.py
@@ -19,9 +19,13 @@ from metaxy import (
 from metaxy.config import MetaxyConfig
 from metaxy.ext.polars.handlers.delta import DeltaMetadataStore
 from metaxy.metadata_store.system.storage import SystemTableStorage
+from metaxy.utils import collect_to_polars
+from metaxy.utils._arrow_map import convert_structs_to_maps
 from metaxy_testing.models import SampleFeatureSpec
 
-from metaxy_testing import TempFeatureModule, add_metaxy_provenance_column
+from metaxy_testing import TempFeatureModule, add_metaxy_provenance_column, by_field_maps_to_structs
+
+BY_FIELD_COLUMNS = ["metaxy_provenance_by_field", "metaxy_data_version_by_field"]
 
 UPSTREAM_KEY = FeatureKey(["test", "upstream"])
 DOWNSTREAM_KEY = FeatureKey(["test", "downstream"])
@@ -99,7 +103,7 @@ def test_rebase_updates_provenance(store: MetadataStore, make_graph: list[TempFe
         store.write(UPSTREAM_KEY, upstream_data)
 
         increment = store.resolve_update(DOWNSTREAM_KEY)
-        store.write(DOWNSTREAM_KEY, increment.new.to_polars())
+        store.write(DOWNSTREAM_KEY, collect_to_polars(increment.new))
 
         old_feature_version = temp_module_v1.graph.get_feature_version(DOWNSTREAM_KEY)
 
@@ -132,16 +136,14 @@ def test_rebase_updates_provenance(store: MetadataStore, make_graph: list[TempFe
             to_feature_version=new_feature_version,
         )
 
-        store.write(DOWNSTREAM_KEY, rebased.to_native(), preserve_feature_version=True)
+        store.write(DOWNSTREAM_KEY, collect_to_polars(rebased), preserve_feature_version=True)
 
-        result = (
+        result = collect_to_polars(
             store.read(
                 DOWNSTREAM_KEY,
                 with_feature_history=True,
                 filters=[nw.col("metaxy_feature_version") == new_feature_version],
             )
-            .collect()
-            .to_polars()
         )
 
         assert result.height == 3
@@ -152,7 +154,8 @@ def test_rebase_updates_provenance(store: MetadataStore, make_graph: list[TempFe
         assert result["metaxy_project_version"].unique().to_list() == [expected_project_version]
 
         # provenance_by_field should have entries for all downstream fields
-        for row_pbf in result["metaxy_provenance_by_field"].to_list():
+        result_structs = by_field_maps_to_structs(result, ["metaxy_provenance_by_field"])
+        for row_pbf in result_structs["metaxy_provenance_by_field"].to_list():
             for field_key in expected_version_by_field:
                 assert field_key in row_pbf
 
@@ -200,10 +203,10 @@ def test_rebase_recalculates_provenance_by_field(tmp_path: Path, make_graph: lis
         store.write(UPSTREAM_KEY, upstream_data)
 
         increment = store.resolve_update(DOWNSTREAM_KEY)
-        store.write(DOWNSTREAM_KEY, increment.new.to_polars())
+        store.write(DOWNSTREAM_KEY, collect_to_polars(increment.new))
 
         old_feature_version = temp_v1.graph.get_feature_version(DOWNSTREAM_KEY)
-        old_pbf = increment.new.to_polars()["metaxy_provenance_by_field"].to_list()
+        old_pbf = by_field_maps_to_structs(collect_to_polars(increment.new))["metaxy_provenance_by_field"].to_list()
 
         storage = SystemTableStorage(store)
         storage.push_graph_snapshot()
@@ -244,22 +247,20 @@ def test_rebase_recalculates_provenance_by_field(tmp_path: Path, make_graph: lis
         )
 
         rebased = store.rebase(DOWNSTREAM_KEY, existing, to_feature_version=new_feature_version)
-        store.write(DOWNSTREAM_KEY, rebased.to_native(), preserve_feature_version=True)
+        store.write(DOWNSTREAM_KEY, collect_to_polars(rebased), preserve_feature_version=True)
 
-        result = (
+        result = collect_to_polars(
             store.read(
                 DOWNSTREAM_KEY,
                 with_feature_history=True,
                 filters=[nw.col("metaxy_feature_version") == new_feature_version],
             )
-            .collect()
-            .to_polars()
         )
 
         assert result.height == 2
 
         # provenance_by_field must differ from v1 — it should now have the "extra" key
-        new_pbf = result["metaxy_provenance_by_field"].to_list()
+        new_pbf = by_field_maps_to_structs(result)["metaxy_provenance_by_field"].to_list()
         assert new_pbf != old_pbf
         for row_pbf in new_pbf:
             assert "default" in row_pbf
@@ -281,7 +282,7 @@ def test_rebase_defaults_to_current_version(store: MetadataStore, make_graph: li
         store.write(UPSTREAM_KEY, upstream_data)
 
         increment = store.resolve_update(DOWNSTREAM_KEY)
-        store.write(DOWNSTREAM_KEY, increment.new.to_polars())
+        store.write(DOWNSTREAM_KEY, collect_to_polars(increment.new))
 
         old_feature_version = temp_module_v1.graph.get_feature_version(DOWNSTREAM_KEY)
 
@@ -302,21 +303,19 @@ def test_rebase_defaults_to_current_version(store: MetadataStore, make_graph: li
             existing,
         )
 
-        collected = rebased.lazy().collect().to_polars()
+        collected = collect_to_polars(rebased)
         assert collected.height == 3
         # Feature version should be set to the current graph's version
         assert collected["metaxy_feature_version"][0] == new_feature_version
 
         store.write(DOWNSTREAM_KEY, collected, preserve_feature_version=True)
 
-        result = (
+        result = collect_to_polars(
             store.read(
                 DOWNSTREAM_KEY,
                 with_feature_history=True,
                 filters=[nw.col("metaxy_feature_version") == new_feature_version],
             )
-            .collect()
-            .to_polars()
         )
         assert result.height == 3
 
@@ -336,7 +335,7 @@ def test_rebase_unknown_version_raises(store: MetadataStore, make_graph: list[Te
         store.write(UPSTREAM_KEY, upstream_data)
 
         increment = store.resolve_update(DOWNSTREAM_KEY)
-        store.write(DOWNSTREAM_KEY, increment.new.to_polars())
+        store.write(DOWNSTREAM_KEY, collect_to_polars(increment.new))
 
         existing = store.read(DOWNSTREAM_KEY)
 
@@ -383,9 +382,11 @@ def test_rebase_preserves_user_data_version(store: MetadataStore, make_graph: li
         store.write(UPSTREAM_KEY, upstream_data)
 
         increment = store.resolve_update(DOWNSTREAM_KEY)
-        store.write(DOWNSTREAM_KEY, increment.new.to_polars())
+        store.write(DOWNSTREAM_KEY, collect_to_polars(increment.new))
 
-        v1_data = store.read(DOWNSTREAM_KEY).collect().to_polars()
+        # Read back with the *_by_field Map columns converted to Struct so the Struct
+        # literal override below unifies with the existing column dtype.
+        v1_data = by_field_maps_to_structs(collect_to_polars(store.read(DOWNSTREAM_KEY)))
         old_provenance = v1_data["metaxy_provenance"].to_list()
         old_data_version = v1_data["metaxy_data_version"].to_list()
         assert old_provenance == old_data_version  # default: data_version == provenance
@@ -403,7 +404,7 @@ def test_rebase_preserves_user_data_version(store: MetadataStore, make_graph: li
             .otherwise(pl.col("metaxy_data_version_by_field"))
             .alias("metaxy_data_version_by_field"),
         )
-        store.write(DOWNSTREAM_KEY, overridden)
+        store.write(DOWNSTREAM_KEY, convert_structs_to_maps(overridden, BY_FIELD_COLUMNS))
 
         old_feature_version = temp_module_v1.graph.get_feature_version(DOWNSTREAM_KEY)
 
@@ -431,24 +432,22 @@ def test_rebase_preserves_user_data_version(store: MetadataStore, make_graph: li
             to_feature_version=new_feature_version,
         )
 
-        store.write(DOWNSTREAM_KEY, rebased.to_native(), preserve_feature_version=True)
+        store.write(DOWNSTREAM_KEY, collect_to_polars(rebased), preserve_feature_version=True)
 
-        result = (
+        result = collect_to_polars(
             store.read(
                 DOWNSTREAM_KEY,
                 with_feature_history=True,
                 filters=[nw.col("metaxy_feature_version") == new_feature_version],
             )
-            .collect()
-            .to_polars()
-            .sort("sample_uid")
-        )
+        ).sort("sample_uid")
 
         assert result.height == 3
 
         # Row 0 (sample_uid=1): user-overridden data_version should be preserved
+        result_structs = by_field_maps_to_structs(result)
         assert result["metaxy_data_version"][0] == custom_dv
-        assert result["metaxy_data_version_by_field"][0] == custom_dv_by_field
+        assert result_structs["metaxy_data_version_by_field"][0] == custom_dv_by_field
 
         # Rows 1-2 (sample_uid=2,3): default data_version should match new provenance
         for i in [1, 2]:
@@ -470,7 +469,7 @@ def test_write_fills_null_data_version_from_provenance(store: MetadataStore, mak
         store.write(UPSTREAM_KEY, upstream_data)
 
         increment = store.resolve_update(DOWNSTREAM_KEY)
-        base_data = increment.new.to_polars()
+        base_data = collect_to_polars(increment.new)
 
         custom_dv_by_field = {"default": "custom_hash"}
         df_with_nulls = base_data.with_columns(
@@ -480,15 +479,26 @@ def test_write_fills_null_data_version_from_provenance(store: MetadataStore, mak
             .alias("metaxy_data_version_by_field"),
         ).drop("metaxy_data_version")
 
+        # data_version_by_field was rebuilt as a Struct literal above while
+        # provenance_by_field stays Map — normalize both to Map before writing.
+        # Struct->Map conversion turns null structs into non-null maps holding null
+        # values, so re-mask the non-custom rows to true nulls that write() then fills.
+        df_with_nulls = convert_structs_to_maps(df_with_nulls, BY_FIELD_COLUMNS).with_columns(
+            pl.when(pl.col("sample_uid") == 1)
+            .then(pl.col("metaxy_data_version_by_field"))
+            .otherwise(None)
+            .alias("metaxy_data_version_by_field")
+        )
         store.write(DOWNSTREAM_KEY, df_with_nulls)
 
-        result = store.read(DOWNSTREAM_KEY).collect().to_polars().sort("sample_uid")
+        result = collect_to_polars(store.read(DOWNSTREAM_KEY)).sort("sample_uid")
 
         assert result.height == 3
 
         # Row 0 (sample_uid=1): custom data_version_by_field preserved
-        assert result["metaxy_data_version_by_field"][0] == custom_dv_by_field
+        result_structs = by_field_maps_to_structs(result)
+        assert result_structs["metaxy_data_version_by_field"][0] == custom_dv_by_field
 
         # Rows 1-2: null data_version_by_field filled from provenance
         for i in [1, 2]:
-            assert result["metaxy_data_version_by_field"][i] == result["metaxy_provenance_by_field"][i]
+            assert result_structs["metaxy_data_version_by_field"][i] == result_structs["metaxy_provenance_by_field"][i]

--- a/tests/metadata_stores/core/test_resolve_update_root_features.py
+++ b/tests/metadata_stores/core/test_resolve_update_root_features.py
@@ -17,7 +17,7 @@ from metaxy.models.types import FeatureKey, FieldKey
 from metaxy_testing.models import SampleFeature, SampleFeatureSpec
 from pytest_cases import parametrize_with_cases
 
-from metaxy_testing import add_metaxy_provenance_column
+from metaxy_testing import add_metaxy_provenance_column, by_field_maps_to_structs
 from tests.metadata_stores.conftest import (
     BasicStoreCases,
 )
@@ -273,8 +273,9 @@ class TestResolveUpdateRootFeatures:
             assert METAXY_DATA_VERSION in result.new.columns
             assert METAXY_DATA_VERSION_BY_FIELD in result.new.columns
 
-            # Verify custom data_version values are preserved (different from provenance)
-            added_df = result.new.to_polars()
+            # Verify custom data_version values are preserved (different from provenance).
+            # Map columns are rendered as Structs so the by-field values compare as dicts.
+            added_df = by_field_maps_to_structs(result.new.to_polars())
             for row in added_df.iter_rows(named=True):
                 # Data version should be the custom value, not provenance
                 assert row[METAXY_DATA_VERSION] == "custom_v1"

--- a/tests/metadata_stores/core/test_resolve_update_skip_comparison.py
+++ b/tests/metadata_stores/core/test_resolve_update_skip_comparison.py
@@ -29,7 +29,7 @@ from metaxy_testing.models import SampleFeature, SampleFeatureSpec
 from pytest_cases import parametrize_with_cases
 from syrupy.assertion import SnapshotAssertion
 
-from metaxy_testing import add_metaxy_provenance_column
+from metaxy_testing import add_metaxy_provenance_column, by_field_maps_to_structs
 from tests.metadata_stores.conftest import (
     BasicStoreCases,
 )
@@ -110,8 +110,8 @@ class TestResolveUpdateSkipComparisonRootFeatures:
             assert METAXY_DATA_VERSION in result.new.columns
             assert METAXY_DATA_VERSION_BY_FIELD in result.new.columns
 
-            # Verify provenance_by_field matches input
-            added_df = result.new.to_polars().sort("sample_uid")
+            # Verify provenance_by_field matches input (Map columns rendered as Structs for comparison)
+            added_df = by_field_maps_to_structs(result.new.to_polars().sort("sample_uid"))
             assert added_df[METAXY_PROVENANCE_BY_FIELD].to_list() == [
                 {"embedding": "hash1"},
                 {"embedding": "hash2"},

--- a/tests/metadata_stores/core/test_validate_schema.py
+++ b/tests/metadata_stores/core/test_validate_schema.py
@@ -15,7 +15,7 @@ from polars_map import Map
 
 @pytest.fixture
 def polars_map_config() -> Iterator[MetaxyConfig]:
-    config = MetaxyConfig(enable_map_datatype=True)
+    config = MetaxyConfig()
     with config.use():
         yield config
 
@@ -34,12 +34,6 @@ class TestIsMapColumn:
         arrow_table = pa.table({"x": pa.array([[("k", "v")]], type=pa.map_(pa.string(), pa.string()))})
         nw_df = nw.from_native(arrow_table)
         assert _is_map_column(nw_df, "x") is True
-
-    def test_returns_false_without_config(self) -> None:
-        """Returns False when enable_map_datatype is not set."""
-        s = pl.Series("x", [[("k", "v")]], dtype=Map(pl.String(), pl.String()))
-        nw_df = nw.from_native(pl.DataFrame([s]))
-        assert _is_map_column(nw_df, "x") is False
 
     def test_struct_is_not_map(self, polars_map_config: MetaxyConfig) -> None:
         """A Polars Struct column is not Map."""

--- a/tests/metadata_stores/shared/ibis_map.py
+++ b/tests/metadata_stores/shared/ibis_map.py
@@ -28,8 +28,8 @@ class IbisMapTests:
 
     @pytest.fixture()
     def polars_map_config(self) -> Iterator[MetaxyConfig]:
-        """Activate enable_map_datatype for the duration of the test."""
-        config = MetaxyConfig(enable_map_datatype=True)
+        """Provide an active MetaxyConfig for the duration of the test."""
+        config = MetaxyConfig()
         with config.use():
             yield config
 

--- a/tests/metadata_stores/shared/map_dtype.py
+++ b/tests/metadata_stores/shared/map_dtype.py
@@ -98,8 +98,8 @@ class MapDtypeTests:
 
     @pytest.fixture
     def polars_map_config(self) -> Iterator[MetaxyConfig]:
-        """Activate enable_map_datatype for the duration of the test."""
-        config = MetaxyConfig(enable_map_datatype=True)
+        """Provide an active MetaxyConfig for the duration of the test."""
+        config = MetaxyConfig()
         with config.use():
             yield config
 
@@ -687,7 +687,7 @@ class MapDtypeTests:
         from metaxy.models.types import FieldKey
         from metaxy_testing.models import SampleFeature, SampleFeatureSpec
 
-        config = MetaxyConfig(enable_map_datatype=True)
+        config = MetaxyConfig()
         with config.use():
 
             class UpstreamMap(

--- a/tests/metadata_stores/shared/resolve_update.py
+++ b/tests/metadata_stores/shared/resolve_update.py
@@ -51,7 +51,11 @@ from metaxy_testing.parametric import (
     feature_metadata_strategy,
 )
 
-from metaxy_testing import add_metaxy_provenance_column
+from metaxy_testing import (
+    add_metaxy_provenance_column,
+    by_field_maps_to_structs,
+    normalize_by_field_maps,
+)
 
 # Type alias for feature plan output
 FeaturePlanOutput = tuple[FeatureGraph, Mapping[FeatureKey, type[BaseFeature]], FeaturePlan]
@@ -280,7 +284,9 @@ def _setup_upstream_and_downstream(
         )
         downstream_df = downstream_df.join(extra_df, on="sample_uid", how="left")
 
-    store.write(downstream_cls, downstream_df)
+    # resolve_update output surfaces the *_by_field columns as List(Struct); restore
+    # the Map dtype the store expects on write.
+    store.write(downstream_cls, normalize_by_field_maps(downstream_df))
 
 
 def _make_features(graph: FeatureGraph) -> tuple[Any, Any]:
@@ -452,8 +458,8 @@ class ResolveUpdateTests:
             assert len(increment.orphaned) == 0
 
             # Verify provenance_by_field structure matches input
-            added_df = increment.new.lazy().collect().to_polars().sort(id_columns)
-            samples_sorted = samples_df.sort(id_columns)
+            added_df = normalize_by_field_maps(increment.new.lazy().collect().to_polars().sort(id_columns))
+            samples_sorted = normalize_by_field_maps(samples_df.sort(id_columns))
 
             pl_testing.assert_series_equal(
                 added_df["metaxy_provenance_by_field"],
@@ -523,8 +529,8 @@ class ResolveUpdateTests:
             common_columns = [
                 col for col in added_sorted.columns if col in golden_sorted.columns and col != METAXY_CREATED_AT
             ]
-            added_selected = added_sorted.select(common_columns)
-            golden_selected = golden_sorted.select(common_columns)
+            added_selected = normalize_by_field_maps(added_sorted.select(common_columns))
+            golden_selected = normalize_by_field_maps(golden_sorted.select(common_columns))
 
             pl_testing.assert_frame_equal(
                 added_selected,
@@ -776,7 +782,7 @@ class ResolveUpdateTests:
                 assert len(increment1.new) > 0, "Expected resolve_update to detect added samples"
 
                 # Write the increment
-                added_df = increment1.new.lazy().collect().to_polars()
+                added_df = normalize_by_field_maps(increment1.new.lazy().collect().to_polars())
                 store.write(child_key, added_df)
 
                 # Second resolve_update - should be empty
@@ -1095,7 +1101,7 @@ class ResolveUpdateTests:
                 }
             )
             # Join with upstream to get proper data_version columns
-            upstream_df = store.read(Video).collect().to_polars()
+            upstream_df = normalize_by_field_maps(store.read(Video).collect().to_polars())
             first_batch_joined = first_batch.join(
                 upstream_df.select(["video_id", "metaxy_data_version_by_field", "metaxy_provenance"]).rename(
                     {
@@ -1228,7 +1234,7 @@ class ResolveUpdateTests:
             frames_df = pl.DataFrame(frame_rows)
 
             # Join with upstream to compute proper provenance
-            upstream_df = store.read(Video).collect().to_polars()
+            upstream_df = normalize_by_field_maps(store.read(Video).collect().to_polars())
             frames_joined = frames_df.join(
                 upstream_df.select(["video_id", "metaxy_data_version_by_field", "metaxy_provenance"]).rename(
                     {
@@ -1347,7 +1353,7 @@ class ResolveUpdateTests:
                     "embedding": ["emb_v1_0", "emb_v1_1", "emb_v2_0", "emb_v2_1"],
                 }
             )
-            upstream_df = store.read(Video).collect().to_polars()
+            upstream_df = normalize_by_field_maps(store.read(Video).collect().to_polars())
             first_batch_joined = first_batch.join(
                 upstream_df.select(["video_id", "metaxy_data_version_by_field", "metaxy_provenance"]).rename(
                     {
@@ -1460,7 +1466,7 @@ class ResolveUpdateTests:
                     "result": [f"result_{i}" for i in range(10)],
                 }
             )
-            upstream_df = store.read(Upstream).collect().to_polars()
+            upstream_df = normalize_by_field_maps(store.read(Upstream).collect().to_polars())
             downstream_joined = downstream_batch.join(
                 upstream_df.select(["chunk_id", "metaxy_data_version_by_field", "metaxy_provenance"]).rename(
                     {
@@ -1572,7 +1578,7 @@ class ResolveUpdateTests:
                     "result": [f"result_{i}" for i in range(10)],
                 }
             )
-            upstream_df = store.read(Upstream).collect().to_polars()
+            upstream_df = normalize_by_field_maps(store.read(Upstream).collect().to_polars())
             downstream_joined = downstream_batch.join(
                 upstream_df.select(["chunk_id", "metaxy_data_version_by_field", "metaxy_provenance"]).rename(
                     {
@@ -1690,7 +1696,7 @@ class ResolveUpdateTests:
 
             # User reads upstream from fallback (via local_store) and materializes downstream
             # This should read 100 chunks from fallback
-            upstream_df = local_store.read(Upstream).collect().to_polars()
+            upstream_df = normalize_by_field_maps(local_store.read(Upstream).collect().to_polars())
             assert len(upstream_df) == 100, f"Expected 100 upstream rows from fallback, got {len(upstream_df)}"
 
             # User computes and writes downstream for all 100 chunks
@@ -1814,8 +1820,8 @@ class ResolveUpdateTests:
                 ]
 
                 # Sort by all comparable columns for deterministic comparison
-                actual_sorted = actual_added.sort(common_columns).select(common_columns)
-                golden_sorted = golden_added.sort(common_columns).select(common_columns)
+                actual_sorted = normalize_by_field_maps(actual_added.sort(common_columns).select(common_columns))
+                golden_sorted = normalize_by_field_maps(golden_added.sort(common_columns).select(common_columns))
 
                 pl_testing.assert_frame_equal(
                     actual_sorted,
@@ -1943,7 +1949,8 @@ class ResolveUpdateTests:
 
                 # Initial resolve
                 increment_v1 = store.resolve_update(ChildFeature)
-                initial_downstream = increment_v1.new.lazy().collect().to_polars()
+                # Convert Map *_by_field columns to Struct so per-field values are indexable.
+                initial_downstream = by_field_maps_to_structs(increment_v1.new.lazy().collect().to_polars())
 
                 # === VERIFY NULL HANDLING ===
                 # Should have all 3 samples (left join keeps s2 even though optional parent is missing)
@@ -1988,7 +1995,7 @@ class ResolveUpdateTests:
                 # === VERIFY PROVENANCE STABILITY FOR MISSING OPTIONAL DEP ===
                 changed_df = increment_v2.stale
                 assert changed_df is not None, "Expected changed to not be None"
-                changed_downstream = changed_df.lazy().collect().to_polars()
+                changed_downstream = by_field_maps_to_structs(changed_df.lazy().collect().to_polars())
 
                 # s1 and s3 should be in changed (they had actual optional dep values)
                 changed_uids = set(changed_downstream["sample_uid"].to_list())
@@ -2238,7 +2245,8 @@ class ResolveUpdateTests:
 
                 # Initial resolve - creates downstream
                 increment_v1 = store.resolve_update(HourlyStats)
-                initial_downstream = increment_v1.new.lazy().collect().to_polars()
+                # Convert Map *_by_field columns to Struct so per-field values are indexable.
+                initial_downstream = by_field_maps_to_structs(increment_v1.new.lazy().collect().to_polars())
                 store.write(HourlyStats, initial_downstream)
 
                 # Get initial provenance
@@ -2273,7 +2281,7 @@ class ResolveUpdateTests:
                 # Here sensor s1 has 2 readings (r1, r2), so we expect 2 changed rows.
                 changed_df = increment_v2.stale
                 assert changed_df is not None, "Expected changed to not be None"
-                changed_downstream = changed_df.lazy().collect().to_polars()
+                changed_downstream = by_field_maps_to_structs(changed_df.lazy().collect().to_polars())
                 assert len(changed_downstream) == 2, "Expected 2 changed rows (one per reading in aggregation group)"
 
                 # All rows in the aggregation group have identical provenance
@@ -2400,7 +2408,7 @@ class ResolveUpdateTests:
 
                     increment_v1 = store.resolve_update(HourlyStatsV1)
 
-                    result_v1 = increment_v1.new.lazy().collect().to_polars()
+                    result_v1 = by_field_maps_to_structs(increment_v1.new.lazy().collect().to_polars())
                     v1_prov_by_field = result_v1["metaxy_provenance_by_field"][0]
                     v1_avg_temp = v1_prov_by_field["avg_temp"]
                     v1_avg_humidity = v1_prov_by_field["avg_humidity"]
@@ -2490,7 +2498,7 @@ class ResolveUpdateTests:
 
                     increment_v2 = store.resolve_update(HourlyStatsV2)
 
-                    result_v2 = increment_v2.new.lazy().collect().to_polars()
+                    result_v2 = by_field_maps_to_structs(increment_v2.new.lazy().collect().to_polars())
                     v2_prov_by_field = result_v2["metaxy_provenance_by_field"][0]
                     v2_avg_temp = v2_prov_by_field["avg_temp"]
                     v2_avg_humidity = v2_prov_by_field["avg_humidity"]
@@ -2836,7 +2844,7 @@ class ResolveUpdateTests:
 
             # Resolve and write downstream for sample 1 with extra column
             inc = store.resolve_update(DownstreamFeature)
-            downstream_df = inc.new.to_polars().with_columns(pl.Series("dataset", ["mead"]))
+            downstream_df = normalize_by_field_maps(inc.new.to_polars().with_columns(pl.Series("dataset", ["mead"])))
             store.write(DownstreamFeature, downstream_df)
 
             # Now add sample 2 to upstream
@@ -2875,7 +2883,7 @@ class ResolveUpdateTests:
             store.write(UpstreamFeature, upstream_data)
 
             inc = store.resolve_update(DownstreamFeature)
-            downstream_df = inc.new.to_polars().with_columns(pl.Series("needs_reprocess", [1]))
+            downstream_df = normalize_by_field_maps(inc.new.to_polars().with_columns(pl.Series("needs_reprocess", [1])))
             store.write(DownstreamFeature, downstream_df)
 
             result = store.resolve_update(

--- a/tests/metadata_stores/shared/versioning.py
+++ b/tests/metadata_stores/shared/versioning.py
@@ -31,11 +31,12 @@ from metaxy.metadata_store import (
 from metaxy.models.field import SpecialFieldDep
 from metaxy.models.plan import FeaturePlan
 from metaxy.models.types import FieldKey
-from metaxy.utils import collect_to_polars
 from metaxy.versioning.types import HashAlgorithm, Increment
 from metaxy_testing.models import SampleFeature, SampleFeatureSpec
 from metaxy_testing.parametric import downstream_metadata_strategy
 from syrupy.assertion import SnapshotAssertion
+
+from metaxy_testing import normalize_by_field_maps
 
 if TYPE_CHECKING:
     pass
@@ -588,8 +589,8 @@ def assert_increment_matches_golden(
         common_columns = [
             col for col in actual_sorted.columns if col in golden_sorted.columns and col != METAXY_CREATED_AT
         ]
-        actual_selected = actual_sorted.select(common_columns)
-        golden_selected = golden_sorted.select(common_columns)
+        actual_selected = normalize_by_field_maps(actual_sorted.select(common_columns))
+        golden_selected = normalize_by_field_maps(golden_sorted.select(common_columns))
 
         pl_testing.assert_frame_equal(
             actual_selected,
@@ -861,7 +862,7 @@ class VersioningTests:
                 # Add older duplicates to upstream metadata
                 for feature_key, upstream_feature in upstream_features.items():
                     # Read existing upstream data
-                    existing_df = store_.read(upstream_feature).lazy().collect().to_polars()
+                    existing_df = normalize_by_field_maps(store_.read(upstream_feature).lazy().collect().to_polars())
 
                     # Create older duplicates (same IDs, older timestamps)
                     older_df = existing_df.clone()
@@ -913,8 +914,8 @@ class VersioningTests:
             added_sorted = added_df.sort(common_columns)
             golden_sorted = golden_downstream.sort(common_columns)
 
-            added_selected = added_sorted.select(common_columns)
-            golden_selected = golden_sorted.select(common_columns)
+            added_selected = normalize_by_field_maps(added_sorted.select(common_columns))
+            golden_selected = normalize_by_field_maps(golden_sorted.select(common_columns))
 
             # Verify that computed provenance matches golden reference
             # This proves deduplication worked correctly - only latest versions were used
@@ -1051,7 +1052,7 @@ class VersioningTests:
 
                 # Add older duplicates for only HALF of the samples in each upstream
                 for feature_key, upstream_feature in upstream_features.items():
-                    existing_df = store_.read(upstream_feature).lazy().collect().to_polars()
+                    existing_df = normalize_by_field_maps(store_.read(upstream_feature).lazy().collect().to_polars())
 
                     # Get half of samples
                     num_samples = len(existing_df)
@@ -1092,8 +1093,8 @@ class VersioningTests:
                 added_sorted = added_df.sort(common_columns)
                 golden_sorted = golden_downstream.sort(common_columns)
 
-                added_selected = added_sorted.select(common_columns)
-                golden_selected = golden_sorted.select(common_columns)
+                added_selected = normalize_by_field_maps(added_sorted.select(common_columns))
+                golden_selected = normalize_by_field_maps(golden_sorted.select(common_columns))
 
                 # Verify provenance matches golden reference
                 pl_testing.assert_frame_equal(
@@ -1196,7 +1197,9 @@ class VersioningTests:
                             }
                         )
 
-                expanded_df = pl.DataFrame(expanded_rows)
+                # Rebuilding a DataFrame from Map values read back from the store yields
+                # List(Struct({key, value})); normalize back to the Map dtype before writing.
+                expanded_df = normalize_by_field_maps(pl.DataFrame(expanded_rows))
                 store.write(VideoFrames, expanded_df)
 
                 # Verify 6 rows stored (2 videos x 3 frames)
@@ -1245,65 +1248,6 @@ class VersioningTests:
 
         except HashAlgorithmNotSupportedError:
             pytest.skip(f"Hash algorithm {store.hash_algorithm} not supported by {store}")
-
-    def test_enable_map_datatype_does_not_affect_versioning(
-        self,
-        store: MetadataStore,
-        feature_plan_sequence: FeaturePlanSequence,
-    ) -> None:
-        """Toggling enable_map_datatype must not change versioning results.
-
-        Writes upstream data once, then runs resolve_update with the flag off
-        and on, asserting both produce identical increments.
-        """
-        feature_plan_config = feature_plan_sequence[0]
-        graph, upstream_features, child_feature_plan = feature_plan_config
-        child_key = child_feature_plan.feature.key
-        child_version = graph.get_feature_version(child_key)
-
-        upstream_data, _ = generate_plan_data(store, feature_plan_config)
-
-        try:
-            with store.open("w"), graph.use():
-                write_upstream_to_store(store, feature_plan_config, upstream_data)
-
-                def _resolve_with_map_flag(enabled: bool) -> pl.DataFrame:
-                    config = MetaxyConfig.get().model_copy(update={"enable_map_datatype": enabled})
-                    with config.use():
-                        increment = store.resolve_update(
-                            child_key,
-                            target_version=child_version,
-                            project_version=graph.project_version,
-                        )
-                        return collect_to_polars(increment.new)
-
-                result_off = _resolve_with_map_flag(False)
-                result_on = _resolve_with_map_flag(True)
-
-        except HashAlgorithmNotSupportedError:
-            pytest.skip(f"Hash algorithm {store.hash_algorithm} not supported by {store}")
-
-        assert len(result_off) > 0, "Expected non-empty versioning result"
-
-        from metaxy.models.constants import METAXY_CREATED_AT, METAXY_DATA_VERSION_BY_FIELD, METAXY_PROVENANCE_BY_FIELD
-        from metaxy.utils._arrow_map import convert_structs_to_maps
-
-        # Normalize result_off's Struct _by_field columns to polars_map.Map so
-        # both frames have the same type and values can be compared.
-        by_field_columns = [
-            c
-            for c in (METAXY_DATA_VERSION_BY_FIELD, METAXY_PROVENANCE_BY_FIELD)
-            if c in result_off.columns and c in result_on.columns
-        ]
-        result_off = convert_structs_to_maps(result_off, columns=by_field_columns)
-
-        common_columns = [c for c in result_off.columns if c in result_on.columns and c != METAXY_CREATED_AT]
-        pl_testing.assert_frame_equal(
-            result_off.select(common_columns).sort(common_columns),
-            result_on.select(common_columns).sort(common_columns),
-            check_row_order=True,
-            check_column_order=False,
-        )
 
     @pytest.mark.parametrize("truncation_length", [16])
     def test_hash_truncation_any_store(

--- a/tests/metaxy_testing/src/metaxy_testing/__init__.py
+++ b/tests/metaxy_testing/src/metaxy_testing/__init__.py
@@ -22,8 +22,11 @@ from metaxy_testing.metaxy_project import (
 )
 from metaxy_testing.models import SampleFeature, SampleFeatureSpec
 from metaxy_testing.pytest_helpers import (
+    BY_FIELD_MAP_COLUMNS,
     add_metaxy_provenance_column,
     add_metaxy_system_columns,
+    by_field_maps_to_structs,
+    normalize_by_field_maps,
 )
 from metaxy_testing.runbook import (
     ApplyPatchStep,
@@ -76,6 +79,9 @@ __all__ = [
     # Pytest helpers
     "add_metaxy_provenance_column",
     "add_metaxy_system_columns",
+    "normalize_by_field_maps",
+    "by_field_maps_to_structs",
+    "BY_FIELD_MAP_COLUMNS",
     # Testing models
     "SampleFeatureSpec",
     "SampleFeature",

--- a/tests/metaxy_testing/src/metaxy_testing/pytest_helpers.py
+++ b/tests/metaxy_testing/src/metaxy_testing/pytest_helpers.py
@@ -12,15 +12,66 @@ from metaxy.models.constants import (
     METAXY_PROVENANCE,
     METAXY_PROVENANCE_BY_FIELD,
 )
+from metaxy.utils._arrow_map import convert_maps_to_polars_map, convert_structs_to_maps
 from narwhals.typing import IntoFrameT
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from metaxy import CoercibleToFeatureKey
     from metaxy.models.feature import BaseFeature
     from metaxy.models.feature_definition import FeatureDefinition
     from metaxy.versioning.types import HashAlgorithm
 
 FrameT = TypeVar("FrameT", bound=nw.DataFrame | nw.LazyFrame)
+PolarsFrameT = TypeVar("PolarsFrameT", pl.DataFrame, pl.LazyFrame)
+
+# The metaxy system columns that the versioning engine and stores emit as the
+# ``polars_map.Map(String, String)`` extension dtype (always-on Map behavior).
+BY_FIELD_MAP_COLUMNS: tuple[str, ...] = (METAXY_PROVENANCE_BY_FIELD, METAXY_DATA_VERSION_BY_FIELD)
+
+
+def normalize_by_field_maps(
+    df: PolarsFrameT,
+    columns: Sequence[str] = BY_FIELD_MAP_COLUMNS,
+) -> PolarsFrameT:
+    """Canonicalize metaxy ``*_by_field`` columns to the ``polars_map.Map`` extension dtype.
+
+    Store output collected through Narwhals surfaces these columns as plain
+    ``List(Struct({key, value}))``, while the versioning engine emits the
+    ``polars_map.Map`` extension type. Test data may also build them as ``Struct``.
+    This normalizes any of those three representations to ``polars_map.Map`` so both
+    sides of a comparison (or a frame about to be written) share one representation.
+    Only the requested columns are touched, and only when they need converting.
+    """
+    df = convert_structs_to_maps(df, columns)
+    return convert_maps_to_polars_map(df, columns)
+
+
+def by_field_maps_to_structs(
+    df: pl.DataFrame,
+    columns: Sequence[str] = BY_FIELD_MAP_COLUMNS,
+) -> pl.DataFrame:
+    """Convert metaxy ``*_by_field`` Map columns back to ``Struct`` for element access.
+
+    Map scalars do not support ``value["field"]`` indexing, so tests that inspect
+    individual field hashes convert the Map columns to Struct first. Accepts Struct,
+    ``List(Struct({key, value}))``, or ``polars_map.Map`` inputs.
+    """
+    import polars_map  # noqa: F401  # registers the ``.map`` accessor
+
+    df = normalize_by_field_maps(df, columns)
+    struct_exprs: list[pl.Expr] = []
+    for col in columns:
+        if col not in df.schema:
+            continue
+        field_names = df[col].map.keys().explode().drop_nulls().unique().sort().to_list()  # ty: ignore[unresolved-attribute]
+        struct_exprs.append(
+            pl.struct([pl.col(col).map.get(name).alias(name) for name in field_names]).alias(col)  # ty: ignore[unresolved-attribute]
+        )
+    if struct_exprs:
+        df = df.with_columns(struct_exprs)
+    return df
 
 
 def add_metaxy_system_columns(df: IntoFrameT) -> IntoFrameT:

--- a/tests/parametric/test_metadata_strategies.py
+++ b/tests/parametric/test_metadata_strategies.py
@@ -18,6 +18,9 @@ from metaxy_testing.parametric import (
     feature_metadata_strategy,
     upstream_metadata_strategy,
 )
+from polars_map import Map
+
+from metaxy_testing import by_field_maps_to_structs
 
 # System columns expected in test-generated metadata (excludes metaxy_materialization_id
 # which is only added when an external materialization ID is provided)
@@ -413,15 +416,18 @@ def test_downstream_metadata_strategy_single_upstream(graph: FeatureGraph) -> No
         assert len(downstream_df) == len(parent_df)  # Same number of rows after join
         assert EXPECTED_SYSTEM_COLUMNS.issubset(set(downstream_df.columns))
 
-        # Check downstream provenance structure
-        provenance_schema = downstream_df.schema[METAXY_PROVENANCE_BY_FIELD]
+        # Downstream metaxy *_by_field columns are Map; convert to Struct to inspect
+        # field-keyed hashes as plain dicts.
+        assert downstream_df.schema[METAXY_PROVENANCE_BY_FIELD] == Map(pl.String(), pl.String())
+        downstream_structs = by_field_maps_to_structs(downstream_df)
+        provenance_schema = downstream_structs.schema[METAXY_PROVENANCE_BY_FIELD]
         assert isinstance(provenance_schema, pl.Struct)
         field_names = {field.name for field in provenance_schema.fields}
         assert field_names == {"child_field"}
 
         # Check that provenance values are correctly truncated
         # Note: xxhash64 as decimal can be up to 20 chars, test uses hash_truncation_length
-        for row in downstream_df.iter_rows(named=True):
+        for row in downstream_structs.iter_rows(named=True):
             provenance = row[METAXY_PROVENANCE_BY_FIELD]
             assert "child_field" in provenance
             assert isinstance(provenance["child_field"], str)
@@ -505,13 +511,15 @@ def test_downstream_metadata_strategy_multiple_upstreams(graph: FeatureGraph) ->
         # Check downstream has correct structure
         assert EXPECTED_SYSTEM_COLUMNS.issubset(set(downstream_df.columns))
 
-        provenance_dtype = downstream_df.schema[METAXY_PROVENANCE_BY_FIELD]
+        assert downstream_df.schema[METAXY_PROVENANCE_BY_FIELD] == Map(pl.String(), pl.String())
+        downstream_structs = by_field_maps_to_structs(downstream_df)
+        provenance_dtype = downstream_structs.schema[METAXY_PROVENANCE_BY_FIELD]
         assert isinstance(provenance_dtype, pl.Struct)
         field_names = {field.name for field in provenance_dtype.fields}
         assert field_names == {"result"}
 
         # Verify provenance is calculated (non-empty hashes)
-        for row in downstream_df.iter_rows(named=True):
+        for row in downstream_structs.iter_rows(named=True):
             provenance = row[METAXY_PROVENANCE_BY_FIELD]
             assert len(provenance["result"]) > 0
 
@@ -562,8 +570,13 @@ def test_downstream_metadata_strategy_no_truncation(graph: FeatureGraph) -> None
     def property_test(data: tuple[dict[str, pl.DataFrame], pl.DataFrame]) -> None:
         _, downstream_df = data
 
+        # Downstream metaxy *_by_field columns are Map; convert to Struct to inspect
+        # field-keyed hashes as plain dicts.
+        assert downstream_df.schema[METAXY_PROVENANCE_BY_FIELD] == Map(pl.String(), pl.String())
+        downstream_structs = by_field_maps_to_structs(downstream_df)
+
         # Without truncation, check that hashes are non-empty strings
-        for row in downstream_df.iter_rows(named=True):
+        for row in downstream_structs.iter_rows(named=True):
             provenance = row[METAXY_PROVENANCE_BY_FIELD]
             hash_value = provenance["result"]
             # Hash should be a non-empty string

--- a/tests/provenance/test_data_version_override.py
+++ b/tests/provenance/test_data_version_override.py
@@ -14,8 +14,11 @@ from metaxy.models.feature import FeatureGraph
 from metaxy.models.feature_spec import FeatureDep
 from metaxy.models.field import FieldDep, FieldSpec, SpecialFieldDep
 from metaxy.models.types import FeatureKey, FieldKey
+from metaxy.utils import collect_to_polars
 from metaxy.versioning.types import HashAlgorithm
 from metaxy_testing.models import SampleFeature, SampleFeatureSpec
+
+from metaxy_testing import by_field_maps_to_structs
 
 
 def test_basic_data_version_override(graph: FeatureGraph, snapshot) -> None:
@@ -86,7 +89,7 @@ def test_basic_data_version_override(graph: FeatureGraph, snapshot) -> None:
         filters={},
     )
 
-    result_df = result.collect().to_polars()
+    result_df = by_field_maps_to_structs(collect_to_polars(result))
 
     # Extract the computed field provenance for the child's "computed" field
     # This should be based on parent's data_version, NOT provenance
@@ -210,8 +213,8 @@ def test_propagation_chain_with_data_version(graph: FeatureGraph, snapshot) -> N
     )
 
     # Extract field provenances
-    b_field_provs = b_result.collect().to_polars()["metaxy_provenance_by_field"].to_list()
-    c_field_provs = c_result.collect().to_polars()["metaxy_provenance_by_field"].to_list()
+    b_field_provs = by_field_maps_to_structs(collect_to_polars(b_result))["metaxy_provenance_by_field"].to_list()
+    c_field_provs = by_field_maps_to_structs(collect_to_polars(c_result))["metaxy_provenance_by_field"].to_list()
 
     # B should have same field provenance for both samples
     # (because A's data_version is the same for both)
@@ -222,8 +225,8 @@ def test_propagation_chain_with_data_version(graph: FeatureGraph, snapshot) -> N
     assert c_field_provs[0]["field_c"] == c_field_provs[1]["field_c"]
 
     # Snapshot the provenance chain for B and C
-    b_df = b_result.collect().to_polars()
-    c_df = c_result.collect().to_polars()
+    b_df = by_field_maps_to_structs(collect_to_polars(b_result))
+    c_df = by_field_maps_to_structs(collect_to_polars(c_result))
 
     chain_data = {
         "feature_b": [
@@ -328,7 +331,7 @@ def test_selective_field_override(graph: FeatureGraph, snapshot) -> None:
         filters={},
     )
 
-    result_df = result.collect().to_polars()
+    result_df = by_field_maps_to_structs(collect_to_polars(result))
 
     # Extract field provenances
     field_provs = result_df["metaxy_provenance_by_field"].to_list()
@@ -416,7 +419,7 @@ def test_default_behavior_no_override(graph: FeatureGraph, snapshot) -> None:
         filters={},
     )
 
-    result_df = result.collect().to_polars()
+    result_df = by_field_maps_to_structs(collect_to_polars(result))
 
     # Extract computed field provenance
     computed_provs = [row["metaxy_provenance_by_field"]["computed"] for row in result_df.iter_rows(named=True)]
@@ -535,7 +538,7 @@ def test_multiple_upstreams_with_overrides(graph: FeatureGraph, snapshot) -> Non
         filters={},
     )
 
-    result_df = result.collect().to_polars()
+    result_df = by_field_maps_to_structs(collect_to_polars(result))
 
     # Extract fusion field provenance
     fusion_provs = [row["metaxy_provenance_by_field"]["fusion"] for row in result_df.iter_rows(named=True)]
@@ -641,7 +644,7 @@ def test_data_version_propagation_with_renames(graph: FeatureGraph, snapshot) ->
         filters={},
     )
 
-    result_df = result.collect().to_polars()
+    result_df = by_field_maps_to_structs(collect_to_polars(result))
 
     # Verify child provenance is computed correctly from parent's data_version
     computed_provs = [row["metaxy_provenance_by_field"]["computed"] for row in result_df.iter_rows(named=True)]
@@ -742,7 +745,7 @@ def test_data_version_cleanup_in_result(graph: FeatureGraph, snapshot) -> None:
     assert "metaxy_data_version" in result_columns
 
     # Snapshot the cleaned result
-    result_df_polars = result_df.to_polars()
+    result_df_polars = by_field_maps_to_structs(collect_to_polars(result_df))
     provenance_data = []
     for i in range(len(result_df_polars)):
         provenance_data.append(

--- a/tests/provenance/test_lineage_relationships.py
+++ b/tests/provenance/test_lineage_relationships.py
@@ -17,8 +17,11 @@ from metaxy.models.feature_spec import FeatureDep
 from metaxy.models.field import FieldSpec, SpecialFieldDep
 from metaxy.models.lineage import LineageRelationship
 from metaxy.models.types import FeatureKey, FieldKey
+from metaxy.utils import collect_to_polars
 from metaxy.versioning.types import HashAlgorithm
 from metaxy_testing.models import SampleFeature, SampleFeatureSpec
+
+from metaxy_testing import by_field_maps_to_structs
 
 # ============================================================================
 # Fixtures for Aggregation (N:1) scenarios
@@ -291,7 +294,7 @@ def test_identity_lineage_load_upstream(
     assert set(result_df["sample_uid"].to_list()) == {1, 2, 3}
 
     # Snapshot the identity lineage provenance
-    result_polars = result_df.to_polars()
+    result_polars = by_field_maps_to_structs(collect_to_polars(result_df))
     provenance_data = sorted(
         [
             {
@@ -717,7 +720,7 @@ def test_expansion_lineage_load_upstream(
     assert set(result_df["video_id"].to_list()) == {"v1", "v2"}
 
     # Snapshot the expansion upstream provenance
-    result_polars = result_df.to_polars()
+    result_polars = by_field_maps_to_structs(collect_to_polars(result_df))
     provenance_data = sorted(
         [
             {
@@ -761,7 +764,7 @@ def test_expansion_lineage_resolve_increment_no_current(
     assert len(added) == 2  # Two videos
 
     # Snapshot the added videos
-    added_polars = added.to_polars()
+    added_polars = by_field_maps_to_structs(collect_to_polars(added))
     added_data = sorted(
         [
             {
@@ -2679,7 +2682,7 @@ def test_aggregation_field_level_provenance_isolation(graph: FeatureGraph) -> No
     ).collect()
 
     # Get initial provenance values
-    result_v1_polars = result_v1.to_polars()
+    result_v1_polars = by_field_maps_to_structs(collect_to_polars(result_v1))
     initial_prov_by_field = result_v1_polars["metaxy_provenance_by_field"][0]
     initial_avg_temp_prov = initial_prov_by_field["avg_temp"]
     initial_avg_humidity_prov = initial_prov_by_field["avg_humidity"]
@@ -2713,7 +2716,7 @@ def test_aggregation_field_level_provenance_isolation(graph: FeatureGraph) -> No
         filters={},
     ).collect()
 
-    result_v2_polars = result_v2.to_polars()
+    result_v2_polars = by_field_maps_to_structs(collect_to_polars(result_v2))
     updated_prov_by_field = result_v2_polars["metaxy_provenance_by_field"][0]
     updated_avg_temp_prov = updated_prov_by_field["avg_temp"]
     updated_avg_humidity_prov = updated_prov_by_field["avg_humidity"]
@@ -2826,7 +2829,7 @@ def test_aggregation_field_level_provenance_multiple_groups(
         filters={},
     ).collect()
 
-    result_polars = result.to_polars().sort("sensor_id", "reading_id")
+    result_polars = by_field_maps_to_structs(collect_to_polars(result)).sort("sensor_id", "reading_id")
     # With window functions, all 4 original rows are preserved
     assert len(result_polars) == 4  # 4 rows (2 per sensor)
 
@@ -2951,7 +2954,7 @@ def test_aggregation_field_level_provenance_definition_change() -> None:
         filters={},
     ).collect()
 
-    result_v1_polars = result_v1.to_polars()
+    result_v1_polars = by_field_maps_to_structs(collect_to_polars(result_v1))
     v1_prov_by_field = result_v1_polars["metaxy_provenance_by_field"][0]
     v1_avg_temp_prov = v1_prov_by_field["avg_temp"]
     v1_avg_humidity_prov = v1_prov_by_field["avg_humidity"]
@@ -3041,7 +3044,7 @@ def test_aggregation_field_level_provenance_definition_change() -> None:
         filters={},
     ).collect()
 
-    result_v2_polars = result_v2.to_polars()
+    result_v2_polars = by_field_maps_to_structs(collect_to_polars(result_v2))
     v2_prov_by_field = result_v2_polars["metaxy_provenance_by_field"][0]
     v2_avg_temp_prov = v2_prov_by_field["avg_temp"]
     v2_avg_humidity_prov = v2_prov_by_field["avg_humidity"]

--- a/tests/provenance/test_polars_tracker.py
+++ b/tests/provenance/test_polars_tracker.py
@@ -7,8 +7,12 @@ import polars as pl
 import pytest
 from metaxy.ext.polars.versioning import PolarsVersioningEngine
 from metaxy.models.feature import FeatureGraph
+from metaxy.utils import collect_to_polars
 from metaxy.versioning.types import HashAlgorithm
 from metaxy_testing.models import SampleFeature
+from polars_map import Map
+
+from metaxy_testing import by_field_maps_to_structs
 
 
 def test_polars_engine_initialization(graph: FeatureGraph, simple_features: dict[str, type[SampleFeature]]) -> None:
@@ -47,22 +51,25 @@ def test_compute_provenance_single_upstream(
     assert "metaxy_provenance_by_field" in result_df.columns
     assert "metaxy_provenance" in result_df.columns
 
-    # Verify provenance_by_field is a struct
-    result_pl = result_df.to_native()
-    assert isinstance(result_pl.schema["metaxy_provenance_by_field"], pl.Struct)
+    # Verify provenance_by_field is the always-on Map dtype
+    result_pl = collect_to_polars(result_df)
+    assert result_pl.schema["metaxy_provenance_by_field"] == Map(pl.String(), pl.String())
+
+    # Convert Map to Struct for field access and snapshotting
+    result_pl = by_field_maps_to_structs(result_pl)
 
     # Verify provenance_by_field has the expected field
-    first_prov = result_df["metaxy_provenance_by_field"][0]
+    first_prov = result_pl["metaxy_provenance_by_field"][0]
     assert "default" in first_prov
 
     # Snapshot the provenance values
     provenance_data = []
-    for i in range(len(result_df)):
+    for i in range(len(result_pl)):
         provenance_data.append(
             {
-                "sample_uid": result_df["sample_uid"][i],
-                "field_provenance": result_df["metaxy_provenance_by_field"][i],
-                "sample_provenance": result_df["metaxy_provenance"][i],
+                "sample_uid": result_pl["sample_uid"][i],
+                "field_provenance": result_pl["metaxy_provenance_by_field"][i],
+                "sample_provenance": result_pl["metaxy_provenance"][i],
             }
         )
 
@@ -100,24 +107,29 @@ def test_compute_provenance_multiple_upstreams(
     assert "metaxy_provenance_by_field" in result_df.columns
     assert "metaxy_provenance" in result_df.columns
 
+    # Convert the always-on Map dtype to Struct to inspect fields
+    result_pl = collect_to_polars(result_df)
+    assert result_pl.schema["metaxy_provenance_by_field"] == Map(pl.String(), pl.String())
+    result_pl = by_field_maps_to_structs(result_pl)
+
     # Verify provenance_by_field has both fields
-    result_pl = result_df.to_native()
     provenance_schema = result_pl.schema["metaxy_provenance_by_field"]
+    assert isinstance(provenance_schema, pl.Struct)
     field_names = {f.name for f in provenance_schema.fields}
     assert field_names == {"fusion", "analysis"}
 
     # Different code versions should produce different field hashes
-    first_prov = result_df["metaxy_provenance_by_field"][0]
+    first_prov = result_pl["metaxy_provenance_by_field"][0]
     assert first_prov["fusion"] != first_prov["analysis"]
 
     # Snapshot the results
     provenance_data = []
-    for i in range(len(result_df)):
+    for i in range(len(result_pl)):
         provenance_data.append(
             {
-                "sample_uid": result_df["sample_uid"][i],
-                "field_provenance": result_df["metaxy_provenance_by_field"][i],
-                "sample_provenance": result_df["metaxy_provenance"][i],
+                "sample_uid": result_pl["sample_uid"][i],
+                "field_provenance": result_pl["metaxy_provenance_by_field"][i],
+                "sample_provenance": result_pl["metaxy_provenance"][i],
             }
         )
 
@@ -147,25 +159,30 @@ def test_compute_provenance_selective_field_deps(
 
     result_df = result.collect()
 
+    # Convert the always-on Map dtype to Struct to inspect fields
+    result_pl = collect_to_polars(result_df)
+    assert result_pl.schema["metaxy_provenance_by_field"] == Map(pl.String(), pl.String())
+    result_pl = by_field_maps_to_structs(result_pl)
+
     # Verify provenance_by_field has all three fields
-    result_pl = result_df.to_native()
     provenance_schema = result_pl.schema["metaxy_provenance_by_field"]
+    assert isinstance(provenance_schema, pl.Struct)
     field_names = {f.name for f in provenance_schema.fields}
     assert field_names == {"visual", "audio_only", "mixed"}
 
     # All fields should have different hashes (different deps + code versions)
-    first_prov = result_df["metaxy_provenance_by_field"][0]
+    first_prov = result_pl["metaxy_provenance_by_field"][0]
     hashes = [first_prov["visual"], first_prov["audio_only"], first_prov["mixed"]]
     assert len(set(hashes)) == 3
 
     # Snapshot the results
     provenance_data = []
-    for i in range(len(result_df)):
+    for i in range(len(result_pl)):
         provenance_data.append(
             {
-                "sample_uid": result_df["sample_uid"][i],
-                "field_provenance": result_df["metaxy_provenance_by_field"][i],
-                "sample_provenance": result_df["metaxy_provenance"][i],
+                "sample_uid": result_pl["sample_uid"][i],
+                "field_provenance": result_pl["metaxy_provenance_by_field"][i],
+                "sample_provenance": result_pl["metaxy_provenance"][i],
             }
         )
 
@@ -352,7 +369,7 @@ def test_compute_provenance_different_algorithms_snapshot(
         filters={},
     )
 
-    result_df = result.collect()
+    result_df = by_field_maps_to_structs(collect_to_polars(result))
 
     # Extract field hashes for snapshot
     field_hashes = [result_df["metaxy_provenance_by_field"][i]["default"] for i in range(len(result_df))]

--- a/tests/provenance/test_tracker_integration.py
+++ b/tests/provenance/test_tracker_integration.py
@@ -14,8 +14,11 @@ from metaxy.models.feature import FeatureGraph
 from metaxy.models.feature_spec import FeatureDep
 from metaxy.models.field import FieldDep, FieldSpec
 from metaxy.models.types import FeatureKey, FieldKey
+from metaxy.utils import collect_to_polars
 from metaxy.versioning.types import HashAlgorithm
 from metaxy_testing.models import SampleFeature, SampleFeatureSpec
+
+from metaxy_testing import by_field_maps_to_structs
 
 
 def test_feature_dep_renames(graph: FeatureGraph, snapshot) -> None:
@@ -105,7 +108,7 @@ def test_feature_dep_renames(graph: FeatureGraph, snapshot) -> None:
         filters={},
     )
 
-    result_df = result.collect()
+    result_df = by_field_maps_to_structs(collect_to_polars(result))
 
     # Snapshot the provenance
     provenance_data = []
@@ -210,7 +213,7 @@ def test_feature_dep_column_selection(graph: FeatureGraph, snapshot) -> None:
         hash_algo=HashAlgorithm.XXHASH64,
         filters={},
     )
-    result_df = result.collect().to_polars()
+    result_df = by_field_maps_to_structs(collect_to_polars(result))
 
     provenance_data = sorted(
         [
@@ -335,7 +338,7 @@ def test_multi_upstream_join_on_common_id_columns(graph: FeatureGraph, snapshot)
         hash_algo=HashAlgorithm.XXHASH64,
         filters={},
     )
-    result_df = result.collect().to_polars()
+    result_df = by_field_maps_to_structs(collect_to_polars(result))
 
     provenance_data = sorted(
         [
@@ -452,7 +455,7 @@ def test_filters_applied_before_join(graph: FeatureGraph, snapshot) -> None:
         hash_algo=HashAlgorithm.XXHASH64,
         filters=filters,
     )
-    result_df = result.collect().to_polars()
+    result_df = by_field_maps_to_structs(collect_to_polars(result))
 
     provenance_data = sorted(
         [

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1613,8 +1613,30 @@ def test_env_var_store_config_merged_with_parent_via_extend(tmp_path: Path, monk
 
 def test_use_calls_apply_extensions() -> None:
     """MetaxyConfig.use() calls _apply_extensions, same as set()."""
-    config = MetaxyConfig(enable_map_datatype=True)
+    config = MetaxyConfig()
     with patch.object(MetaxyConfig, "_apply_extensions") as mock:
         with config.use():
             pass
     mock.assert_called_once()
+
+
+def test_enable_map_datatype_property_is_deprecated() -> None:
+    """The deprecated enable_map_datatype property warns on access and always returns True."""
+    config = MetaxyConfig()
+    with pytest.warns(DeprecationWarning, match="will be removed in Metaxy 0.3.0"):
+        assert config.enable_map_datatype is True
+
+
+def test_enable_map_datatype_config_key_is_deprecated_noop() -> None:
+    """Passing the deprecated enable_map_datatype setting warns but is accepted as a no-op."""
+    with pytest.warns(DeprecationWarning, match="will be removed in Metaxy 0.3.0"):
+        config = MetaxyConfig.model_validate({"enable_map_datatype": True})
+    assert "enable_map_datatype" not in config.model_dump()
+
+
+def test_enable_map_datatype_cannot_be_disabled() -> None:
+    """Setting enable_map_datatype to False is rejected."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError, match="cannot be disabled"):
+        MetaxyConfig.model_validate({"enable_map_datatype": False})

--- a/tests/test_hash_truncation.py
+++ b/tests/test_hash_truncation.py
@@ -18,7 +18,10 @@ from metaxy.ext.polars.handlers.delta import DeltaMetadataStore
 from metaxy.metadata_store.system import SystemTableStorage
 from metaxy.models.feature_spec import FieldSpec
 from metaxy.models.types import FeatureKey, FieldKey
+from metaxy.utils import collect_to_polars
 from metaxy_testing.models import SampleFeature, SampleFeatureSpec
+
+from metaxy_testing import by_field_maps_to_structs
 
 
 class TestHashTruncationUtils:
@@ -447,8 +450,7 @@ class TestMetadataStoreTruncation:
 
                 # Read back and verify
 
-                result = store.read(TestFeature).collect()
-                result_pl = result.to_polars()
+                result_pl = by_field_maps_to_structs(collect_to_polars(store.read(TestFeature)))
                 assert result_pl.height == 2
 
                 # Field provenance should be truncated
@@ -515,8 +517,7 @@ class TestEndToEnd:
 
                 # Verify stored versions are truncated
 
-                result = store.read(ParentFeature).collect()
-                result_pl = result.to_polars()
+                result_pl = by_field_maps_to_structs(collect_to_polars(store.read(ParentFeature)))
 
                 for row in result_pl.iter_rows(named=True):
                     assert len(row["metaxy_feature_version"]) == 16

--- a/tests/versioning/test_polars_map.py
+++ b/tests/versioning/test_polars_map.py
@@ -94,8 +94,8 @@ class TestMapRoundtrip:
 
 @pytest.fixture
 def polars_map_config() -> Iterator[MetaxyConfig]:
-    """Activate enable_map_datatype for the duration of the test."""
-    config = MetaxyConfig(enable_map_datatype=True)
+    """Provide an active MetaxyConfig for the duration of the test."""
+    config = MetaxyConfig()
     with config.use():
         yield config
 

--- a/tests/versioning/test_struct_column.py
+++ b/tests/versioning/test_struct_column.py
@@ -4,7 +4,6 @@ import ibis
 import narwhals as nw
 import polars as pl
 import pyarrow as pa
-from metaxy.config import MetaxyConfig
 from metaxy.ext.ibis.versioning import IbisVersioningEngine
 from metaxy.ext.polars.versioning import PolarsVersioningEngine
 from metaxy.models.feature import FeatureGraph
@@ -12,7 +11,7 @@ from metaxy.models.feature_definition import FeatureDefinition
 from polars_map import Map
 
 
-def test_build_struct_column_uses_shared_narwhals_expr_for_polars(
+def test_build_map_column_for_polars(
     test_graph: FeatureGraph,
     test_features: dict[str, FeatureDefinition],
 ) -> None:
@@ -20,55 +19,11 @@ def test_build_struct_column_uses_shared_narwhals_expr_for_polars(
     engine = PolarsVersioningEngine(plan)
     df = nw.from_native(pl.DataFrame({"_frames": ["f1"], "_audio": ["a1"]}))
 
-    result = engine.build_struct_column(
+    result = engine.build_map_column(
         df,
         "versions",
         {"frames": "_frames", "audio": "_audio"},
     )
-
-    result_pl = result.to_native()
-    assert result.implementation == nw.Implementation.POLARS
-    assert result_pl.schema["versions"] == pl.Struct({"frames": pl.String, "audio": pl.String})
-    assert result_pl["versions"].to_list() == [{"frames": "f1", "audio": "a1"}]
-
-
-def test_build_struct_column_uses_shared_narwhals_expr_for_ibis(
-    test_graph: FeatureGraph,
-    test_features: dict[str, FeatureDefinition],
-) -> None:
-    plan = test_graph.get_feature_plan(test_features["UpstreamFeatureA"].key)
-    engine = IbisVersioningEngine(plan, hash_functions={})
-    df = nw.from_native(ibis.memtable({"_frames": ["f1"], "_audio": ["a1"]}), eager_only=False)
-    assert isinstance(df, nw.LazyFrame)
-
-    result = engine.build_struct_column(
-        df,
-        "versions",
-        {"frames": "_frames", "audio": "_audio"},
-    )
-    assert isinstance(result, nw.LazyFrame)
-
-    result_pl = result.collect().to_polars()
-    assert result.implementation == nw.Implementation.IBIS
-    assert result_pl.schema["versions"] == pl.Struct({"frames": pl.String, "audio": pl.String})
-    assert result_pl["versions"].to_list() == [{"frames": "f1", "audio": "a1"}]
-
-
-def test_build_struct_column_delegates_to_polars_map_when_enabled(
-    test_graph: FeatureGraph,
-    test_features: dict[str, FeatureDefinition],
-) -> None:
-    plan = test_graph.get_feature_plan(test_features["UpstreamFeatureA"].key)
-    engine = PolarsVersioningEngine(plan)
-    df = nw.from_native(pl.DataFrame({"_frames": ["f1"], "_audio": ["a1"]}))
-    config = MetaxyConfig.get().model_copy(update={"enable_map_datatype": True})
-
-    with config.use():
-        result = engine.build_struct_column(
-            df,
-            "versions",
-            {"frames": "_frames", "audio": "_audio"},
-        )
 
     result_pl = result.to_native()
     assert result_pl.schema["versions"] == Map(pl.String(), pl.String())
@@ -76,7 +31,7 @@ def test_build_struct_column_delegates_to_polars_map_when_enabled(
     assert result_pl["versions"].map.get("audio").to_list() == ["a1"]
 
 
-def test_build_struct_column_delegates_to_ibis_map_when_enabled(
+def test_build_map_column_for_ibis(
     test_graph: FeatureGraph,
     test_features: dict[str, FeatureDefinition],
 ) -> None:
@@ -84,14 +39,12 @@ def test_build_struct_column_delegates_to_ibis_map_when_enabled(
     engine = IbisVersioningEngine(plan, hash_functions={})
     df = nw.from_native(ibis.memtable({"_frames": ["f1"], "_audio": ["a1"]}), eager_only=False)
     assert isinstance(df, nw.LazyFrame)
-    config = MetaxyConfig.get().model_copy(update={"enable_map_datatype": True})
 
-    with config.use():
-        result = engine.build_struct_column(
-            df,
-            "versions",
-            {"frames": "_frames", "audio": "_audio"},
-        )
+    result = engine.build_map_column(
+        df,
+        "versions",
+        {"frames": "_frames", "audio": "_audio"},
+    )
     assert isinstance(result, nw.LazyFrame)
 
     table = result.collect().to_arrow()

--- a/uv.lock
+++ b/uv.lock
@@ -3345,9 +3345,11 @@ source = { editable = "." }
 dependencies = [
     { name = "cyclopts" },
     { name = "narwhals" },
+    { name = "narwhals-map" },
     { name = "packaging" },
     { name = "polars" },
     { name = "polars-hash" },
+    { name = "polars-map" },
     { name = "pydantic" },
     { name = "pydantic-core" },
     { name = "pydantic-settings" },
@@ -3396,10 +3398,6 @@ lancedb = [
     { name = "lancedb" },
     { name = "polars" },
 ]
-map = [
-    { name = "narwhals-map" },
-    { name = "polars-map" },
-]
 mcp = [
     { name = "fastmcp" },
 ]
@@ -3441,13 +3439,11 @@ dev = [
     { name = "mistune" },
     { name = "mkdocs-metaxy" },
     { name = "moto", extra = ["s3", "server"] },
-    { name = "narwhals-map" },
     { name = "nox" },
     { name = "nox-uv" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pandas" },
-    { name = "polars-map" },
     { name = "prek" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -3508,13 +3504,13 @@ requires-dist = [
     { name = "lancedb", marker = "extra == 'lancedb'", specifier = ">=0.15.0" },
     { name = "mermaid-py", marker = "extra == 'mermaid'", specifier = ">=0.8.0" },
     { name = "narwhals", specifier = ">=2.20.0" },
-    { name = "narwhals-map", marker = "extra == 'map'", specifier = ">=0.1.1" },
+    { name = "narwhals-map", specifier = ">=0.1.1" },
     { name = "packaging", specifier = ">=25.0" },
     { name = "polars", specifier = ">=1.35.0" },
     { name = "polars", marker = "extra == 'iceberg'", specifier = ">=1.39.0" },
     { name = "polars", marker = "extra == 'lancedb'", specifier = ">=1.36.1" },
     { name = "polars-hash", specifier = ">=0.5.1" },
-    { name = "polars-map", marker = "extra == 'map'", specifier = ">=0.2.1" },
+    { name = "polars-map", specifier = ">=0.2.1" },
     { name = "psycopg", marker = "extra == 'postgres'", specifier = ">=3.2.0" },
     { name = "pyarrow", marker = "extra == 'ibis'", specifier = ">=18.0.0" },
     { name = "pydantic", specifier = ">=2.11.9" },
@@ -3535,7 +3531,7 @@ requires-dist = [
     { name = "tomlkit", specifier = ">=0.13.2" },
     { name = "typing-extensions", specifier = ">=4.0.0" },
 ]
-provides-extras = ["map", "ibis", "mermaid", "sqlalchemy", "sqlmodel", "bigquery", "clickhouse", "duckdb", "delta", "dagster", "iceberg", "lancedb", "postgres", "mcp", "ray"]
+provides-extras = ["ibis", "mermaid", "sqlalchemy", "sqlmodel", "bigquery", "clickhouse", "duckdb", "delta", "dagster", "iceberg", "lancedb", "postgres", "mcp", "ray"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -3556,12 +3552,10 @@ dev = [
     { name = "mistune", specifier = ">=3.1.4" },
     { name = "mkdocs-metaxy", editable = "docs/.mkdocs-metaxy" },
     { name = "moto", extras = ["s3", "server"], specifier = ">=5.1.16" },
-    { name = "narwhals-map", specifier = ">=0.1.1" },
     { name = "nox", specifier = ">=2025.2.9" },
     { name = "nox-uv", specifier = ">=0.7.1" },
     { name = "numpy", specifier = ">=2.2.6" },
     { name = "pandas", specifier = ">=2.3.3" },
-    { name = "polars-map", specifier = ">=0.2.1" },
     { name = "prek", specifier = ">=0.2.11" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-asyncio", specifier = ">=0.26.0" },


### PR DESCRIPTION
## Summary

This PR enables `Map` datatype support by default. 

Resolves #1241.

## Changelog

`Map` datatype is now enabled by default for Metaxy's versioning columns. The top-level `enable_map_datatype` still exists but may no longer be set to `False`. 

<!--
User-facing changelog details, rendered below the commit title in CHANGELOG.md.
Delete this section if there are no user-facing changes.
-->

## Test Plan

<!-- How was this tested? -->
